### PR TITLE
Temporarily remove ScalaDoc comments on traits with macro annotations

### DIFF
--- a/core/src/main/scala/cats/Applicative.scala
+++ b/core/src/main/scala/cats/Applicative.scala
@@ -2,7 +2,7 @@ package cats
 
 import simulacrum._
 
-/**
+/*
  * Applicative functor.
  * 
  * Must obey the following laws:

--- a/core/src/main/scala/cats/Apply.scala
+++ b/core/src/main/scala/cats/Apply.scala
@@ -2,7 +2,7 @@ package cats
 
 import simulacrum._
 
-/**
+/*
  * Weaker version of Applicative[F]; has apply but not pure.
  * 
  * Laws:

--- a/core/src/main/scala/cats/Functor.scala
+++ b/core/src/main/scala/cats/Functor.scala
@@ -2,7 +2,7 @@ package cats
 
 import simulacrum._
 
-/**
+/*
  * Functor.
  *
  * Must obey the following laws:


### PR DESCRIPTION
`sbt doc` currently fails with a bunch of errors like this:

```
error] /home/travis/code/projects/typelevel/cats/core/src/main/scala/cats/Applicative.scala:14: not found: type F
[error] @typeclass trait Applicative[F[_]] extends Apply[F] {
[error]                                                  ^
```

This means it's not possible to publish the project locally.

This is a [known Macro Paradise bug](https://github.com/scalamacros/paradise/issues/53#issuecomment-70427156)—it seems that any ScalaDoc comment on a trait or class definition that's been rewritten by a macro annotation will result in errors while producing the docs (even if it compiles just fine).

One option would be to disable ScalaDoc altogether, but this is only an issue in a few cases, so it's probably more practical simply not to use the ScalaDoc comment format for these three traits until the bug is fixed.

I could add a comment to that effect in the code, but I'm not sure that's necessary.
