### PR TITLE
Add Comonad laws and check that Function0 satisfies them

### DIFF
--- a/laws/src/main/scala/cats/laws/ComonadLaws.scala
+++ b/laws/src/main/scala/cats/laws/ComonadLaws.scala
@@ -1,0 +1,60 @@
+package cats.laws
+
+import algebra.Eq
+import algebra.laws._
+
+import org.scalacheck.{Arbitrary, Prop}
+import org.scalacheck.Prop._
+import org.typelevel.discipline.Laws
+
+import cats._
+
+object ComonadLaws {
+  def apply[F[_]: ArbitraryK, A: Arbitrary, B: Arbitrary](implicit eqfa: Eq[F[A]]): ComonadLaws[F, A, B] =
+    new ComonadLaws[F, A, B] {
+      def EqFA = eqfa
+      def ArbA = implicitly[Arbitrary[A]]
+      def ArbB = implicitly[Arbitrary[B]]
+      def ArbF = implicitly[ArbitraryK[F]]
+    }
+}
+
+trait ComonadLaws[F[_], A, B] extends Laws {
+
+  implicit def EqFA: Eq[F[A]]
+  def ArbF: ArbitraryK[F]
+  implicit def ArbA: Arbitrary[A]
+  implicit def ArbB: Arbitrary[B]
+  implicit def ArbFA: Arbitrary[F[A]] = ArbF.synthesize[A](ArbA)
+  implicit def ArbFB: Arbitrary[F[B]] = ArbF.synthesize[B](ArbB)
+
+  def coflatmap[C: Arbitrary](implicit F: CoFlatMap[F], FC: Eq[F[C]]) =
+    new ComonadProperties(
+      name = "coflatmap",
+      parents = Nil,
+      "associativity" -> forAll { (fa: F[A], f: F[A] => B, g: F[B] => C) =>
+        F.coflatMap(F.coflatMap(fa)(f))(g) ?==
+          F.coflatMap(fa)(x => g(F.coflatMap(x)(f)))
+      }
+    )
+
+  def comonad[C: Arbitrary](implicit F: Comonad[F], FC: Eq[F[C]], B: Eq[B]) =
+    new ComonadProperties(
+      name = "comonad",
+      parents = Seq(coflatmap[C]),
+      "left identity" -> forAll { (fa: F[A]) =>
+        F.coflatMap(fa)(F.extract) ?== fa
+      },
+      "right identity" -> forAll { (fa: F[A], f: F[A] => B) =>
+        F.extract(F.coflatMap(fa)(f)) ?== f(fa)
+      }
+    )
+
+  class ComonadProperties(
+    val name: String,
+    val parents: Seq[ComonadProperties],
+    val props: (String, Prop)*
+  ) extends RuleSet {
+    val bases = Nil
+  }
+}

--- a/tests/src/test/scala/cats/tests/LawTests.scala
+++ b/tests/src/test/scala/cats/tests/LawTests.scala
@@ -15,6 +15,7 @@ import cats.std.option._
 
 class LawTests extends FunSuite with Discipline {
   checkAll("Function0[Int]", FunctorLaws[Function0, Int].applicative[Int, Int])
+  checkAll("Function0[Int]", ComonadLaws[Function0, Int, Int].comonad[Int])
   checkAll("Option[Int]", FunctorLaws[Option, Int].applicative[Int, Int])
   checkAll("Option[String]", FunctorLaws[Option, String].applicative[Int, Int])
   checkAll("List[Int]", FunctorLaws[List, Int].applicative[Int, Int])


### PR DESCRIPTION
This is a first draft of the comonad laws. I copied the structure of `ComonadLaws` from `FunctorLaws`. One thing I don't like about it is that the laws are somewhat hidden between all those `Arbitrary` defs and the discipline glue code. I would love to move them right under the instance definition like scalaz does. The reason is that the instance definition is incomplete without the associated laws.