### PR TITLE
add default implementation for lmap and rmap and add documentation for Profunctor

### DIFF
--- a/core/src/main/scala/cats/arrow/Arrow.scala
+++ b/core/src/main/scala/cats/arrow/Arrow.scala
@@ -7,10 +7,10 @@ trait Arrow[F[_, _]] extends Split[F] with Strong[F] with Category[F] { self =>
 
   def lift[A, B](f: A => B): F[A, B]
 
-  def lmap[A, B, C](fab: F[A, B])(f: C => A): F[C, B] =
+  override def lmap[A, B, C](fab: F[A, B])(f: C => A): F[C, B] =
     andThen(lift(f), fab)
 
-  def rmap[A, B, C](fab: F[A, B])(f: B => C): F[A, C] =
+  override def rmap[A, B, C](fab: F[A, B])(f: B => C): F[A, C] =
     compose(lift(f), fab)
 
   def second[A, B, C](fa: F[A, B]): F[(C, A), (C, B)] = {

--- a/core/src/main/scala/cats/functor/Profunctor.scala
+++ b/core/src/main/scala/cats/functor/Profunctor.scala
@@ -32,17 +32,7 @@ object Profunctor {
 
   def apply[F[_, _]](implicit ev: Profunctor[F]): Profunctor[F] = ev
 
-  case class UpStar[F[_]: Functor, A, B](f: A => F[B])
-
   case class DownStar[F[_]: Functor, A, B](f: F[A] => B)
-
-  def upStar[F[_]: Functor]: Profunctor[UpStar[F, ?, ?]] =
-    new Profunctor[UpStar[F, ?, ?]] {
-      override def lmap[A, B, C](fab: UpStar[F, A, B])(f: C => A): UpStar[F, C, B] =
-        UpStar(fab.f compose f)
-      override def rmap[A, B, C](fab: UpStar[F, A, B])(f: B => C): UpStar[F, A, C] =
-        UpStar(a => Functor[F].map(fab.f(a))(f))
-    }
 
   def downStar[F[_]: Functor]: Profunctor[DownStar[F, ?, ?]] =
     new Profunctor[DownStar[F, ?, ?]] {

--- a/core/src/main/scala/cats/functor/Profunctor.scala
+++ b/core/src/main/scala/cats/functor/Profunctor.scala
@@ -29,16 +29,5 @@ trait Profunctor[F[_, _]] { self =>
 
 
 object Profunctor {
-
   def apply[F[_, _]](implicit ev: Profunctor[F]): Profunctor[F] = ev
-
-  case class DownStar[F[_]: Functor, A, B](f: F[A] => B)
-
-  def downStar[F[_]: Functor]: Profunctor[DownStar[F, ?, ?]] =
-    new Profunctor[DownStar[F, ?, ?]] {
-      override def lmap[A, B, C](fab: DownStar[F, A, B])(f: C => A): DownStar[F, C, B] =
-        DownStar(fc => fab.f(Functor[F].map(fc)(f)))
-      override def rmap[A, B, C](fab: DownStar[F, A, B])(f: B => C): DownStar[F, A, C] =
-        DownStar(f compose fab.f)
-    }
 }

--- a/core/src/main/scala/cats/functor/UpStar.scala
+++ b/core/src/main/scala/cats/functor/UpStar.scala
@@ -1,0 +1,96 @@
+package cats.functor
+
+import cats._
+
+
+final case class UpStar[F[_], A, B](fab: A => F[B]){
+  def dimap[C, D](f: C => A)(g: B => D)(implicit F: Functor[F]): UpStar[F, C, D] =
+    UpStar(c => Functor[F].map(fab(f(c)))(g))
+
+  def lmap[C](f: C => A): UpStar[F, C, B] =
+    UpStar(fab compose f)
+
+  def rmap[C](f: B => C)(implicit F: Functor[F]): UpStar[F, A, C] =
+    UpStar(a => Functor[F].map(fab(a))(f))
+
+  def first[C](implicit F: Functor[F]): UpStar[F, (A, C), (B, C)] =
+    UpStar{ case (a, c) => F.fproduct(fab(a))(_ => c)}
+
+  def second[C](implicit F: Functor[F]): UpStar[F, (C, A), (C, B)] =
+    UpStar{ case (c, a) => F.map(fab(a))(c -> _)}
+
+  def flatMap[C](f: B => UpStar[F, A, C])(implicit F: FlatMap[F]): UpStar[F, A, C] =
+    UpStar(a => F.flatMap(fab(a))(b => f(b).fab(a)))
+
+  def apply[C](f: UpStar[F, A, B => C])(implicit F: Apply[F]): UpStar[F, A, C] =
+    UpStar(a => F.apply(fab(a))(f.fab(a)))
+}
+
+object UpStar extends UpStarInstances {
+  def pure[F[_], A, B](x: B)(implicit F: Applicative[F]): UpStar[F, A, B] =
+    UpStar(_ => F.pure(x))
+}
+
+sealed abstract class UpStarInstances {
+  implicit def upStarStrong[F[_]: Functor]: Profunctor[UpStar[F, ?, ?]] = new Strong[UpStar[F, ?, ?]]{
+    override def lmap[A, B, C](fab: UpStar[F, A, B])(f: C => A): UpStar[F, C, B] =
+      fab.lmap(f)
+
+    override def rmap[A, B, C](fab: UpStar[F, A, B])(f: (B) => C): UpStar[F, A, C] =
+      fab.rmap(f)
+
+    override def dimap[A, B, C, D](fab: UpStar[F, A, B])(f: C => A)(g: B => D): UpStar[F, C, D] =
+      fab.dimap(f)(g)
+
+    def first[A, B, C](fa: UpStar[F, A, B]): UpStar[F, (A, C), (B, C)] =
+      fa.first[C]
+
+    def second[A, B, C](fa: UpStar[F, A, B]): UpStar[F, (C, A), (C, B)] =
+      fa.second[C]
+  }
+
+  implicit def upStarMonad[F[_]: Monad, A]: Monad[UpStar[F, A, ?]] = new Monad[UpStar[F, A, ?]] {
+    def pure[B](x: B): UpStar[F, A, B] =
+      UpStar.pure[F, A, B](x)
+
+    def flatMap[B, C](fa: UpStar[F, A, B])(f: B => UpStar[F, A, C]): UpStar[F, A, C] =
+      fa.flatMap(f)
+  }
+}
+
+sealed abstract class UpStarInstances0 extends UpStarInstances1 {
+  implicit def upStarFlatMap[F[_]: FlatMap, A]: FlatMap[UpStar[F, A, ?]] = new FlatMap[UpStar[F, A, ?]] {
+    def flatMap[B, C](fa: UpStar[F, A, B])(f: B => UpStar[F, A, C]): UpStar[F, A, C] =
+      fa.flatMap(f)
+
+    def map[B, C](fa: UpStar[F, A, B])(f: B => C): UpStar[F, A, C] =
+      fa.rmap(f)
+  }
+}
+
+sealed abstract class UpStarInstances1 extends UpStarInstances2 {
+  implicit def upStarApplicative[F[_]: Applicative, A]: Applicative[UpStar[F, A, ?]] = new Applicative[UpStar[F, A, ?]] {
+    def pure[B](x: B): UpStar[F, A, B] =
+      UpStar.pure[F, A, B](x)
+
+    def apply[B, C](fa: UpStar[F, A, B])(f: UpStar[F, A, B => C]): UpStar[F, A, C] =
+      fa.apply(f)
+  }
+}
+
+sealed abstract class UpStarInstances2 extends UpStarInstances3 {
+  implicit def upStarApply[F[_]: Apply, A]: Apply[UpStar[F, A, ?]] = new Apply[UpStar[F, A, ?]] {
+    def apply[B, C](fa: UpStar[F, A, B])(f: UpStar[F, A, B => C]): UpStar[F, A, C] =
+      fa.apply(f)
+
+    def map[B, C](fa: UpStar[F, A, B])(f: B => C): UpStar[F, A, C] =
+      fa.rmap(f)
+  }
+}
+
+sealed abstract class UpStarInstances3 {
+  implicit def upStarFunctor[F[_]: Functor, A]: Functor[UpStar[F, A, ?]] = new Functor[UpStar[F, A, ?]] {
+    def map[B, C](fa: UpStar[F, A, B])(f: B => C): UpStar[F, A, C] =
+      fa.rmap(f)
+  }
+}

--- a/data/src/main/scala/cats/data/DownStar.scala
+++ b/data/src/main/scala/cats/data/DownStar.scala
@@ -1,0 +1,44 @@
+package cats.data
+
+import cats.functor.Profunctor
+import cats.{Functor, Monad}
+
+final case class DownStar[F[_], A, B](fab: F[A] => B){
+  def dimap[C, D](f: C => A)(g: B => D)(implicit F: Functor[F]): DownStar[F, C, D] =
+    DownStar(fc => g(fab(F.map(fc)(f))))
+
+  def lmap[C](f: C => A)(implicit F: Functor[F]): DownStar[F, C, B] =
+    DownStar(fc => fab(F.map(fc)(f)))
+
+  def rmap[C](f: B => C): DownStar[F, A, C] =
+    DownStar(f compose fab)
+
+  def flatMap[C](f: B => DownStar[F, A, C]): DownStar[F, A, C] =
+    DownStar(fa => f(fab(fa)).fab(fa))
+}
+
+object DownStar extends DownStarInstances {
+  def pure[F[_], A, B](x: B): DownStar[F, A, B] =
+    DownStar(_ => x)
+}
+
+sealed abstract class DownStarInstances {
+  implicit def downStarProfunctor[F[_]: Functor] = new Profunctor[DownStar[F, ?, ?]] {
+    override def lmap[A, B, C](fab: DownStar[F, A, B])(f: C => A): DownStar[F, C, B] =
+      fab.lmap(f)
+
+    override def rmap[A, B, C](fab: DownStar[F, A, B])(f: B => C): DownStar[F, A, C] =
+      fab.rmap(f)
+
+    override def dimap[A, B, C, D](fab: DownStar[F, A, B])(f: C => A)(g: B => D): DownStar[F, C, D] =
+      fab.dimap(f)(g)
+  }
+
+  implicit def downStarMonad[F[_], A]: Monad[DownStar[F, A, ?]] = new Monad[DownStar[F, A, ?]] {
+    def pure[B](x: B): DownStar[F, A, B] =
+      DownStar.pure(x)
+
+    def flatMap[B, C](fa: DownStar[F, A, B])(f: B => DownStar[F, A, C]): DownStar[F, A, C] =
+      fa.flatMap(f)
+  }
+}

--- a/data/src/main/scala/cats/data/UpStar.scala
+++ b/data/src/main/scala/cats/data/UpStar.scala
@@ -1,6 +1,7 @@
-package cats.functor
+package cats.data
 
 import cats._
+import cats.functor.{Strong, Profunctor}
 
 
 final case class UpStar[F[_], A, B](fab: A => F[B]){
@@ -31,12 +32,12 @@ object UpStar extends UpStarInstances {
     UpStar(_ => F.pure(x))
 }
 
-sealed abstract class UpStarInstances {
-  implicit def upStarStrong[F[_]: Functor]: Profunctor[UpStar[F, ?, ?]] = new Strong[UpStar[F, ?, ?]]{
+sealed abstract class UpStarInstances extends UpStarInstances0 {
+  implicit def upStarStrong[F[_]: Functor]: Strong[UpStar[F, ?, ?]] = new Strong[UpStar[F, ?, ?]]{
     override def lmap[A, B, C](fab: UpStar[F, A, B])(f: C => A): UpStar[F, C, B] =
       fab.lmap(f)
 
-    override def rmap[A, B, C](fab: UpStar[F, A, B])(f: (B) => C): UpStar[F, A, C] =
+    override def rmap[A, B, C](fab: UpStar[F, A, B])(f: B => C): UpStar[F, A, C] =
       fab.rmap(f)
 
     override def dimap[A, B, C, D](fab: UpStar[F, A, B])(f: C => A)(g: B => D): UpStar[F, C, D] =


### PR DESCRIPTION
I want to do more work on `Profunctor` but in the meantime I wanted to use this PR to discuss default implementation of TC.

I feel that in many cases it is rather arbitrary which method has a default implementation. I would prefer that we provide as many default implementation as possible and that we use the doc to say what is the minimum implementation required.

Also we should keep in mind that for many instances, it is more efficient to override the default implementation.