### PR TITLE
Topic/syntax

### DIFF
--- a/core/src/main/scala/cats/Functor.scala
+++ b/core/src/main/scala/cats/Functor.scala
@@ -17,7 +17,7 @@ import simulacrum._
   /** alias for map */
   def fmap[A, B](f: A => B): F[A] => F[B] = fa => map(fa)(f)
 
-  def imap[A, B](fa: F[A])(f: A => B, fi: B => A): F[B] = map(fa)(f)
+  def imap[A, B](fa: F[A])(f: A => B)(fi: B => A): F[B] = map(fa)(f)
 
   /////////////////////////////////////////////////////////////////////////
   // derived functions

--- a/core/src/main/scala/cats/Id.scala
+++ b/core/src/main/scala/cats/Id.scala
@@ -12,6 +12,6 @@ object Id {
       override def flatten[A](ffa: A): A = ffa
       override def map2[A, B, Z](fa: A, fb: B)(f: (A, B) => Z): Z = f(fa, fb)
       override def fmap[A, B](f: A => B): A => B = f
-      override def imap[A, B](fa: A)(f: A => B, fi: B => A): B = f(fa)
+      override def imap[A, B](fa: A)(f: A => B)(fi: B => A): B = f(fa)
     }
 }

--- a/core/src/main/scala/cats/Lazy.scala
+++ b/core/src/main/scala/cats/Lazy.scala
@@ -63,7 +63,7 @@ object Lazy {
       override def fmap[A, B](f: A => B): Lazy[A] => Lazy[B] =
         la => la.map(f)
 
-      override def imap[A, B](fa: Lazy[A])(f: A => B, fi: B => A): Lazy[B] =
+      override def imap[A, B](fa: Lazy[A])(f: A => B)(fi: B => A): Lazy[B] =
         fa.map(f)
     }
 }

--- a/core/src/main/scala/cats/functor/Contravariant.scala
+++ b/core/src/main/scala/cats/functor/Contravariant.scala
@@ -5,5 +5,5 @@ import simulacrum._
 
 @typeclass trait Contravariant[F[_]] extends Invariant[F] {
   def contramap[A, B](fa: F[A])(f: B => A): F[B]
-  override def imap[A, B](fa: F[A])(f: A => B, fi: B => A): F[B] = contramap(fa)(fi)
+  override def imap[A, B](fa: F[A])(f: A => B)(fi: B => A): F[B] = contramap(fa)(fi)
 }

--- a/core/src/main/scala/cats/functor/Invariant.scala
+++ b/core/src/main/scala/cats/functor/Invariant.scala
@@ -4,5 +4,5 @@ package functor
 import simulacrum._
 
 @typeclass trait Invariant[F[_]] extends Any {
-  def imap[A, B](fa: F[A])(f: A => B, fi: B => A): F[B]
+  def imap[A, B](fa: F[A])(f: A => B)(fi: B => A): F[B]
 }

--- a/core/src/main/scala/cats/package.scala
+++ b/core/src/main/scala/cats/package.scala
@@ -9,4 +9,11 @@ package object cats {
 
   type ⊥ = Nothing
   type ⊤ = Any
+
+  type Eq[A] = algebra.Eq[A]
+  type PartialOrder[A] = algebra.PartialOrder[A]
+  type Order[A] = algebra.Order[A]
+
+  type Semigroup[A] = algebra.Semigroup[A]
+  type Monoid[A] = algebra.Monoid[A]
 }

--- a/core/src/main/scala/cats/syntax/all.scala
+++ b/core/src/main/scala/cats/syntax/all.scala
@@ -1,3 +1,8 @@
 package cats.syntax
 
-trait AllSyntax extends FunctorSyntax
+trait AllSyntax
+    extends InvariantSyntax
+    with ContravariantSyntax
+    with FunctorSyntax
+    with ApplySyntax
+    with FlatMapSyntax

--- a/core/src/main/scala/cats/syntax/all.scala
+++ b/core/src/main/scala/cats/syntax/all.scala
@@ -6,12 +6,15 @@ trait AllSyntax
     with CoFlatMapSyntax
     with ComonadSyntax
     with ContravariantSyntax
+    with EqSyntax
     with FlatMapSyntax
     with FoldableSyntax
     with FunctorSyntax
     with InvariantSyntax
     with MonadCombineSyntax
     with MonadFilterSyntax
+    with OrderSyntax
+    with PartialOrderSyntax
     with ProfunctorSyntax
     with SemigroupSyntax
     with ShowSyntax

--- a/core/src/main/scala/cats/syntax/all.scala
+++ b/core/src/main/scala/cats/syntax/all.scala
@@ -1,0 +1,3 @@
+package cats.syntax
+
+trait AllSyntax extends FunctorSyntax

--- a/core/src/main/scala/cats/syntax/all.scala
+++ b/core/src/main/scala/cats/syntax/all.scala
@@ -13,5 +13,6 @@ trait AllSyntax
     with MonadCombineSyntax
     with MonadFilterSyntax
     with ProfunctorSyntax
+    with SemigroupSyntax
     with ShowSyntax
     with StrongSyntax

--- a/core/src/main/scala/cats/syntax/all.scala
+++ b/core/src/main/scala/cats/syntax/all.scala
@@ -1,8 +1,17 @@
 package cats.syntax
 
 trait AllSyntax
-    extends InvariantSyntax
+    extends ApplySyntax
+    with BifunctorSyntax
+    with CoFlatMapSyntax
+    with ComonadSyntax
     with ContravariantSyntax
-    with FunctorSyntax
-    with ApplySyntax
     with FlatMapSyntax
+    with FoldableSyntax
+    with FunctorSyntax
+    with InvariantSyntax
+    with MonadCombineSyntax
+    with MonadFilterSyntax
+    with ProfunctorSyntax
+    with ShowSyntax
+    with StrongSyntax

--- a/core/src/main/scala/cats/syntax/apply.scala
+++ b/core/src/main/scala/cats/syntax/apply.scala
@@ -1,0 +1,14 @@
+package cats
+package syntax
+
+trait ApplySyntax {
+  // TODO: use simulacrum instances eventually
+  implicit def applySyntax[F[_]: Apply, A](fa: F[A]) =
+    new ApplyOps[F, A](fa)
+}
+
+class ApplyOps[F[_], A](fa: F[A])(implicit F: Apply[F]) {
+  def apply[B](f: F[A => B]): F[B] = F.apply(fa)(f)
+  def apply2[B, Z](fb: F[B])(f: F[(A, B) => Z]): F[Z] = F.apply2(fa, fb)(f)
+  def map2[B, Z](fb: F[B])(f: (A, B) => Z): F[Z] = F.map2(fa, fb)(f)
+}

--- a/core/src/main/scala/cats/syntax/bifunctor.scala
+++ b/core/src/main/scala/cats/syntax/bifunctor.scala
@@ -1,0 +1,14 @@
+package cats
+package syntax
+
+import cats.functor.Bifunctor
+
+trait BifunctorSyntax {
+  // TODO: use simulacrum instances eventually
+  implicit def bifunctorSyntax[F[_, _]: Bifunctor, A, B](fab: F[A, B]) =
+    new BifunctorOps[F, A, B](fab)
+}
+
+class BifunctorOps[F[_, _], A, B](fab: F[A, B])(implicit F: Bifunctor[F]) {
+  def bimap[C, D](fcd: F[C, D]): F[(A, C), (B, D)] = F.bimap(fab, fcd)
+}

--- a/core/src/main/scala/cats/syntax/coflatMap.scala
+++ b/core/src/main/scala/cats/syntax/coflatMap.scala
@@ -1,0 +1,13 @@
+package cats
+package syntax
+
+trait CoFlatMapSyntax {
+  // TODO: use simulacrum instances eventually
+  implicit def coflatMapSyntax[F[_]: CoFlatMap, A](fa: F[A]) =
+    new CoFlatMapOps[F, A](fa)
+}
+
+class CoFlatMapOps[F[_], A](fa: F[A])(implicit F: CoFlatMap[F]) {
+  def coflatMap[B](f: F[A] => B): F[B] = F.coflatMap(fa)(f)
+  def coflatten: F[F[A]] = F.coflatten(fa)
+}

--- a/core/src/main/scala/cats/syntax/comonad.scala
+++ b/core/src/main/scala/cats/syntax/comonad.scala
@@ -1,0 +1,12 @@
+package cats
+package syntax
+
+trait ComonadSyntax {
+  // TODO: use simulacrum instances eventually
+  implicit def comonadSyntax[F[_]: Comonad, A](fa: F[A]) =
+    new ComonadOps[F, A](fa)
+}
+
+class ComonadOps[F[_], A](fa: F[A])(implicit F: Comonad[F]) {
+  def extract: A = F.extract(fa)
+}

--- a/core/src/main/scala/cats/syntax/contravariant.scala
+++ b/core/src/main/scala/cats/syntax/contravariant.scala
@@ -1,0 +1,13 @@
+package cats
+package syntax
+
+import cats.functor.Contravariant
+
+trait ContravariantSyntax {
+  implicit def invariantSyntax[F[_]: Contravariant, A](fa: F[A]) =
+    new ContravariantOps(fa)
+}
+
+class ContravariantOps[F[_], A](fa: F[A])(implicit F: Contravariant[F]) {
+  def contramap[B](f: B => A): F[B] = F.contramap(fa)(f)
+}

--- a/core/src/main/scala/cats/syntax/eq.scala
+++ b/core/src/main/scala/cats/syntax/eq.scala
@@ -1,0 +1,13 @@
+package cats
+package syntax
+
+trait EqSyntax {
+  // TODO: use simulacrum instances eventually
+  implicit def eqSyntax[A: Eq](a: A) =
+    new EqOps[A](a)
+}
+
+class EqOps[A](lhs: A)(implicit A: Eq[A]) {
+  def ===(rhs: A): Boolean = A.eqv(lhs, rhs)
+  def =!=(rhs: A): Boolean = A.neqv(lhs, rhs)
+}

--- a/core/src/main/scala/cats/syntax/flatMap.scala
+++ b/core/src/main/scala/cats/syntax/flatMap.scala
@@ -1,0 +1,19 @@
+package cats
+package syntax
+
+trait FlatMapSyntax {
+  // TODO: use simulacrum instances eventually
+  implicit def flatMapSyntax[F[_]: FlatMap, A](fa: F[A]) =
+    new FlatMapOps[F, A](fa)
+
+  implicit def flattenSyntax[F[_]: FlatMap, A](ffa: F[F[A]]) =
+    new FlattenOps[F, A](ffa)
+}
+
+class FlatMapOps[F[_], A](fa: F[A])(implicit F: FlatMap[F]) {
+  def flatMap[B](f: A => F[B]): F[B] = F.flatMap(fa)(f)
+}
+
+class FlattenOps[F[_], A](ffa: F[F[A]])(implicit F: FlatMap[F]) {
+  def flatten: F[A] = F.flatten(ffa)
+}

--- a/core/src/main/scala/cats/syntax/foldable.scala
+++ b/core/src/main/scala/cats/syntax/foldable.scala
@@ -1,0 +1,25 @@
+package cats
+package syntax
+
+trait FoldableSyntax {
+  // TODO: use simulacrum instances eventually
+  implicit def foldableSyntax[F[_]: Foldable, A](fa: F[A]) =
+    new FoldableOps[F, A](fa)
+
+  implicit def nestedFoldableSyntax[F[_]: Foldable, G[_], A](fga: F[G[A]]) =
+    new NestedFoldableOps[F, G, A](fga)
+}
+
+class FoldableOps[F[_], A](fa: F[A])(implicit F: Foldable[F]) {
+  def foldLeft[B](b: B)(f: (B, A) => B): B = F.foldLeft(fa, b)(f)
+  def foldRight[B](b: B)(f: (A, B) => B): B = F.foldRight(fa, b)(f)
+  def foldRight[B](b: Lazy[B])(f: (A, Lazy[B]) => B): Lazy[B] = F.foldRight(fa, b)(f)
+  def foldMap[B: Monoid](f: A => B): B = F.foldMap(fa)(f)
+  def fold(implicit A: Monoid[A]): A = F.fold(fa)
+  def traverse_[G[_]: Applicative, B](f: A => G[B]): G[Unit] = F.traverse_(fa)(f)
+}
+
+class NestedFoldableOps[F[_], G[_], A](fga: F[G[A]])(implicit F: Foldable[F]) {
+  def sequence_[B](implicit G: Applicative[G]): G[Unit] = F.sequence_(fga)
+  def foldK(fga: F[G[A]])(implicit G: MonoidK[G]): G[A] = F.foldK(fga)
+}

--- a/core/src/main/scala/cats/syntax/functor.scala
+++ b/core/src/main/scala/cats/syntax/functor.scala
@@ -1,0 +1,7 @@
+package cats
+package syntax
+
+trait FunctorSyntax {
+  implicit def functorSyntax[F[_]: Functor, A](fa: F[A]) =
+    Functor.ops.toFunctorOps(fa)
+}

--- a/core/src/main/scala/cats/syntax/functor.scala
+++ b/core/src/main/scala/cats/syntax/functor.scala
@@ -2,6 +2,14 @@ package cats
 package syntax
 
 trait FunctorSyntax {
+  // TODO: use simulacrum instances eventually
   implicit def functorSyntax[F[_]: Functor, A](fa: F[A]) =
-    Functor.ops.toFunctorOps(fa)
+    new FunctorOps[F, A](fa)
+}
+
+class FunctorOps[F[_], A](fa: F[A])(implicit F: Functor[F]) {
+  def map[B](f: A => B): F[B] = F.map(fa)(f)
+  def void: F[Unit] = F.void(fa)
+  def fproduct[B](f: A => B): F[(A, B)] = F.fproduct(fa)(f)
+  def as[B](b: B): F[B] = F.as(fa, b)
 }

--- a/core/src/main/scala/cats/syntax/invariant.scala
+++ b/core/src/main/scala/cats/syntax/invariant.scala
@@ -1,0 +1,13 @@
+package cats
+package syntax
+
+import cats.functor.Invariant
+
+trait InvariantSyntax {
+  implicit def invariantSyntax[F[_]: Invariant, A](fa: F[A]) =
+    new InvariantOps(fa)
+}
+
+class InvariantOps[F[_], A](fa: F[A])(implicit F: Invariant[F]) {
+  def imap[B](f: A => B)(fi: B => A): F[B] = F.imap(fa)(f)(fi)
+}

--- a/core/src/main/scala/cats/syntax/monadCombine.scala
+++ b/core/src/main/scala/cats/syntax/monadCombine.scala
@@ -1,0 +1,12 @@
+package cats
+package syntax
+
+trait MonadCombineSyntax {
+  // TODO: use simulacrum instances eventually
+  implicit def nestedMonadCombineSyntax[F[_]: MonadCombine, G[_], A](fga: F[G[A]]) =
+    new NestedMonadCombineOps[F, G, A](fga)
+}
+
+class NestedMonadCombineOps[F[_], G[_], A](fga: F[G[A]])(implicit F: MonadCombine[F]) {
+  def unite(implicit G: Foldable[G]): F[A] = F.unite(fga)
+}

--- a/core/src/main/scala/cats/syntax/monadFilter.scala
+++ b/core/src/main/scala/cats/syntax/monadFilter.scala
@@ -1,0 +1,13 @@
+package cats
+package syntax
+
+trait MonadFilterSyntax {
+  // TODO: use simulacrum instances eventually
+  implicit def monadFilterSyntax[F[_]: MonadFilter, A](fa: F[A]) =
+    new MonadFilterOps[F, A](fa)
+}
+
+class MonadFilterOps[F[_], A](fa: F[A])(implicit F: MonadFilter[F]) {
+  def filter(f: A => Boolean): F[A] = F.filter(fa)(f)
+  def filterM(f: A => F[Boolean]): F[A] = F.filterM(fa)(f)
+}

--- a/core/src/main/scala/cats/syntax/order.scala
+++ b/core/src/main/scala/cats/syntax/order.scala
@@ -1,0 +1,14 @@
+package cats
+package syntax
+
+trait OrderSyntax {
+  // TODO: use simulacrum instances eventually
+  implicit def orderSyntax[A: Order](a: A) =
+    new OrderOps[A](a)
+}
+
+class OrderOps[A](lhs: A)(implicit A: Order[A]) {
+  def compare(rhs: A): Int = A.compare(lhs, rhs)
+  def min(rhs: A): A = A.min(lhs, rhs)
+  def max(rhs: A): A = A.max(lhs, rhs)
+}

--- a/core/src/main/scala/cats/syntax/package.scala
+++ b/core/src/main/scala/cats/syntax/package.scala
@@ -7,12 +7,15 @@ package object syntax {
   object coflatMap extends CoFlatMapSyntax
   object comonad extends ComonadSyntax
   object contravariant extends ContravariantSyntax
+  object eq extends EqSyntax
   object flatMap extends FlatMapSyntax
   object foldable extends FoldableSyntax
   object functor extends FunctorSyntax
   object invariant extends InvariantSyntax
   object monadCombine extends MonadCombineSyntax
   object monadFilter extends MonadFilterSyntax
+  object order extends OrderSyntax
+  object partialOrder extends PartialOrderSyntax
   object profunctor extends ProfunctorSyntax
   object semigroup extends SemigroupSyntax
   object show extends ShowSyntax

--- a/core/src/main/scala/cats/syntax/package.scala
+++ b/core/src/main/scala/cats/syntax/package.scala
@@ -14,6 +14,7 @@ package object syntax {
   object monadCombine extends MonadCombineSyntax
   object monadFilter extends MonadFilterSyntax
   object profunctor extends ProfunctorSyntax
+  object semigroup extends SemigroupSyntax
   object show extends ShowSyntax
   object strong extends StrongSyntax
 }

--- a/core/src/main/scala/cats/syntax/package.scala
+++ b/core/src/main/scala/cats/syntax/package.scala
@@ -2,9 +2,18 @@ package cats
 
 package object syntax {
   object all extends AllSyntax
-  object invariant extends InvariantSyntax
-  object contravariant extends ContravariantSyntax
-  object functor extends FunctorSyntax
   object apply extends ApplySyntax
+  object bifunctor extends BifunctorSyntax
+  object coflatMap extends CoFlatMapSyntax
+  object comonad extends ComonadSyntax
+  object contravariant extends ContravariantSyntax
   object flatMap extends FlatMapSyntax
+  object foldable extends FoldableSyntax
+  object functor extends FunctorSyntax
+  object invariant extends InvariantSyntax
+  object monadCombine extends MonadCombineSyntax
+  object monadFilter extends MonadFilterSyntax
+  object profunctor extends ProfunctorSyntax
+  object show extends ShowSyntax
+  object strong extends StrongSyntax
 }

--- a/core/src/main/scala/cats/syntax/package.scala
+++ b/core/src/main/scala/cats/syntax/package.scala
@@ -1,0 +1,6 @@
+package cats
+
+package object syntax {
+  object all extends AllSyntax
+  object functor extends FunctorSyntax
+}

--- a/core/src/main/scala/cats/syntax/package.scala
+++ b/core/src/main/scala/cats/syntax/package.scala
@@ -2,5 +2,9 @@ package cats
 
 package object syntax {
   object all extends AllSyntax
+  object invariant extends InvariantSyntax
+  object contravariant extends ContravariantSyntax
   object functor extends FunctorSyntax
+  object apply extends ApplySyntax
+  object flatMap extends FlatMapSyntax
 }

--- a/core/src/main/scala/cats/syntax/partialOrder.scala
+++ b/core/src/main/scala/cats/syntax/partialOrder.scala
@@ -1,0 +1,20 @@
+package cats
+package syntax
+
+trait PartialOrderSyntax {
+  // TODO: use simulacrum instances eventually
+  implicit def partialOrderSyntax[A: PartialOrder](a: A) =
+    new PartialOrderOps[A](a)
+}
+
+class PartialOrderOps[A](lhs: A)(implicit A: PartialOrder[A]) {
+  def >(rhs: A): Boolean = A.gt(lhs, rhs)
+  def >=(rhs: A): Boolean = A.gteqv(lhs, rhs)
+  def <(rhs: A): Boolean = A.lt(lhs, rhs)
+  def <=(rhs: A): Boolean = A.lteqv(lhs, rhs)
+
+  def partialCompare(rhs: A): Double = A.partialCompare(lhs, rhs)
+  def tryCompare(rhs: A): Option[Int] = A.tryCompare(lhs, rhs)
+  def pmin(rhs: A): Option[A] = A.pmin(lhs, rhs)
+  def pmax(rhs: A): Option[A] = A.pmax(lhs, rhs)
+}

--- a/core/src/main/scala/cats/syntax/profunctor.scala
+++ b/core/src/main/scala/cats/syntax/profunctor.scala
@@ -1,0 +1,16 @@
+package cats
+package syntax
+
+import cats.functor.Profunctor
+
+trait ProfunctorSyntax {
+  // TODO: use simulacrum instances eventually
+  implicit def profunctorSyntax[F[_, _]: Profunctor, A, B](fab: F[A, B]) =
+    new ProfunctorOps[F, A, B](fab)
+}
+
+class ProfunctorOps[F[_, _], A, B](fab: F[A, B])(implicit F: Profunctor[F]) {
+  def lmap[C](f: C => A): F[C, B] = F.lmap(fab)(f)
+  def rmap[C](f: B => C): F[A, C] = F.rmap(fab)(f)
+  def dimap[C, D](f: C => A)(g: B => D): F[C, D] = F.dimap(fab)(f)(g)
+}

--- a/core/src/main/scala/cats/syntax/semigroup.scala
+++ b/core/src/main/scala/cats/syntax/semigroup.scala
@@ -1,0 +1,14 @@
+package cats
+package syntax
+
+trait SemigroupSyntax {
+  // TODO: use simulacrum instances eventually
+  implicit def semigroupSyntax[A: Semigroup](a: A) =
+    new SemigroupOps[A](a)
+}
+
+class SemigroupOps[A](lhs: A)(implicit A: Semigroup[A]) {
+  def |+|(rhs: A): A = A.combine(lhs, rhs)
+  def combine(rhs: A): A = A.combine(lhs, rhs)
+  def combineN(rhs: Int): A = A.combineN(lhs, rhs)
+}

--- a/core/src/main/scala/cats/syntax/show.scala
+++ b/core/src/main/scala/cats/syntax/show.scala
@@ -1,0 +1,12 @@
+package cats
+package syntax
+
+trait ShowSyntax {
+  // TODO: use simulacrum instances eventually
+  implicit def showSyntax[A: Show](a: A) =
+    new ShowOps[A](a)
+}
+
+class ShowOps[A](a: A)(implicit A: Show[A]) {
+  def show: String = A.show(a)
+}

--- a/core/src/main/scala/cats/syntax/strong.scala
+++ b/core/src/main/scala/cats/syntax/strong.scala
@@ -1,0 +1,15 @@
+package cats
+package syntax
+
+import cats.functor.Strong
+
+trait StrongSyntax {
+  // TODO: use simulacrum instances eventually
+  implicit def strongSyntax[F[_, _]: Strong, A, B](fab: F[A, B]) =
+    new StrongOps[F, A, B](fab)
+}
+
+class StrongOps[F[_, _], A, B](fab: F[A, B])(implicit F: Strong[F]) {
+  def first[C]: F[(A, C), (B, C)] = F.first(fab)
+  def second[C]: F[(C, A), (C, B)] = F.second(fab)
+}

--- a/laws/src/main/scala/cats/laws/FunctorLaws.scala
+++ b/laws/src/main/scala/cats/laws/FunctorLaws.scala
@@ -31,10 +31,10 @@ trait FunctorLaws[F[_], A] extends Laws {
       name = "functor",
       parents = Nil,
       "invariant identity" -> forAll { (fa: F[A]) =>
-        F.imap(fa)(identity[A], identity[A]) ?== fa
+        F.imap(fa)(identity[A])(identity[A]) ?== fa
       },
       "invariant composition" -> forAll { (fa: F[A], f1: A => B, f2: B => A, g1: B => C, g2: C => B) =>
-        F.imap(F.imap(fa)(f1, f2))(g1, g2) ?== F.imap(fa)(f1 andThen g1, g2 andThen f2)
+        F.imap(F.imap(fa)(f1)(f2))(g1)(g2) ?== F.imap(fa)(f1 andThen g1)(g2 andThen f2)
       })
 
   def covariant[B: Arbitrary, C: Arbitrary](implicit F: Functor[F], FC: Eq[F[C]]) =

--- a/std/src/main/scala/cats/implicits/package.scala
+++ b/std/src/main/scala/cats/implicits/package.scala
@@ -1,0 +1,3 @@
+package cats
+
+object implicits extends syntax.AllSyntax with std.AllInstances


### PR DESCRIPTION
Here's a first pass at setting up syntax in cats.

High-level stuff:

1. Syntax lives in `core`
2. Syntax contained in the "most general" class
3. Specific imports work, e.g. `import cats.syntax.functor._`
4. General import works, e.g. `import cats.syntax.all._`
5. Omnibus import for syntax + instances works, e.g. `import cats.implicits._`

Let me know what you think!