### PR TITLE
Add Scalastyle

### DIFF
--- a/core/src/main/scala/cats/arrow/Kleisli.scala
+++ b/core/src/main/scala/cats/arrow/Kleisli.scala
@@ -14,13 +14,13 @@ final case class Kleisli[M[_], A, B](run: A => M[B]) { self =>
 
   def andThen[C](f: B => M[C])(implicit b: FlatMap[M]): Kleisli[M, A, C] =
     Kleisli((a: A) => b.flatMap(run(a))(f))
-  
+
   def andThen[C](k: Kleisli[M, B, C])(implicit b: FlatMap[M]): Kleisli[M, A, C] =
     this andThen k.run
-  
+
   def compose[Z](f: Z => M[A])(implicit M: FlatMap[M]): Kleisli[M, Z, B] =
     Kleisli((z: Z) => M.flatMap(f(z))(run))
-  
+
   def compose[Z](k: Kleisli[M, Z, A])(implicit b: FlatMap[M]): Kleisli[M, Z, B] =
     this compose k.run
 

--- a/core/src/main/scala/cats/free/Coyoneda.scala
+++ b/core/src/main/scala/cats/free/Coyoneda.scala
@@ -59,9 +59,9 @@ object Coyoneda {
 
   /**
    * Partial application of type parameters to `apply`.
-   * 
+   *
    * It can be nicer to say `Coyoneda.by[F]{ x: X => ... }`
-   * 
+   *
    * ...instead of `Coyoneda[...](...){ x => ... }`.
    */
   def by[F[_]]: By[F] = new By[F]

--- a/core/src/main/scala/cats/free/Free.scala
+++ b/core/src/main/scala/cats/free/Free.scala
@@ -72,7 +72,8 @@ sealed abstract class Free[S[_], A] {
           x.f(a).resume
         case Suspend(t) =>
           Left(S.map(t)(_ flatMap x.f))
-        case y: Gosub[S, x.C] =>
+        // The _ should be x.C, but we are hitting this bug: https://github.com/daniel-trinh/scalariform/issues/44
+        case y: Gosub[S, _] =>
           y.a().flatMap(z => y.f(z) flatMap x.f).resume
       }
   }
@@ -106,7 +107,7 @@ sealed abstract class Free[S[_], A] {
 
   /**
    * Catamorphism for `Free`.
-   * 
+   *
    * Runs to completion, mapping the suspension with the given transformation at each step and
    * accumulating into the monad `M`.
    */

--- a/core/src/main/scala/cats/free/Yoneda.scala
+++ b/core/src/main/scala/cats/free/Yoneda.scala
@@ -24,14 +24,14 @@ abstract class Yoneda[F[_], A] { self =>
   /**
    * Simple function composition. Allows map fusion without traversing an `F`.
    */
-  def map[B](f: A => B): Yoneda[F, B] = 
+  def map[B](f: A => B): Yoneda[F, B] =
     new Yoneda[F, B] {
       def apply[C](g: B => C) = self(f andThen g)
     }
 
   // import Id._
   // /** `Yoneda[F, _]` is the right Kan extension of `F` along `Id` */
-  // def toRan: Ran[Id, F, A] = 
+  // def toRan: Ran[Id, F, A] =
   //   new Ran[Id, F, A] {
   //     def apply[B](f: A => B) = self(f)
   //   }

--- a/data/src/main/scala/cats/data/OneAnd.scala
+++ b/data/src/main/scala/cats/data/OneAnd.scala
@@ -8,7 +8,7 @@ trait OneAndInstances {
   implicit def oneAndShow[A, F[_]](implicit showHead: Show[A], showTail: Show[F[A]]): Show[OneAnd[A, F]] =
     Show.show[OneAnd[A, F]](x => s"OneAnd(${showHead.show(x.head)}, ${showTail.show(x.tail)})")
 
-  implicit def instance[F[_]](implicit monoid: MonoidK[F], functor: Functor[F], monad: Monad[F]):Comonad[OneAnd[?, F]] with Monad[OneAnd[?, F]] = new Comonad[OneAnd[?, F]] with Monad[OneAnd[?, F]] {
+  implicit def instance[F[_]](implicit monoid: MonoidK[F], functor: Functor[F], monad: Monad[F]): Comonad[OneAnd[?, F]] with Monad[OneAnd[?, F]] = new Comonad[OneAnd[?, F]] with Monad[OneAnd[?, F]] {
     def extract[A](x: OneAnd[A,F]) = x.head
 
     def coflatMap[A, B](fa: OneAnd[A,F])(f: OneAnd[A,F] => B) =

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,4 @@
 addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.3.1")
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "0.7.1")
 addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8")
+addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.6.0")

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -1,0 +1,62 @@
+<scalastyle>
+ <name>Scalastyle standard configuration</name>
+ <check level="error" class="org.scalastyle.file.FileTabChecker" enabled="true"></check>
+ <check level="error" class="org.scalastyle.file.FileLengthChecker" enabled="true">
+  <parameters>
+   <parameter name="maxFileLength"><![CDATA[800]]></parameter>
+  </parameters>
+ </check>
+ <check level="error" class="org.scalastyle.file.WhitespaceEndOfLineChecker" enabled="true"></check>
+ <check level="error" class="org.scalastyle.scalariform.ClassNamesChecker" enabled="true">
+  <parameters>
+   <parameter name="regex"><![CDATA[[A-Z][A-Za-z]*]]></parameter>
+  </parameters>
+ </check>
+ <check level="error" class="org.scalastyle.scalariform.ObjectNamesChecker" enabled="true">
+  <parameters>
+   <parameter name="regex"><![CDATA[[A-Za-z][A-Za-z]*]]></parameter>
+  </parameters>
+ </check>
+ <check level="error" class="org.scalastyle.scalariform.PackageObjectNamesChecker" enabled="true">
+  <parameters>
+   <parameter name="regex"><![CDATA[^[a-z][a-z]*$]]></parameter>
+  </parameters>
+ </check>
+ <check level="error" class="org.scalastyle.scalariform.EqualsHashCodeChecker" enabled="true"></check>
+ <check level="error" class="org.scalastyle.scalariform.IllegalImportsChecker" enabled="true">
+  <parameters>
+   <parameter name="illegalImports"><![CDATA[sun._,java.awt._]]></parameter>
+  </parameters>
+ </check>
+ <check level="error" class="org.scalastyle.scalariform.NoWhitespaceBeforeLeftBracketChecker" enabled="true"></check>
+ <check level="error" class="org.scalastyle.scalariform.NoWhitespaceAfterLeftBracketChecker" enabled="true"></check>
+ <check level="error" class="org.scalastyle.scalariform.ReturnChecker" enabled="true"></check>
+ <check level="error" class="org.scalastyle.scalariform.NullChecker" enabled="true"></check>
+ <check level="error" class="org.scalastyle.scalariform.NoCloneChecker" enabled="true"></check>
+ <check level="error" class="org.scalastyle.scalariform.NoFinalizeChecker" enabled="true"></check>
+ <check level="error" class="org.scalastyle.scalariform.CovariantEqualsChecker" enabled="true"></check>
+ <check level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+  <parameters>
+   <parameter name="regex"><![CDATA[println]]></parameter>
+  </parameters>
+ </check>
+ <check level="error" class="org.scalastyle.scalariform.NumberOfTypesChecker" enabled="true">
+  <parameters>
+   <parameter name="maxTypes"><![CDATA[30]]></parameter>
+  </parameters>
+ </check>
+ <check level="error" class="org.scalastyle.scalariform.CyclomaticComplexityChecker" enabled="true">
+  <parameters>
+   <parameter name="maximum"><![CDATA[10]]></parameter>
+  </parameters>
+ </check>
+ <check level="error" class="org.scalastyle.scalariform.UppercaseLChecker" enabled="true"></check>
+ <check level="error" class="org.scalastyle.scalariform.SimplifyBooleanExpressionChecker" enabled="true"></check>
+ <check level="error" class="org.scalastyle.scalariform.MethodLengthChecker" enabled="true">
+  <parameters>
+   <parameter name="maxLength"><![CDATA[50]]></parameter>
+  </parameters>
+ </check>
+ <check level="error" class="org.scalastyle.file.NewLineAtEofChecker" enabled="true"></check>
+ <check level="error" class="org.scalastyle.file.NoNewLineAtEofChecker" enabled="false"></check>
+</scalastyle>

--- a/std/src/main/scala/cats/std/list.scala
+++ b/std/src/main/scala/cats/std/list.scala
@@ -42,7 +42,7 @@ trait ListInstances {
 
       def foldRight[A, B](fa: List[A], b: Lazy[B])(f: (A, Lazy[B]) => B): Lazy[B] = {
         // we use Lazy.byName(...) to avoid memoizing intermediate values.
-        def loop(as: List[A], b: Lazy[B]): Lazy[B] = 
+        def loop(as: List[A], b: Lazy[B]): Lazy[B] =
           as match {
             case Nil => b
             case a :: rest => Lazy.byName(f(a, foldRight(rest, b)(f)))

--- a/std/src/main/scala/cats/std/set.scala
+++ b/std/src/main/scala/cats/std/set.scala
@@ -13,7 +13,7 @@ trait SetInstances extends algebra.std.SetInstances {
 
       def foldLeft[A, B](fa: Set[A], b: B)(f: (B, A) => B): B =
         fa.foldLeft(b)(f)
-      
+
       def foldRight[A, B](fa: Set[A], b: B)(f: (A, B) => B): B =
         fa.foldRight(b)(f)
 

--- a/std/src/main/scala/cats/std/stream.scala
+++ b/std/src/main/scala/cats/std/stream.scala
@@ -38,7 +38,7 @@ trait StreamInstances {
       // this foldRight variant is lazy
       def foldRight[A, B](fa: Stream[A], b: Lazy[B])(f: (A, Lazy[B]) => B): Lazy[B] = {
         // we use Lazy.byName(...) to avoid memoizing intermediate values.
-        def loop(as: Stream[A], b: Lazy[B]): Lazy[B] = 
+        def loop(as: Stream[A], b: Lazy[B]): Lazy[B] =
           as match {
             case Stream.Empty => b
             case a #:: rest => Lazy.byName(f(a, foldRight(rest, b)(f)))


### PR DESCRIPTION
This addresses one of the requests made in #50.

I just kind of went with rules that seemed right for the project. People are free to suggest changes.

Currently one has to explicitly run the `scalastyle` or `test:scalastyle` task to check style. Adding linting to the compile task would probably be too slow. We could potentially add it to the test task, but I gave that a quick try and was having some trouble getting it to check the main source in addition to the test source with that approach. Once we have Travis CI integration, we should be able to run the linting without slowing down our compile or test tasks. It might still be worth making one uber sbt task to test and run linting, and I would encourage someone who understands SBT much better than I do to do so! :)