### PR TITLE
Set up Machinist, use macros for Eq through Order syntax.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -56,14 +56,18 @@ lazy val aggregate = project.in(file("."))
   .settings(catsSettings: _*)
   .settings(docSettings: _*)
   .settings(noPublishSettings: _*)
-  .aggregate(core, laws, tests, data, std, examples)
-  .dependsOn(core, laws, tests, data, std, examples)
+  .aggregate(macros, core, laws, tests, data, std, examples)
+  .dependsOn(macros, core, laws, tests, data, std, examples)
 
-lazy val core = project
+lazy val macros = project
+  .settings(moduleName := "cats-macros")
+  .settings(catsSettings: _*)
+
+lazy val core = project.dependsOn(macros)
   .settings(moduleName := "cats")
   .settings(catsSettings: _*)
 
-lazy val laws = project.dependsOn(core, data)
+lazy val laws = project.dependsOn(macros, core, data)
   .settings(moduleName := "cats-laws")
   .settings(catsSettings: _*)
   .settings(
@@ -72,14 +76,14 @@ lazy val laws = project.dependsOn(core, data)
     )
   )
 
-lazy val std = project.dependsOn(core, laws)
+lazy val std = project.dependsOn(macros, core, laws)
   .settings(moduleName := "cats-std")
   .settings(catsSettings: _*)
   .settings(
     libraryDependencies += "org.spire-math" %% "algebra-std" % "0.2.0-SNAPSHOT" from "http://plastic-idolatry.com/jars/algebra-std_2.11-0.2.0-SNAPSHOT.jar"
   )
 
-lazy val tests = project.dependsOn(core, data, std, laws)
+lazy val tests = project.dependsOn(macros, core, data, std, laws)
   .settings(moduleName := "cats-tests")
   .settings(catsSettings: _*)
   .settings(noPublishSettings: _*)
@@ -89,11 +93,11 @@ lazy val tests = project.dependsOn(core, data, std, laws)
     )
   )
 
-lazy val data = project.dependsOn(core)
+lazy val data = project.dependsOn(macros, core)
   .settings(moduleName := "cats-data")
   .settings(catsSettings: _*)
 
-lazy val examples = project.dependsOn(core)
+lazy val examples = project.dependsOn(macros, core)
   .settings(moduleName := "cats-examples")
   .settings(catsSettings: _*)
   .settings(noPublishSettings: _*)

--- a/build.sbt
+++ b/build.sbt
@@ -19,6 +19,7 @@ lazy val commonSettings = Seq(
     "-language:existentials",
     "-language:higherKinds",
     "-language:implicitConversions",
+    "-language:experimental.macros",
     "-unchecked",
     "-Xfatal-warnings",
     "-Xlint",

--- a/core/src/main/scala/cats/Foldable.scala
+++ b/core/src/main/scala/cats/Foldable.scala
@@ -1,6 +1,5 @@
 package cats
 
-import algebra.Monoid
 import simulacrum._
 
 /**

--- a/core/src/main/scala/cats/Foldable.scala
+++ b/core/src/main/scala/cats/Foldable.scala
@@ -25,8 +25,8 @@ import simulacrum._
   /**
    * Apply f to each element of F and combine them using the Monoid[B].
    */
-  def foldMap[A, B: Monoid](fa: F[A])(f: A => B): B = foldLeft(fa, algebra.Monoid[B].empty) { (b, a) =>
-    algebra.Monoid[B].combine(b, f(a))
+  def foldMap[A, B: Monoid](fa: F[A])(f: A => B): B = foldLeft(fa, Monoid[B].empty) { (b, a) =>
+    Monoid[B].combine(b, f(a))
   }
 
   /**

--- a/core/src/main/scala/cats/MonoidK.scala
+++ b/core/src/main/scala/cats/MonoidK.scala
@@ -1,6 +1,5 @@
 package cats
 
-import algebra.Monoid
 import simulacrum._
 
 @typeclass trait MonoidK[F[_]] extends SemigroupK[F] { self =>
@@ -12,7 +11,3 @@ import simulacrum._
       def combine(x: F[A], y: F[A]): F[A] = self.combine(x, y)
     }
 }
-
-// object MonoidK {
-//   def apply[F[_]](implicit ev: MonoidK[F]): MonoidK[F] = ev
-// }

--- a/core/src/main/scala/cats/SemigroupK.scala
+++ b/core/src/main/scala/cats/SemigroupK.scala
@@ -1,6 +1,5 @@
 package cats
 
-import algebra.Semigroup
 import simulacrum._
 
 @typeclass trait SemigroupK[F[_]] { self =>
@@ -16,7 +15,3 @@ import simulacrum._
       def combine(x: F[A], y: F[A]): F[A] = self.combine(x, y)
     }
 }
-
-// object SemigroupK {
-//   def apply[F[_]](implicit ev: SemigroupK[F]): SemigroupK[F] = ev
-// }

--- a/core/src/main/scala/cats/arrow/Category.scala
+++ b/core/src/main/scala/cats/arrow/Category.scala
@@ -1,8 +1,6 @@
 package cats
 package arrow
 
-import algebra.Monoid
-
 trait Category[F[_, _]] extends Compose[F] { self =>
 
   def id[A]: F[A, A]

--- a/core/src/main/scala/cats/arrow/Compose.scala
+++ b/core/src/main/scala/cats/arrow/Compose.scala
@@ -1,8 +1,6 @@
 package cats
 package arrow
 
-import algebra.Semigroup
-
 trait Compose[F[_, _]] { self =>
   def compose[A, B, C](f: F[B, C], g: F[A, B]): F[A, C]
 

--- a/core/src/main/scala/cats/package.scala
+++ b/core/src/main/scala/cats/package.scala
@@ -13,7 +13,12 @@ package object cats {
   type Eq[A] = algebra.Eq[A]
   type PartialOrder[A] = algebra.PartialOrder[A]
   type Order[A] = algebra.Order[A]
-
   type Semigroup[A] = algebra.Semigroup[A]
   type Monoid[A] = algebra.Monoid[A]
+
+  val Eq = algebra.Eq
+  val PartialOrder = algebra.PartialOrder
+  val Order = algebra.Order
+  val Semigroup = algebra.Semigroup
+  val Monoid = algebra.Monoid
 }

--- a/core/src/main/scala/cats/syntax/eq.scala
+++ b/core/src/main/scala/cats/syntax/eq.scala
@@ -1,13 +1,14 @@
 package cats
 package syntax
 
+import cats.macros.Ops
+import scala.language.experimental.macros
+
 trait EqSyntax {
-  // TODO: use simulacrum instances eventually
-  implicit def eqSyntax[A: Eq](a: A) =
-    new EqOps[A](a)
+  implicit def eqSyntax[A: Eq](a: A) = new EqOps[A](a)
 }
 
 class EqOps[A](lhs: A)(implicit A: Eq[A]) {
-  def ===(rhs: A): Boolean = A.eqv(lhs, rhs)
-  def =!=(rhs: A): Boolean = A.neqv(lhs, rhs)
+  def ===(rhs: A): Boolean = macro Ops.binop[A, Boolean]
+  def =!=(rhs: A): Boolean = macro Ops.binop[A, Boolean]
 }

--- a/core/src/main/scala/cats/syntax/eq.scala
+++ b/core/src/main/scala/cats/syntax/eq.scala
@@ -2,7 +2,6 @@ package cats
 package syntax
 
 import cats.macros.Ops
-import scala.language.experimental.macros
 
 trait EqSyntax {
   implicit def eqSyntax[A: Eq](a: A) = new EqOps[A](a)

--- a/core/src/main/scala/cats/syntax/order.scala
+++ b/core/src/main/scala/cats/syntax/order.scala
@@ -2,7 +2,6 @@ package cats
 package syntax
 
 import cats.macros.Ops
-import scala.language.experimental.macros
 
 trait OrderSyntax {
   implicit def orderSyntax[A: Order](a: A) = new OrderOps[A](a)

--- a/core/src/main/scala/cats/syntax/order.scala
+++ b/core/src/main/scala/cats/syntax/order.scala
@@ -1,14 +1,15 @@
 package cats
 package syntax
 
+import cats.macros.Ops
+import scala.language.experimental.macros
+
 trait OrderSyntax {
-  // TODO: use simulacrum instances eventually
-  implicit def orderSyntax[A: Order](a: A) =
-    new OrderOps[A](a)
+  implicit def orderSyntax[A: Order](a: A) = new OrderOps[A](a)
 }
 
 class OrderOps[A](lhs: A)(implicit A: Order[A]) {
-  def compare(rhs: A): Int = A.compare(lhs, rhs)
-  def min(rhs: A): A = A.min(lhs, rhs)
-  def max(rhs: A): A = A.max(lhs, rhs)
+  def compare(rhs: A): Int = macro Ops.binop[A, Int]
+  def min(rhs: A): A = macro Ops.binop[A, A]
+  def max(rhs: A): A = macro Ops.binop[A, A]
 }

--- a/core/src/main/scala/cats/syntax/partialOrder.scala
+++ b/core/src/main/scala/cats/syntax/partialOrder.scala
@@ -2,7 +2,6 @@ package cats
 package syntax
 
 import cats.macros.Ops
-import scala.language.experimental.macros
 
 trait PartialOrderSyntax {
   implicit def partialOrderSyntax[A: PartialOrder](a: A) = new PartialOrderOps[A](a)

--- a/core/src/main/scala/cats/syntax/partialOrder.scala
+++ b/core/src/main/scala/cats/syntax/partialOrder.scala
@@ -1,20 +1,21 @@
 package cats
 package syntax
 
+import cats.macros.Ops
+import scala.language.experimental.macros
+
 trait PartialOrderSyntax {
-  // TODO: use simulacrum instances eventually
-  implicit def partialOrderSyntax[A: PartialOrder](a: A) =
-    new PartialOrderOps[A](a)
+  implicit def partialOrderSyntax[A: PartialOrder](a: A) = new PartialOrderOps[A](a)
 }
 
 class PartialOrderOps[A](lhs: A)(implicit A: PartialOrder[A]) {
-  def >(rhs: A): Boolean = A.gt(lhs, rhs)
-  def >=(rhs: A): Boolean = A.gteqv(lhs, rhs)
-  def <(rhs: A): Boolean = A.lt(lhs, rhs)
-  def <=(rhs: A): Boolean = A.lteqv(lhs, rhs)
+  def >(rhs: A): Boolean = macro Ops.binop[A, Boolean]
+  def >=(rhs: A): Boolean = macro Ops.binop[A, Boolean]
+  def <(rhs: A): Boolean = macro Ops.binop[A, Boolean]
+  def <=(rhs: A): Boolean = macro Ops.binop[A, Boolean]
 
-  def partialCompare(rhs: A): Double = A.partialCompare(lhs, rhs)
-  def tryCompare(rhs: A): Option[Int] = A.tryCompare(lhs, rhs)
-  def pmin(rhs: A): Option[A] = A.pmin(lhs, rhs)
-  def pmax(rhs: A): Option[A] = A.pmax(lhs, rhs)
+  def partialCompare(rhs: A): Double = macro Ops.binop[A, Double]
+  def tryCompare(rhs: A): Option[Int] = macro Ops.binop[A, Option[Int]]
+  def pmin(rhs: A): Option[A] = macro Ops.binop[A, Option[A]]
+  def pmax(rhs: A): Option[A] = macro Ops.binop[A, Option[A]]
 }

--- a/data/src/main/scala/cats/data/Const.scala
+++ b/data/src/main/scala/cats/data/Const.scala
@@ -1,6 +1,6 @@
-package cats.data
+package cats
+package data
 
-import algebra._
 import cats.{Applicative, Apply, Lazy, Show, Traverse}
 
 /**

--- a/data/src/main/scala/cats/data/Or.scala
+++ b/data/src/main/scala/cats/data/Or.scala
@@ -2,7 +2,6 @@ package cats
 package data
 
 import Or.{LeftOr, RightOr}
-import algebra.{PartialOrder, Eq, Order, Monoid}
 import cats.functor.Invariant
 
 import scala.reflect.ClassTag

--- a/laws/src/main/scala/cats/laws/ComonadLaws.scala
+++ b/laws/src/main/scala/cats/laws/ComonadLaws.scala
@@ -1,6 +1,5 @@
 package cats.laws
 
-import algebra.Eq
 import algebra.laws._
 
 import org.scalacheck.{Arbitrary, Prop}

--- a/laws/src/main/scala/cats/laws/FunctorLaws.scala
+++ b/laws/src/main/scala/cats/laws/FunctorLaws.scala
@@ -1,6 +1,5 @@
 package cats.laws
 
-import algebra.Eq
 import algebra.laws._
 
 import org.typelevel.discipline.Laws

--- a/macros/src/main/scala/cats/macros/Ops.scala
+++ b/macros/src/main/scala/cats/macros/Ops.scala
@@ -1,0 +1,18 @@
+package cats.macros
+
+object Ops extends machinist.Ops {
+
+  def uesc(c: Char): String = "$u%04X".format(c.toInt)
+
+  val operatorNames: Map[String, String] =
+    Map(
+      ("$eq$eq$eq", "eqv"),
+      ("$eq$bang$eq", "neqv"),
+      ("$greater", "gt"),
+      ("$greater$eq", "gteqv"),
+      ("$less", "lt"),
+      ("$less$eq", "lteqv"),
+      ("$bar$plus$bar", "combine"),
+      ("$bar$minus$bar", "remove")
+    )
+}


### PR DESCRIPTION
This commit adds cats-macros, upon which cats depends.
Right now, the only macros being used are Machinist's
operator macros, which are configured in cats.macros.Ops.

The punchline of doing this is that:

    def xyz[A: Eq](x: A, y: A): Boolean =
      x === y

is now exactly the same as:

    def xyz[A](x: A, y: A)(implicit A: Eq[A]): Boolean =
      A.eqv(x, y)

i.e. the syntax implicit conversions are completely erased.
This eliminates the performance penalty that syntax normally
implies. It also means the syntax classes don't need to be
value classes (or specialized) since they are not used at
runtime.