### PR TITLE
Fix Or's scaladoc references to LeftOr and RightOr.

### DIFF
--- a/data/src/main/scala/cats/data/Or.scala
+++ b/data/src/main/scala/cats/data/Or.scala
@@ -8,10 +8,10 @@ import scala.reflect.ClassTag
 
 /** Represents a right-biased disjunction that is either an `A` or a `B`.
  *
- * An instance of `A` [[Or]] `B` is either a [[LeftOr]]`[A]` or a [[RightOr]]`[B]`.
+ * An instance of `A` [[Or]] `B` is either a [[Or.LeftOr LeftOr]]`[A]` or a [[Or.RightOr RightOr]]`[B]`.
  *
  * A common use of [[Or]] is to explicitly represent the possibility of failure in a result as opposed to
- * throwing an exception.  By convention, [[LeftOr]] is used for errors and [[RightOr]] is reserved for successes.
+ * throwing an exception.  By convention, [[Or.LeftOr LeftOr]] is used for errors and [[Or.RightOr RightOr]] is reserved for successes.
  * For example, a function that attempts to parse an integer from a string may have a return type of
  * `NumberFormatException` [[Or]] `Int`. However, since there is no need to actually throw an exception, the type (`A`)
  * chosen for the "left" could be any type representing an error and has no need to actually extend `Exception`.


### PR DESCRIPTION
The unidoc task was failing with "Could not find any member to link for "LeftOr" because
scaladoc for cats.data.Or is trying to to find LeftOr and RightOr in cats.data instead of cats.data.Or.