### PR TITLE
Add scaladoc for FlatMap.

### DIFF
--- a/core/src/main/scala/cats/FlatMap.scala
+++ b/core/src/main/scala/cats/FlatMap.scala
@@ -2,6 +2,20 @@ package cats
 
 import simulacrum._
 
+/**
+  *  FlatMap typeclass gives us flatMap, which allows us to have a value
+  *  in a context (F[A]) and then feed that into a function that takes
+  *  a normal value and returns a value in a context.
+  *  
+  *  One motivation for separating this out from Monad is that there are 
+  *  situations where we can implement flatMap but not pure.  For example, 
+  *  we can implement map or flatMap that transforms the values of Map[K, ?], 
+  *  but we can't implement pure (because we wouldn't know what key to use
+  *  when instantiating the new Map).  
+  * 
+  *  @see See [[https://github.com/non/cats/issues/3]] for some discussion.
+  * 
+  */
 @typeclass trait FlatMap[F[_]] extends Apply[F] {
   def flatMap[A, B](fa: F[A])(f: A => F[B]): F[B]
 

--- a/core/src/main/scala/cats/FlatMap.scala
+++ b/core/src/main/scala/cats/FlatMap.scala
@@ -3,19 +3,19 @@ package cats
 import simulacrum._
 
 /**
-  *  FlatMap typeclass gives us flatMap, which allows us to have a value
-  *  in a context (F[A]) and then feed that into a function that takes
-  *  a normal value and returns a value in a context.
-  *  
-  *  One motivation for separating this out from Monad is that there are 
-  *  situations where we can implement flatMap but not pure.  For example, 
-  *  we can implement map or flatMap that transforms the values of Map[K, ?], 
-  *  but we can't implement pure (because we wouldn't know what key to use
-  *  when instantiating the new Map).  
-  * 
-  *  @see See [[https://github.com/non/cats/issues/3]] for some discussion.
-  * 
-  */
+ *  FlatMap typeclass gives us flatMap, which allows us to have a value
+ *  in a context (F[A]) and then feed that into a function that takes
+ *  a normal value and returns a value in a context (A => F[B]).
+ *  
+ *  One motivation for separating this out from Monad is that there are 
+ *  situations where we can implement flatMap but not pure.  For example, 
+ *  we can implement map or flatMap that transforms the values of Map[K, ?], 
+ *  but we can't implement pure (because we wouldn't know what key to use
+ *  when instantiating the new Map).  
+ * 
+ *  @see See [[https://github.com/non/cats/issues/3]] for some discussion.
+ * 
+ */
 @typeclass trait FlatMap[F[_]] extends Apply[F] {
   def flatMap[A, B](fa: F[A])(f: A => F[B]): F[B]
 

--- a/core/src/main/scala/cats/FlatMap.scala
+++ b/core/src/main/scala/cats/FlatMap.scala
@@ -6,15 +6,15 @@ import simulacrum._
  *  FlatMap typeclass gives us flatMap, which allows us to have a value
  *  in a context (F[A]) and then feed that into a function that takes
  *  a normal value and returns a value in a context (A => F[B]).
- *  
- *  One motivation for separating this out from Monad is that there are 
- *  situations where we can implement flatMap but not pure.  For example, 
- *  we can implement map or flatMap that transforms the values of Map[K, ?], 
+ *
+ *  One motivation for separating this out from Monad is that there are
+ *  situations where we can implement flatMap but not pure.  For example,
+ *  we can implement map or flatMap that transforms the values of Map[K, ?],
  *  but we can't implement pure (because we wouldn't know what key to use
- *  when instantiating the new Map).  
- * 
+ *  when instantiating the new Map).
+ *
  *  @see See [[https://github.com/non/cats/issues/3]] for some discussion.
- * 
+ *
  */
 @typeclass trait FlatMap[F[_]] extends Apply[F] {
   def flatMap[A, B](fa: F[A])(f: A => F[B]): F[B]


### PR DESCRIPTION
This commit adds some scaladoc for FlatMap -- in particular, I add
a brief explanation of why its useful to have FlatMap separated from
Monad and link to the discussion at https://github.com/non/cats/issues/3.