### PR TITLE
remove UpStar and DownStar and add doc for Profunctor

### DIFF
--- a/core/src/main/scala/cats/arrow/Arrow.scala
+++ b/core/src/main/scala/cats/arrow/Arrow.scala
@@ -7,15 +7,12 @@ trait Arrow[F[_, _]] extends Split[F] with Strong[F] with Category[F] { self =>
 
   def lift[A, B](f: A => B): F[A, B]
 
-  def lmap[A, B, C](fab: F[A, B])(f: C => A): F[C, B] =
-    andThen(lift(f), fab)
-
-  def rmap[A, B, C](fab: F[A, B])(f: B => C): F[A, C] =
-    compose(lift(f), fab)
+  def dimap[A, B, C, D](fab: F[A, B])(f: C => A)(g: B => D): F[C, D] =
+    compose(lift(g), andThen(lift(f), fab))
 
   def second[A, B, C](fa: F[A, B]): F[(C, A), (C, B)] = {
     def swap[X, Y] = lift[(X, Y), (Y, X)] { case (x, y) => (y, x) }
-    compose(swap, (compose(first[A, B, C](fa), swap)))
+    compose(swap, compose(first[A, B, C](fa), swap))
   }
 }
 

--- a/core/src/main/scala/cats/functor/Profunctor.scala
+++ b/core/src/main/scala/cats/functor/Profunctor.scala
@@ -1,34 +1,28 @@
 package cats
 package functor
 
+/**
+ * A [[Profunctor]] is a [[Contravariant]] functor on its first type parameter
+ * and a [[Functor]] on its second type parameter.
+ */
 trait Profunctor[F[_, _]] { self =>
+  /**
+   * contramap on the first type parameter
+   */
   def lmap[A, B, C](fab: F[A, B])(f: C => A): F[C, B]
+
+  /**
+   * map on the second type parameter
+   */
   def rmap[A, B, C](fab: F[A, B])(f: B => C): F[A, C]
+
+  /**
+   * contramap on the first type parameter and map on the second type parameter
+   */
   def dimap[A, B, C, D](fab: F[A, B])(f: C => A)(g: B => D): F[C, D] = rmap(lmap(fab)(f))(g)
 }
 
 
 object Profunctor {
-
   def apply[F[_, _]](implicit ev: Profunctor[F]): Profunctor[F] = ev
-
-  case class UpStar[F[_]: Functor, A, B](f: A => F[B])
-
-  case class DownStar[F[_]: Functor, A, B](f: F[A] => B)
-
-  def upStar[F[_]: Functor]: Profunctor[UpStar[F, ?, ?]] =
-    new Profunctor[UpStar[F, ?, ?]] {
-      def lmap[A, B, C](fab: UpStar[F, A, B])(f: C => A): UpStar[F, C, B] =
-        UpStar(fab.f compose f)
-      def rmap[A, B, C](fab: UpStar[F, A, B])(f: B => C): UpStar[F, A, C] =
-        UpStar(a => Functor[F].map(fab.f(a))(f))
-    }
-
-  def downStar[F[_]: Functor]: Profunctor[DownStar[F, ?, ?]] =
-    new Profunctor[DownStar[F, ?, ?]] {
-      def lmap[A, B, C](fab: DownStar[F, A, B])(f: C => A): DownStar[F, C, B] =
-        DownStar(fc => fab.f(Functor[F].map(fc)(f)))
-      def rmap[A, B, C](fab: DownStar[F, A, B])(f: B => C): DownStar[F, A, C] =
-        DownStar(f compose fab.f)
-    }
 }

--- a/core/src/main/scala/cats/functor/Profunctor.scala
+++ b/core/src/main/scala/cats/functor/Profunctor.scala
@@ -7,19 +7,21 @@ package functor
  */
 trait Profunctor[F[_, _]] { self =>
   /**
+   * contramap on the first type parameter and map on the second type parameter
+   */
+  def dimap[A, B, C, D](fab: F[A, B])(f: C => A)(g: B => D): F[C, D]
+
+  /**
    * contramap on the first type parameter
    */
-  def lmap[A, B, C](fab: F[A, B])(f: C => A): F[C, B]
+  def lmap[A, B, C](fab: F[A, B])(f: C => A): F[C, B] =
+    dimap(fab)(f)(identity)
 
   /**
    * map on the second type parameter
    */
-  def rmap[A, B, C](fab: F[A, B])(f: B => C): F[A, C]
-
-  /**
-   * contramap on the first type parameter and map on the second type parameter
-   */
-  def dimap[A, B, C, D](fab: F[A, B])(f: C => A)(g: B => D): F[C, D] = rmap(lmap(fab)(f))(g)
+  def rmap[A, B, C](fab: F[A, B])(f: B => C): F[A, C] =
+    dimap[A, B, A, C](fab)(identity)(f)
 }
 
 


### PR DESCRIPTION
what do you think about using dimap as a single abstract method instead of lmap and rmap?
Anyway if you want an efficient implementation you need to override all of them and if you don't care, you only need to implement one method