### PR TITLE
Add applicative composition law

### DIFF
--- a/core/src/main/scala/cats/Applicative.scala
+++ b/core/src/main/scala/cats/Applicative.scala
@@ -15,6 +15,7 @@ import simulacrum._
  *  - apply(pure(a))(pure(f)) = pure(f(a))
  *  - apply(pure(a))(ff) = apply(ff)(pure(f => f(a)))
  *  - map(fa)(f) = apply(fa)(pure(f))
+ *  - apply(fa)(apply(fab)(apply(fbc)(pure(compose)))) = apply(apply(fa)(fab))(fbc)
  */
 trait Applicative[F[_]] extends Apply[F] { self =>
   /**


### PR DESCRIPTION
Given on the [Haskell wiki](http://en.wikibooks.org/wiki/Haskell/Applicative_Functors) as `pure (.) <*> u <*> v <*> w = u <*> (v <*> w)`.

I think I have this right since it compiles and tests pass, but please review carefully - I want to make sure I didn't mess anything up.

Also this law is notably missing from scalaz, which makes me wonder if there is a good reason for that.