### PR TITLE
Decouple laws from discipline test code

### DIFF
--- a/core/src/main/scala/cats/Applicative.scala
+++ b/core/src/main/scala/cats/Applicative.scala
@@ -10,12 +10,7 @@ import simulacrum._
  * See: [[https://www.cs.ox.ac.uk/jeremy.gibbons/publications/iterator.pdf The Essence of the Iterator Pattern]]
  * Also: [[http://staff.city.ac.uk/~ross/papers/Applicative.pdf Applicative programming with effects]]
  *
- * Must obey the following laws:
- *  - apply(fa)(pure(a => a)) = fa
- *  - apply(pure(a))(pure(f)) = pure(f(a))
- *  - apply(pure(a))(ff) = apply(ff)(pure(f => f(a)))
- *  - map(fa)(f) = apply(fa)(pure(f))
- *  - apply(fa)(apply(fab)(apply(fbc)(pure(compose)))) = apply(apply(fa)(fab))(fbc)
+ * Must obey the laws defined in [[laws.ApplicativeLaws]].
  */
 trait Applicative[F[_]] extends Apply[F] { self =>
   /**

--- a/core/src/main/scala/cats/Apply.scala
+++ b/core/src/main/scala/cats/Apply.scala
@@ -5,8 +5,7 @@ import simulacrum._
 /**
  * Weaker version of Applicative[F]; has apply but not pure.
  *
- * Laws:
- *  - apply(apply(fa)(fab))(fbc) = apply(fa)(apply(fab)(map(fbc)(bc => ab => ab andThen bc)))
+ * Must obey the laws defined in [[laws.ApplyLaws]].
  */
 trait Apply[F[_]] extends Functor[F] with ApplyArityFunctions[F] { self =>
 

--- a/core/src/main/scala/cats/CoFlatMap.scala
+++ b/core/src/main/scala/cats/CoFlatMap.scala
@@ -2,6 +2,9 @@ package cats
 
 import simulacrum._
 
+/**
+ * Must obey the laws defined in [[laws.CoFlatMapLaws]].
+ */
 @typeclass trait CoFlatMap[F[_]] extends Functor[F] {
   def coflatMap[A, B](fa: F[A])(f: F[A] => B): F[B]
 

--- a/core/src/main/scala/cats/Comonad.scala
+++ b/core/src/main/scala/cats/Comonad.scala
@@ -2,6 +2,9 @@ package cats
 
 import simulacrum._
 
+/**
+ * Must obey the laws defined in [[laws.ComonadLaws]].
+ */
 @typeclass trait Comonad[F[_]] extends CoFlatMap[F] {
   def extract[A](x: F[A]): A
 }

--- a/core/src/main/scala/cats/Functor.scala
+++ b/core/src/main/scala/cats/Functor.scala
@@ -7,9 +7,7 @@ import simulacrum._
  *
  * The name is short for "covariant functor".
  *
- * Must obey the following laws:
- *  - map(fa)(identity) = fa
- *  - map(map(fa)(f1))(f2) = map(fa)(f2 compose f1)
+ * Must obey the laws defined in [[laws.FunctorLaws]].
  */
 @typeclass trait Functor[F[_]] extends functor.Invariant[F] { self =>
   def map[A, B](fa: F[A])(f: A => B): F[B]

--- a/core/src/main/scala/cats/functor/Invariant.scala
+++ b/core/src/main/scala/cats/functor/Invariant.scala
@@ -3,6 +3,9 @@ package functor
 
 import simulacrum._
 
+/**
+ * Must obey the laws defined in [[laws.InvariantLaws]].
+ */
 @typeclass trait Invariant[F[_]] extends Any {
   def imap[A, B](fa: F[A])(f: A => B)(fi: B => A): F[B]
 }

--- a/laws/src/main/scala/cats/laws/ApplicativeLaws.scala
+++ b/laws/src/main/scala/cats/laws/ApplicativeLaws.scala
@@ -1,0 +1,32 @@
+package cats.laws
+
+import cats.Applicative
+import cats.syntax.apply._
+import cats.syntax.functor._
+
+/**
+ * Laws that must be obeyed by any [[Applicative]].
+ */
+class ApplicativeLaws[F[_]](implicit F: Applicative[F]) extends ApplyLaws[F] {
+  def applicativeIdentity[A](fa: F[A]): (F[A], F[A]) =
+    fa.apply(F.pure((a: A) => a)) -> fa
+
+  def applicativeHomomorphism[A, B](a: A, f: A => B): (F[B], F[B]) =
+    F.pure(a).apply(F.pure(f)) -> F.pure(f(a))
+
+  def applicativeInterchange[A, B](a: A, ff: F[A => B]): (F[B], F[B]) =
+    F.pure(a).apply(ff) -> ff.apply(F.pure(f => f(a)))
+
+  def applicativeMap[A, B](fa: F[A], f: A => B): (F[B], F[B]) =
+    fa.map(f) -> fa.apply(F.pure(f))
+
+  /**
+   * This law is [[applyComposition]] stated in terms of [[Applicative.pure]].
+   * It is a combination of [[applyComposition]] and [[applicativeMap]] and
+   * hence not strictly necessary.
+   */
+  def applicativeComposition[A, B, C](fa: F[A], fab: F[A => B], fbc: F[B => C]) = {
+    val compose: (B => C) => (A => B) => (A => C) = _.compose
+    fa.apply(fab.apply(fbc.apply(F.pure(compose)))) -> fa.apply(fab).apply(fbc)
+  }
+}

--- a/laws/src/main/scala/cats/laws/ApplicativeLaws.scala
+++ b/laws/src/main/scala/cats/laws/ApplicativeLaws.scala
@@ -25,7 +25,7 @@ class ApplicativeLaws[F[_]](implicit F: Applicative[F]) extends ApplyLaws[F] {
    * It is a combination of [[applyComposition]] and [[applicativeMap]] and
    * hence not strictly necessary.
    */
-  def applicativeComposition[A, B, C](fa: F[A], fab: F[A => B], fbc: F[B => C]) = {
+  def applicativeComposition[A, B, C](fa: F[A], fab: F[A => B], fbc: F[B => C]): (F[C], F[C]) = {
     val compose: (B => C) => (A => B) => (A => C) = _.compose
     fa.apply(fab.apply(fbc.apply(F.pure(compose)))) -> fa.apply(fab).apply(fbc)
   }

--- a/laws/src/main/scala/cats/laws/ApplyLaws.scala
+++ b/laws/src/main/scala/cats/laws/ApplyLaws.scala
@@ -1,0 +1,15 @@
+package cats.laws
+
+import cats.Apply
+import cats.syntax.apply._
+import cats.syntax.functor._
+
+/**
+ * Laws that must be obeyed by any [[Apply]].
+ */
+class ApplyLaws[F[_]](implicit F: Apply[F]) extends FunctorLaws[F] {
+  def applyComposition[A, B, C](fa: F[A], fab: F[A => B], fbc: F[B => C]): (F[C], F[C]) = {
+    val compose: (B => C) => (A => B) => (A => C) = _.compose
+    fa.apply(fab).apply(fbc) -> fa.apply(fab.apply(fbc.map(compose)))
+  }
+}

--- a/laws/src/main/scala/cats/laws/CoFlatMapLaws.scala
+++ b/laws/src/main/scala/cats/laws/CoFlatMapLaws.scala
@@ -1,0 +1,22 @@
+package cats.laws
+
+import cats.CoFlatMap
+import cats.arrow.Cokleisli
+import cats.syntax.coflatMap._
+
+/**
+ * Laws that must be obeyed by any [[CoFlatMap]].
+ */
+class CoFlatMapLaws[F[_]](implicit F: CoFlatMap[F]) extends FunctorLaws[F] {
+  def coFlatMapAssociativity[A, B, C](fa: F[A], f: F[A] => B, g: F[B] => C): (F[C], F[C]) =
+    fa.coflatMap(f).coflatMap(g) -> fa.coflatMap(x => g(x.coflatMap(f)))
+
+  /**
+   * The composition of [[cats.arrow.Cokleisli]] arrows is associative. This is
+   * analogous to the associativity law of [[CoFlatMap.coflatMap]].
+   */
+  def cokleisliAssociativity[A, B, C, D](f: F[A] => B, g: F[B] => C, h: F[C] => D, fa: F[A]): (D, D) = {
+    val (cf, cg, ch) = (Cokleisli(f), Cokleisli(g), Cokleisli(h))
+    (cf compose (cg compose ch)).run(fa) -> ((cf compose cg) compose ch).run(fa)
+  }
+}

--- a/laws/src/main/scala/cats/laws/ComonadLaws.scala
+++ b/laws/src/main/scala/cats/laws/ComonadLaws.scala
@@ -1,59 +1,16 @@
 package cats.laws
 
-import algebra.laws._
+import cats.Comonad
+import cats.syntax.coflatMap._
+import cats.syntax.comonad._
 
-import org.scalacheck.{Arbitrary, Prop}
-import org.scalacheck.Prop._
-import org.typelevel.discipline.Laws
+/**
+ * Laws that must be obeyed by any [[Comonad]].
+ */
+class ComonadLaws[F[_]](implicit F: Comonad[F]) extends CoFlatMapLaws[F] {
+  def comonadLeftIdentity[A](fa: F[A]): (F[A], F[A]) =
+    fa.coflatMap(_.extract) -> fa
 
-import cats._
-
-object ComonadLaws {
-  def apply[F[_]: ArbitraryK, A: Arbitrary, B: Arbitrary](implicit eqfa: Eq[F[A]]): ComonadLaws[F, A, B] =
-    new ComonadLaws[F, A, B] {
-      def EqFA = eqfa
-      def ArbA = implicitly[Arbitrary[A]]
-      def ArbB = implicitly[Arbitrary[B]]
-      def ArbF = implicitly[ArbitraryK[F]]
-    }
-}
-
-trait ComonadLaws[F[_], A, B] extends Laws {
-
-  implicit def EqFA: Eq[F[A]]
-  def ArbF: ArbitraryK[F]
-  implicit def ArbA: Arbitrary[A]
-  implicit def ArbB: Arbitrary[B]
-  implicit def ArbFA: Arbitrary[F[A]] = ArbF.synthesize[A](ArbA)
-  implicit def ArbFB: Arbitrary[F[B]] = ArbF.synthesize[B](ArbB)
-
-  def coflatmap[C: Arbitrary](implicit F: CoFlatMap[F], FC: Eq[F[C]]) =
-    new ComonadProperties(
-      name = "coflatmap",
-      parents = Nil,
-      "associativity" -> forAll { (fa: F[A], f: F[A] => B, g: F[B] => C) =>
-        F.coflatMap(F.coflatMap(fa)(f))(g) ?==
-          F.coflatMap(fa)(x => g(F.coflatMap(x)(f)))
-      }
-    )
-
-  def comonad[C: Arbitrary](implicit F: Comonad[F], FC: Eq[F[C]], B: Eq[B]) =
-    new ComonadProperties(
-      name = "comonad",
-      parents = Seq(coflatmap[C]),
-      "left identity" -> forAll { (fa: F[A]) =>
-        F.coflatMap(fa)(F.extract) ?== fa
-      },
-      "right identity" -> forAll { (fa: F[A], f: F[A] => B) =>
-        F.extract(F.coflatMap(fa)(f)) ?== f(fa)
-      }
-    )
-
-  class ComonadProperties(
-    val name: String,
-    val parents: Seq[ComonadProperties],
-    val props: (String, Prop)*
-  ) extends RuleSet {
-    val bases = Nil
-  }
+  def comonadRightIdentity[A, B](fa: F[A], f: F[A] => B): (B, B) =
+    fa.coflatMap(f).extract -> f(fa)
 }

--- a/laws/src/main/scala/cats/laws/FunctorLaws.scala
+++ b/laws/src/main/scala/cats/laws/FunctorLaws.scala
@@ -1,105 +1,15 @@
 package cats.laws
 
-import algebra.laws._
+import cats.Functor
+import cats.syntax.functor._
 
-import org.typelevel.discipline.Laws
-import org.scalacheck.{Arbitrary, Prop}
-import org.scalacheck.Prop._
+/**
+ * Laws that must be obeyed by any [[Functor]].
+ */
+class FunctorLaws[F[_]](implicit F: Functor[F]) extends InvariantLaws[F] {
+  def covariantIdentity[A](fa: F[A]): (F[A], F[A]) =
+    fa.map(identity) -> fa
 
-import cats._
-import cats.functor._
-
-object FunctorLaws {
-  def apply[F[_]: ArbitraryK, A: Arbitrary](implicit eqfa: Eq[F[A]]): FunctorLaws[F, A] =
-    new FunctorLaws[F, A] {
-      def EqFA = eqfa
-      def ArbA = implicitly[Arbitrary[A]]
-      def ArbF = implicitly[ArbitraryK[F]]
-    }
-}
-
-trait FunctorLaws[F[_], A] extends Laws {
-
-  implicit def EqFA: Eq[F[A]]
-  def ArbF: ArbitraryK[F]
-  implicit def ArbA: Arbitrary[A]
-  implicit def ArbFA: Arbitrary[F[A]] = ArbF.synthesize[A](ArbA)
-
-  def invariant[B: Arbitrary, C: Arbitrary](implicit F: Invariant[F], FC: Eq[F[C]]) =
-    new FunctorProperties(
-      name = "functor",
-      parents = Nil,
-      "invariant identity" -> forAll { (fa: F[A]) =>
-        F.imap(fa)(identity[A])(identity[A]) ?== fa
-      },
-      "invariant composition" -> forAll { (fa: F[A], f1: A => B, f2: B => A, g1: B => C, g2: C => B) =>
-        F.imap(F.imap(fa)(f1)(f2))(g1)(g2) ?== F.imap(fa)(f1 andThen g1)(g2 andThen f2)
-      })
-
-  def covariant[B: Arbitrary, C: Arbitrary](implicit F: Functor[F], FC: Eq[F[C]]) =
-    new FunctorProperties(
-      name = "functor",
-      parents = Seq(invariant[B, C]),
-      "covariant identity" -> forAll { (fa: F[A]) =>
-        F.map(fa)(identity) ?== fa
-      },
-      "covariant composition" -> forAll { (fa: F[A], f: A => B, g: B => C) =>
-        F.map(F.map(fa)(f))(g) ?== F.map(fa)(f andThen g)
-      })
-
-  def apply[B: Arbitrary, C: Arbitrary](implicit F: Apply[F], FC: Eq[F[C]]) = {
-    implicit val ArbFAB: Arbitrary[F[A => B]] = ArbF.synthesize[A => B]
-    implicit val ArbFBC: Arbitrary[F[B => C]] = ArbF.synthesize[B => C]
-    new FunctorProperties(
-      name = "apply",
-      parents = Seq(covariant[B, C]),
-      "apply composition" -> forAll { (fa: F[A], fab: F[A => B], fbc: F[B => C]) =>
-        try {
-          val lhs = F.apply(F.apply(fa)(fab))(fbc)
-          val rhs = F.apply(fa)(F.apply(fab)(F.map(fbc) { (bc: B => C) =>
-            (ab: A => B) => ab andThen bc
-          }))
-          lhs ?== rhs
-        } catch { case (e: StackOverflowError) =>
-            e.printStackTrace
-            throw e
-        }
-      })
-  }
-
-  def applicative[B: Arbitrary, C: Arbitrary](implicit F: Applicative[F], FC: Eq[F[C]]) = {
-    implicit val ArbFAC: Arbitrary[F[A => C]] = ArbF.synthesize[A => C]
-    implicit val ArbFAB: Arbitrary[F[A => B]] = ArbF.synthesize[A => B]
-    implicit val ArbFBC: Arbitrary[F[B => C]] = ArbF.synthesize[B => C]
-    new FunctorProperties(
-      name = "applicative",
-      parents = Seq(apply[B, C]),
-      "applicative identity" -> forAll { (fa: F[A]) =>
-        F.apply(fa)(F.pure((a: A) => a)) ?== fa
-      },
-      "applicative homomorphism" -> forAll { (a: A, f: A => C) =>
-        F.apply(F.pure(a))(F.pure(f)) ?== F.pure(f(a))
-      },
-      "applicative interchange" -> forAll { (a: A, ff: F[A => C]) =>
-        F.apply(F.pure(a))(ff) ?== F.apply(ff)(F.pure(f => f(a)))
-      },
-      "applicative map" -> forAll { (fa: F[A], f: A => C) =>
-        F.map(fa)(f) ?== F.apply(fa)(F.pure(f))
-      },
-      "applicative composition" -> forAll { (fa: F[A], fab: F[A => B], fbc: F[B => C]) =>
-        // helping out type inference
-        val compose: (B => C) => (A => B) => (A => C) = _.compose
-
-        F.apply(fa)(F.apply(fab)(F.apply(fbc)(F.pure(compose)))) ?==
-          F.apply((F.apply(fa)(fab)))(fbc)
-      })
-    }
-
-  class FunctorProperties(
-    val name: String,
-    val parents: Seq[FunctorProperties],
-    val props: (String, Prop)*
-  ) extends RuleSet {
-    val bases = Nil
-  }
+  def covariantComposition[A, B, C](fa: F[A], f: A => B, g: B => C): (F[C], F[C]) =
+    fa.map(f).map(g) -> fa.map(f andThen g)
 }

--- a/laws/src/main/scala/cats/laws/InvariantLaws.scala
+++ b/laws/src/main/scala/cats/laws/InvariantLaws.scala
@@ -1,0 +1,15 @@
+package cats.laws
+
+import cats.functor.Invariant
+import cats.syntax.invariant._
+
+/**
+ * Laws that must be obeyed by any [[cats.functor.Invariant]].
+ */
+class InvariantLaws[F[_]](implicit F: Invariant[F]) {
+  def invariantIdentity[A](fa: F[A]): (F[A], F[A]) =
+    fa.imap(identity[A])(identity[A]) -> fa
+
+  def invariantComposition[A, B, C](fa: F[A], f1: A => B, f2: B => A, g1: B => C, g2: C => B): (F[C], F[C]) =
+    fa.imap(f1)(f2).imap(g1)(g2) -> fa.imap(f1 andThen g1)(g2 andThen f2)
+}

--- a/laws/src/main/scala/cats/laws/discipline/Arbitrary.scala
+++ b/laws/src/main/scala/cats/laws/discipline/Arbitrary.scala
@@ -1,7 +1,7 @@
-package cats.laws
+package cats.laws.discipline
 
 import cats.data.{Or, Const}
-import org.scalacheck.{Gen, Arbitrary}
+import org.scalacheck.{Arbitrary, Gen}
 
 /**
  * Arbitrary instances for cats.data

--- a/laws/src/main/scala/cats/laws/discipline/ArbitraryK.scala
+++ b/laws/src/main/scala/cats/laws/discipline/ArbitraryK.scala
@@ -1,8 +1,8 @@
-package cats.laws
+package cats.laws.discipline
 
 import cats.data.{Or, Const}
 import org.scalacheck.Arbitrary
-import cats.laws.arbitrary._
+import cats.laws.discipline.arbitrary._
 
 trait ArbitraryK[F[_]] {
   def synthesize[A: Arbitrary]: Arbitrary[F[A]]

--- a/laws/src/main/scala/cats/laws/discipline/ComonadTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/ComonadTests.scala
@@ -1,0 +1,64 @@
+package cats.laws.discipline
+
+import algebra.laws._
+import cats._
+import cats.laws.{CoFlatMapLaws, ComonadLaws}
+import org.scalacheck.Prop._
+import org.scalacheck.{Arbitrary, Prop}
+import org.typelevel.discipline.Laws
+
+object ComonadTests {
+  def apply[F[_]: ArbitraryK, A: Arbitrary, B: Arbitrary](implicit eqfa: Eq[F[A]]): ComonadTests[F, A, B] =
+    new ComonadTests[F, A, B] {
+      def EqFA = eqfa
+      def ArbA = implicitly[Arbitrary[A]]
+      def ArbB = implicitly[Arbitrary[B]]
+      def ArbF = implicitly[ArbitraryK[F]]
+    }
+}
+
+trait ComonadTests[F[_], A, B] extends Laws {
+
+  implicit def EqFA: Eq[F[A]]
+  def ArbF: ArbitraryK[F]
+  implicit def ArbA: Arbitrary[A]
+  implicit def ArbB: Arbitrary[B]
+  implicit def ArbFA: Arbitrary[F[A]] = ArbF.synthesize[A](ArbA)
+  implicit def ArbFB: Arbitrary[F[B]] = ArbF.synthesize[B](ArbB)
+
+  def coflatmap[C: Arbitrary](implicit F: CoFlatMap[F], FC: Eq[F[C]]) = {
+    val laws = new CoFlatMapLaws[F]
+    new ComonadProperties(
+      name = "coflatmap",
+      parents = Nil,
+      "associativity" -> forAll { (fa: F[A], f: F[A] => B, g: F[B] => C) =>
+        val (lhs, rhs) = laws.coFlatMapAssociativity(fa, f, g)
+        lhs ?== rhs
+      }
+    )
+  }
+
+  def comonad[C: Arbitrary](implicit F: Comonad[F], FC: Eq[F[C]], B: Eq[B]) = {
+    val laws = new ComonadLaws[F]
+    new ComonadProperties(
+      name = "comonad",
+      parents = Seq(coflatmap[C]),
+      "left identity" -> forAll { (fa: F[A]) =>
+        val (lhs, rhs) = laws.comonadLeftIdentity(fa)
+        lhs ?== rhs
+      },
+      "right identity" -> forAll { (fa: F[A], f: F[A] => B) =>
+        val (lhs, rhs) = laws.comonadRightIdentity(fa, f)
+        lhs ?== rhs
+      }
+    )
+  }
+
+  class ComonadProperties(
+    val name: String,
+    val parents: Seq[ComonadProperties],
+    val props: (String, Prop)*
+  ) extends RuleSet {
+    val bases = Nil
+  }
+}

--- a/laws/src/main/scala/cats/laws/discipline/FunctorTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/FunctorTests.scala
@@ -1,0 +1,112 @@
+package cats.laws.discipline
+
+import algebra.laws._
+import cats._
+import cats.functor._
+import cats.laws.{ApplicativeLaws, ApplyLaws, FunctorLaws, InvariantLaws}
+import org.scalacheck.Prop._
+import org.scalacheck.{Arbitrary, Prop}
+import org.typelevel.discipline.Laws
+
+object FunctorTests {
+  def apply[F[_]: ArbitraryK, A: Arbitrary](implicit eqfa: Eq[F[A]]): FunctorTests[F, A] =
+    new FunctorTests[F, A] {
+      def EqFA = eqfa
+      def ArbA = implicitly[Arbitrary[A]]
+      def ArbF = implicitly[ArbitraryK[F]]
+    }
+}
+
+trait FunctorTests[F[_], A] extends Laws {
+
+  implicit def EqFA: Eq[F[A]]
+  def ArbF: ArbitraryK[F]
+  implicit def ArbA: Arbitrary[A]
+  implicit def ArbFA: Arbitrary[F[A]] = ArbF.synthesize[A](ArbA)
+
+  def invariant[B: Arbitrary, C: Arbitrary](implicit F: Invariant[F], FC: Eq[F[C]]) = {
+    val laws = new InvariantLaws[F]
+    new FunctorProperties(
+      name = "functor",
+      parents = Nil,
+      "invariant identity" -> forAll { (fa: F[A]) =>
+        val (lhs, rhs) = laws.invariantIdentity(fa)
+        lhs ?== rhs
+      },
+      "invariant composition" -> forAll { (fa: F[A], f1: A => B, f2: B => A, g1: B => C, g2: C => B) =>
+        val (lhs, rhs) = laws.invariantComposition(fa, f1, f2, g1, g2)
+        lhs ?== rhs
+      })
+  }
+
+  def covariant[B: Arbitrary, C: Arbitrary](implicit F: Functor[F], FC: Eq[F[C]]) = {
+    val laws = new FunctorLaws[F]
+    new FunctorProperties(
+      name = "functor",
+      parents = Seq(invariant[B, C]),
+      "covariant identity" -> forAll { (fa: F[A]) =>
+        val (lhs, rhs) = laws.covariantIdentity(fa)
+        lhs ?== rhs
+      },
+      "covariant composition" -> forAll { (fa: F[A], f: A => B, g: B => C) =>
+        val (lhs, rhs) = laws.covariantComposition(fa, f, g)
+        lhs ?== rhs
+      })
+  }
+
+  def apply[B: Arbitrary, C: Arbitrary](implicit F: Apply[F], FC: Eq[F[C]]) = {
+    implicit val ArbFAB: Arbitrary[F[A => B]] = ArbF.synthesize[A => B]
+    implicit val ArbFBC: Arbitrary[F[B => C]] = ArbF.synthesize[B => C]
+    val laws = new ApplyLaws[F]
+    new FunctorProperties(
+      name = "apply",
+      parents = Seq(covariant[B, C]),
+      "apply composition" -> forAll { (fa: F[A], fab: F[A => B], fbc: F[B => C]) =>
+        try {
+          val (lhs, rhs) = laws.applyComposition(fa, fab, fbc)
+          lhs ?== rhs
+        } catch { case (e: StackOverflowError) =>
+            e.printStackTrace
+            throw e
+        }
+      })
+  }
+
+  def applicative[B: Arbitrary, C: Arbitrary](implicit F: Applicative[F], FC: Eq[F[C]]) = {
+    implicit val ArbFAC: Arbitrary[F[A => C]] = ArbF.synthesize[A => C]
+    implicit val ArbFAB: Arbitrary[F[A => B]] = ArbF.synthesize[A => B]
+    implicit val ArbFBC: Arbitrary[F[B => C]] = ArbF.synthesize[B => C]
+    val laws = new ApplicativeLaws[F]
+    new FunctorProperties(
+      name = "applicative",
+      parents = Seq(apply[B, C]),
+      "applicative identity" -> forAll { (fa: F[A]) =>
+        val (lhs, rhs) = laws.applicativeIdentity(fa)
+        lhs ?== rhs
+      },
+      "applicative homomorphism" -> forAll { (a: A, f: A => C) =>
+        val (lhs, rhs) = laws.applicativeHomomorphism(a, f)
+        lhs ?== rhs
+      },
+      "applicative interchange" -> forAll { (a: A, ff: F[A => C]) =>
+        val (lhs, rhs) = laws.applicativeInterchange(a, ff)
+        lhs ?== rhs
+      },
+      "applicative map" -> forAll { (fa: F[A], f: A => C) =>
+        val (lhs, rhs) = laws.applicativeMap(fa, f)
+        lhs ?== rhs
+      },
+      "applicative composition" -> forAll { (fa: F[A], fab: F[A => B], fbc: F[B => C]) =>
+        val (lhs, rhs) = laws.applicativeComposition(fa, fab, fbc)
+        lhs ?== rhs
+      })
+    }
+
+  class FunctorProperties(
+    val name: String,
+    val parents: Seq[FunctorProperties],
+    val props: (String, Prop)*
+  ) extends RuleSet {
+    val bases = Nil
+  }
+}

--- a/tests/src/test/scala/cats/tests/ConstTests.scala
+++ b/tests/src/test/scala/cats/tests/ConstTests.scala
@@ -1,13 +1,13 @@
 package cats.tests
 
 import cats.data.Const
-import cats.laws.FunctorLaws
+import cats.laws.discipline.FunctorTests
 import org.scalatest.FunSuite
 import org.typelevel.discipline.scalatest.Discipline
 import algebra.std.string._
 
 class ConstTests extends FunSuite with Discipline {
 
-  checkAll("Const[String, Int]", FunctorLaws[Const[String, ?], Int].applicative[Int, Int])
+  checkAll("Const[String, Int]", FunctorTests[Const[String, ?], Int].applicative[Int, Int])
 
 }

--- a/tests/src/test/scala/cats/tests/OrTests.scala
+++ b/tests/src/test/scala/cats/tests/OrTests.scala
@@ -2,12 +2,12 @@ package cats.tests
 
 import algebra.std.int._
 import algebra.std.string._
+import cats.laws.discipline.FunctorTests
 import org.scalatest.FunSuite
 import org.typelevel.discipline.scalatest.Discipline
 
 import cats.data.Or
-import cats.laws.FunctorLaws
 
 class OrTests extends FunSuite with Discipline {
-  checkAll("Or[String, Int]", FunctorLaws[String Or ?, Int].applicative[Int, Int])
+  checkAll("Or[String, Int]", FunctorTests[String Or ?, Int].applicative[Int, Int])
 }

--- a/tests/src/test/scala/cats/tests/StdTests.scala
+++ b/tests/src/test/scala/cats/tests/StdTests.scala
@@ -1,7 +1,8 @@
 package cats.tests
 
 import algebra.laws._
-import cats.laws.{ComonadLaws, FunctorLaws}
+import cats.laws.discipline.FunctorTests$
+import cats.laws.discipline.{ComonadTests, FunctorTests}
 import org.typelevel.discipline.scalatest.Discipline
 import org.scalatest.FunSuite
 
@@ -14,9 +15,9 @@ import cats.std.list._
 import cats.std.option._
 
 class StdTests extends FunSuite with Discipline {
-  checkAll("Function0[Int]", FunctorLaws[Function0, Int].applicative[Int, Int])
-  checkAll("Function0[Int]", ComonadLaws[Function0, Int, Int].comonad[Int])
-  checkAll("Option[Int]", FunctorLaws[Option, Int].applicative[Int, Int])
-  checkAll("Option[String]", FunctorLaws[Option, String].applicative[Int, Int])
-  checkAll("List[Int]", FunctorLaws[List, Int].applicative[Int, Int])
+  checkAll("Function0[Int]", FunctorTests[Function0, Int].applicative[Int, Int])
+  checkAll("Function0[Int]", ComonadTests[Function0, Int, Int].comonad[Int])
+  checkAll("Option[Int]", FunctorTests[Option, Int].applicative[Int, Int])
+  checkAll("Option[String]", FunctorTests[Option, String].applicative[Int, Int])
+  checkAll("List[Int]", FunctorTests[List, Int].applicative[Int, Int])
 }


### PR DESCRIPTION
This PR decouples the laws from the test code by adding a dedicated `Laws` class in the `cats.laws` package for each typeclass. The laws are stated such that they return a pair of values of the same type which will be equal for lawfull instances. The intention for this PR is to make the laws more visible by putting them in their own classes and by decoupling them from the test framework. See #81 for more details.

fixes #81