### PR TITLE
List's traverse method was applying effects in reverse.

### DIFF
--- a/std/src/main/scala/cats/std/list.scala
+++ b/std/src/main/scala/cats/std/list.scala
@@ -53,9 +53,11 @@ trait ListInstances {
 
       def traverse[G[_]: Applicative, A, B](fa: List[A])(f: A => G[B]): G[List[B]] = {
         val G = Applicative[G]
-        val gba = G.pure(ListBuffer.empty[B])
-        val gbb = fa.foldLeft(gba)((buf, a) => G.map2(buf, f(a))(_ += _))
-        G.map(gbb)(_.toList)
+        val init = G.pure(ListBuffer.empty[B])
+        val gbuf = fa.foldLeft(init) { (gbuf, a) =>
+          G.map2(f(a), gbuf)((b, buf) => buf += b)
+        }
+        G.map(gbuf)(_.toList)
       }
     }
 

--- a/tests/src/test/scala/cats/tests/RegressionTests.scala
+++ b/tests/src/test/scala/cats/tests/RegressionTests.scala
@@ -1,0 +1,41 @@
+package cats.tests
+
+import cats._
+import cats.implicits._
+import org.scalatest.FunSuite
+
+class RegressionTests extends FunSuite {
+
+  // test sequence order using a contrived, unsafe state monad.
+  // 
+
+  test("#140: confirm sequence order") {
+    val allocated = List("Alice", "Bob", "Claire").map(alloc)
+    val state = Traverse[List].sequence[State[Int, ?],Person](allocated)
+    val (people, counter) = state.run(0)
+    assert(people == List(Person(0, "Alice"), Person(1, "Bob"), Person(2, "Claire")))
+    assert(counter == 3)
+  }
+
+  case class Person(id: Int, name: String)
+
+  def alloc(name: String): State[Int, Person] =
+    State(id => (Person(id, name), id + 1))
+
+  // toy state class
+  // not stack safe, very minimal, not for actual use
+
+  case class State[S, A](run: S => (A, S)) { self =>
+    def map[B](f: A => B) =
+      State[S, B]({ s => val (a, s2) = self.run(s); (f(a), s2) })
+    def flatMap[B](f: A => State[S, B]) =
+      State[S, B]({ s => val (a, s2) = self.run(s); f(a).run(s2) })
+  }
+
+  object State {
+    implicit def instance[S] = new Monad[State[S, ?]] {
+      def pure[A](a: A) = State[S, A](s => (a, s))
+      def flatMap[A, B](sa: State[S, A])(f: A => State[S, B]) = sa.flatMap(f)
+    }
+  }
+}

--- a/tests/src/test/scala/cats/tests/RegressionTests.scala
+++ b/tests/src/test/scala/cats/tests/RegressionTests.scala
@@ -6,25 +6,8 @@ import org.scalatest.FunSuite
 
 class RegressionTests extends FunSuite {
 
-  // test sequence order using a contrived, unsafe state monad.
-  // 
-
-  test("#140: confirm sequence order") {
-    val allocated = List("Alice", "Bob", "Claire").map(alloc)
-    val state = Traverse[List].sequence[State[Int, ?],Person](allocated)
-    val (people, counter) = state.run(0)
-    assert(people == List(Person(0, "Alice"), Person(1, "Bob"), Person(2, "Claire")))
-    assert(counter == 3)
-  }
-
-  case class Person(id: Int, name: String)
-
-  def alloc(name: String): State[Int, Person] =
-    State(id => (Person(id, name), id + 1))
-
   // toy state class
   // not stack safe, very minimal, not for actual use
-
   case class State[S, A](run: S => (A, S)) { self =>
     def map[B](f: A => B) =
       State[S, B]({ s => val (a, s2) = self.run(s); (f(a), s2) })
@@ -37,5 +20,24 @@ class RegressionTests extends FunSuite {
       def pure[A](a: A) = State[S, A](s => (a, s))
       def flatMap[A, B](sa: State[S, A])(f: A => State[S, B]) = sa.flatMap(f)
     }
+  }
+
+  case class Person(id: Int, name: String)
+
+  def alloc(name: String): State[Int, Person] =
+    State(id => (Person(id, name), id + 1))
+
+  test("#140: confirm sequence order") {
+
+    // test result order
+    val ons = List(Option(1), Option(2), Option(3))
+    assert(Traverse[List].sequence(ons) == Some(List(1, 2, 3)))
+
+    // test order of effects using a contrived, unsafe state monad.
+    val allocated = List("Alice", "Bob", "Claire").map(alloc)
+    val state = Traverse[List].sequence[State[Int, ?],Person](allocated)
+    val (people, counter) = state.run(0)
+    assert(people == List(Person(0, "Alice"), Person(1, "Bob"), Person(2, "Claire")))
+    assert(counter == 3)
   }
 }


### PR DESCRIPTION
This commit fixes this issue (which had to do with passing
arguments to G.map2 in the wrong order) and adds a regression
test to be sure we don't accidentally mess this up in the
future.

Fixes #140 

Review by @refried et al.