### PR TITLE
Move cats.free.Free.Trampoline alias to cats.free package object

### DIFF
--- a/core/src/main/scala/cats/free/Free.scala
+++ b/core/src/main/scala/cats/free/Free.scala
@@ -24,10 +24,6 @@ object Free {
       val a = a0
       val f = f0
     }
-
-  type Trampoline[A] = Free[Function0, A]
-
-  type FreeC[S[_], A] = Free[Coyoneda[S, ?], A]
 }
 
 import Free._
@@ -118,13 +114,3 @@ sealed abstract class Free[S[_], A] {
     }
 }
 
-object Trampoline {
-  def done[A](a: A): Trampoline[A] =
-    Free.Pure[Function0,A](a)
-
-  def suspend[A](a: => Trampoline[A]): Trampoline[A] =
-    Free.Suspend[Function0, A](() => a)
-
-  def delay[A](a: => A): Trampoline[A] =
-    suspend(done(a))
-}

--- a/core/src/main/scala/cats/free/Trampoline.scala
+++ b/core/src/main/scala/cats/free/Trampoline.scala
@@ -1,0 +1,14 @@
+package cats
+package free
+
+object Trampoline {
+  def done[A](a: A): Trampoline[A] =
+    Free.Pure[Function0,A](a)
+
+  def suspend[A](a: => Trampoline[A]): Trampoline[A] =
+    Free.Suspend[Function0, A](() => a)
+
+  def delay[A](a: => A): Trampoline[A] =
+    suspend(done(a))
+}
+

--- a/core/src/main/scala/cats/free/package.scala
+++ b/core/src/main/scala/cats/free/package.scala
@@ -1,0 +1,9 @@
+package cats
+
+package object free {
+
+  /** Alias for the free monad over the `Function0` functor. */
+  type Trampoline[A] = Free[Function0, A]
+
+  type FreeC[S[_], A] = Free[Coyoneda[S, ?], A]
+}


### PR DESCRIPTION
Prior to this PR, in order to use `Trampoline`, you'd have to import the type alias from `cats.free.Free.Trampoline` and the object from `cats.free.Trampoline`. After this PR, 1 import serves both purposes.