### PR TITLE
Renamed lazy foldRight to foldLazy, and made it stack-safe.

### DIFF
--- a/core/src/main/scala/cats/Fold.scala
+++ b/core/src/main/scala/cats/Fold.scala
@@ -67,7 +67,7 @@ package cats
  *
  * {{{
  *    def foldl[A, B](as: List[A], b: B)(f: (B, A) => B): B =
- *      as.foldLazy(Lazy.byName((b: B) => b)) { a =>
+ *      as.foldLazy(Lazy((b: B) => b)) { a =>
  *        Fold.Continue(g => (b: B) => g(f(b, a)))
  *      }.force(b)
  * }}}

--- a/core/src/main/scala/cats/Fold.scala
+++ b/core/src/main/scala/cats/Fold.scala
@@ -6,8 +6,8 @@ package cats
  * It is a sum type that has three possible subtypes:
  *
  *   - `Return(a)`: stop the fold with a value of `a`.
- *   - `Continue(f)`: continue the fold, suspending the computation `f`.
- *   - `Pass`: continue the fold, with no additional computation.
+ *   - `Continue(f)`: continue the fold, suspending the computation `f` for this step.
+ *   - `Pass`: continue the fold, with no computation for this step.
  *
  * The meaning of these types can be made more clear with an example
  * of the foldLazy method in action. Here's a method to count how many

--- a/core/src/main/scala/cats/Fold.scala
+++ b/core/src/main/scala/cats/Fold.scala
@@ -111,9 +111,7 @@ object Fold {
       fs.foldLeft(b)((b, f) => f(b))
     def loop(it: Iterator[A], fs: List[B => B]): B =
       if (it.hasNext) {
-        val a: A = it.next
-        val fb: Fold[B] = f(it.next)
-        fb match {
+        f(it.next) match {
           case Return(b) => unroll(b, fs)
           case Continue(f) => loop(it, f :: fs)
           case _ => loop(it, fs)

--- a/core/src/main/scala/cats/Fold.scala
+++ b/core/src/main/scala/cats/Fold.scala
@@ -1,0 +1,124 @@
+package cats
+
+/**
+ * Fold is designed to allow laziness/short-circuiting in foldLazy.
+ * 
+ * It is a sum type that has three possible subtypes:
+ * 
+ *   - Return(a): stop the fold with a value of `a`.
+ *   - Continue(f): continue the fold, suspending the computation `f`.
+ *   - Pass: continue the fold, with no additional computation.
+ * 
+ * The meaning of these types can be made more clear with an example
+ * of the foldLazy method in action. Here's a method to count how many
+ * elements appear in a list before 3:
+ * 
+ *     def f(n: Int): Fold[Int] =
+ *       if (n == 3) Fold.Return (0) else Fold.Continue(_ + 1)
+ * 
+ *     val count: Lazy[Int] = List(1,2,3,4).foldLazy(Lazy(0))(f)
+ * 
+ * When we call `count.force`, the following occurs:
+ * 
+ *  - f(1) produces res0: Continue(_ + 1)
+ *  - f(2) produces res1: Continue(_ + 1)
+ *  - f(3) produces res2: Return(0)
+ * 
+ * Now we unwind back through the continue instances:
+ * 
+ *  - res2 produces 0
+ *  - res1(0) produces 1
+ *  - res0(1) produces 2
+ * 
+ * And so the result is 2.
+ * 
+ * This code searches an infinite stream for 77:
+ * 
+ *    val found: Lazy[Boolean] =
+ *      Stream.from(0).foldLazy(Lazy(false)) { n =>
+ *        if (n == 77) Fold.Return(true) else Fold.Pass
+ *      }
+ * 
+ * Here's another example that sums the list until it reaches a
+ * negative number:
+ * 
+ *    val sum: Lazy[Double] =
+ *      numbers.foldLazy(Lazy(0.0)) { n =>
+ *        if (n < 0) Fold.Return(0.0) else Fold.Continue(n + _)
+ *      }
+ * 
+ * This strange example counts an infinite stream. Since the result is
+ * lazy, it will only hang the program once `count.force` is called:
+ * 
+ *    val count: Lazy[Long] =
+ *      Stream.from(0).foldLazy(Lazy(0L)) { _ =>
+ *        Fold.Continue(_ + 1L)
+ *      }
+ * 
+ * You can even implement foldLeft in terms of foldLazy (!):
+ * 
+ *    def foldl[A, B](as: List[A], b: B)(f: (B, A) => B): B =
+ *      as.foldLazy(Lazy.byName((b: B) => b)) { a =>
+ *        Fold.Continue(g => (b: B) => g(f(b, a)))
+ *      }.force(b)
+ */
+sealed abstract class Fold[A] {
+  import Fold.{Return, Continue, Pass}
+
+  def complete(a: A): A =
+    this match {
+      case Return(a) => a
+      case Continue(f) => f(a)
+      case _ => a
+    }
+}
+
+object Fold {
+
+  /**
+   * Return signals that the "rest" of a fold can be ignored.
+   * 
+   * Crucially, the `a` value here is not necessarily the value that
+   * will be returned from foldLazy, but instead it is the value that
+   * will be returned to the previous functions provided by any Continue
+   * instances.
+   */
+  final case class Return[A](a: A) extends Fold[A]
+
+  /**
+   * Continue suspends a calculation, allowing the fold to continue.
+   * 
+   * When the end of the fold is reached, the final A value will
+   * propagate back through these functions, producing a final result.
+   */
+  final case class Continue[A](f: A => A) extends Fold[A]
+
+  /**
+   * Pass allows the fold to continue, without modifying the result.
+   * 
+   * Pass' behavior is identical to Continue(identity[A]), but it may be
+   * more efficient.
+   */
+  final def Pass[A]: Fold[A] = pass.asInstanceOf[Fold[A]]
+
+  final case object pass extends Fold[Nothing]
+
+  /**
+   * 
+   */
+  def iterateRight[A, B](as: Iterable[A], b: Lazy[B])(f: A => Fold[B]): Lazy[B] = {
+    def unroll(b: B, fs: List[B => B]): B =
+      fs.foldLeft(b)((b, f) => f(b))
+    def loop(it: Iterator[A], fs: List[B => B]): B =
+      if (it.hasNext) {
+        val a: A = it.next
+        val fb: Fold[B] = f(it.next)
+        fb match {
+          case Return(b) => unroll(b, fs)
+          case Continue(f) => loop(it, f.asInstanceOf[B => B] :: fs) // scalac!
+          case _ => loop(it, fs)
+        }
+      } else unroll(b.force, fs)
+    Lazy(loop(as.iterator, Nil))
+  }
+}

--- a/core/src/main/scala/cats/Fold.scala
+++ b/core/src/main/scala/cats/Fold.scala
@@ -71,6 +71,9 @@ package cats
  *        Fold.Continue(g => (b: B) => g(f(b, a)))
  *      }.force(b)
  * }}}
+ *
+ * (In practice you would not want to use the `foldl` because it is
+ * not stack-safe.)
  */
 sealed abstract class Fold[A] {
   import Fold.{Return, Continue, Pass}

--- a/core/src/main/scala/cats/Fold.scala
+++ b/core/src/main/scala/cats/Fold.scala
@@ -2,61 +2,61 @@ package cats
 
 /**
  * Fold is designed to allow laziness/short-circuiting in foldLazy.
- * 
+ *
  * It is a sum type that has three possible subtypes:
- * 
+ *
  *   - Return(a): stop the fold with a value of `a`.
  *   - Continue(f): continue the fold, suspending the computation `f`.
  *   - Pass: continue the fold, with no additional computation.
- * 
+ *
  * The meaning of these types can be made more clear with an example
  * of the foldLazy method in action. Here's a method to count how many
  * elements appear in a list before 3:
- * 
+ *
  *     def f(n: Int): Fold[Int] =
- *       if (n == 3) Fold.Return (0) else Fold.Continue(_ + 1)
- * 
+ *       if (n == 3) Fold.Return(0) else Fold.Continue(_ + 1)
+ *
  *     val count: Lazy[Int] = List(1,2,3,4).foldLazy(Lazy(0))(f)
- * 
+ *
  * When we call `count.force`, the following occurs:
- * 
+ *
  *  - f(1) produces res0: Continue(_ + 1)
  *  - f(2) produces res1: Continue(_ + 1)
  *  - f(3) produces res2: Return(0)
- * 
+ *
  * Now we unwind back through the continue instances:
- * 
+ *
  *  - res2 produces 0
  *  - res1(0) produces 1
  *  - res0(1) produces 2
- * 
+ *
  * And so the result is 2.
- * 
+ *
  * This code searches an infinite stream for 77:
- * 
+ *
  *    val found: Lazy[Boolean] =
  *      Stream.from(0).foldLazy(Lazy(false)) { n =>
  *        if (n == 77) Fold.Return(true) else Fold.Pass
  *      }
- * 
+ *
  * Here's another example that sums the list until it reaches a
  * negative number:
- * 
+ *
  *    val sum: Lazy[Double] =
  *      numbers.foldLazy(Lazy(0.0)) { n =>
  *        if (n < 0) Fold.Return(0.0) else Fold.Continue(n + _)
  *      }
- * 
+ *
  * This strange example counts an infinite stream. Since the result is
  * lazy, it will only hang the program once `count.force` is called:
- * 
+ *
  *    val count: Lazy[Long] =
  *      Stream.from(0).foldLazy(Lazy(0L)) { _ =>
  *        Fold.Continue(_ + 1L)
  *      }
- * 
+ *
  * You can even implement foldLeft in terms of foldLazy (!):
- * 
+ *
  *    def foldl[A, B](as: List[A], b: B)(f: (B, A) => B): B =
  *      as.foldLazy(Lazy.byName((b: B) => b)) { a =>
  *        Fold.Continue(g => (b: B) => g(f(b, a)))
@@ -77,7 +77,7 @@ object Fold {
 
   /**
    * Return signals that the "rest" of a fold can be ignored.
-   * 
+   *
    * Crucially, the `a` value here is not necessarily the value that
    * will be returned from foldLazy, but instead it is the value that
    * will be returned to the previous functions provided by any Continue
@@ -87,7 +87,7 @@ object Fold {
 
   /**
    * Continue suspends a calculation, allowing the fold to continue.
-   * 
+   *
    * When the end of the fold is reached, the final A value will
    * propagate back through these functions, producing a final result.
    */
@@ -95,7 +95,7 @@ object Fold {
 
   /**
    * Pass allows the fold to continue, without modifying the result.
-   * 
+   *
    * Pass' behavior is identical to Continue(identity[A]), but it may be
    * more efficient.
    */
@@ -104,7 +104,7 @@ object Fold {
   final case object pass extends Fold[Nothing]
 
   /**
-   * 
+   * iteratRight provides a sample right-fold for Iterable[A] values.
    */
   def iterateRight[A, B](as: Iterable[A], b: Lazy[B])(f: A => Fold[B]): Lazy[B] = {
     def unroll(b: B, fs: List[B => B]): B =
@@ -115,7 +115,7 @@ object Fold {
         val fb: Fold[B] = f(it.next)
         fb match {
           case Return(b) => unroll(b, fs)
-          case Continue(f) => loop(it, f.asInstanceOf[B => B] :: fs) // scalac!
+          case Continue(f) => loop(it, f :: fs)
           case _ => loop(it, fs)
         }
       } else unroll(b.force, fs)

--- a/core/src/main/scala/cats/Foldable.scala
+++ b/core/src/main/scala/cats/Foldable.scala
@@ -5,6 +5,20 @@ import simulacrum._
 /**
  * Data structures that can be folded to a summary value.
  *
+ * In the case of a collection (such as `List` or `Set`), these
+ * methods will fold together (combine) the values contained in the
+ * collection to produce a single result. Most collection types have
+ * `foldLeft` methods, which will usually be used by the associationed
+ * `Fold[_]` instance.
+ *
+ * Foldable[F] is implemented in terms of two basic methods:
+ *
+ *  - `foldLeft(fa, b)(f)` eagerly folds `fa` from left-to-right.
+ *  - `foldLazy(fa, lb)(f)` lazily folds `fa` from right-to-left.
+ *
+ * Beyond these it provides many other useful methods related to
+ * folding over F[A] values.
+ *
  * See: [[https://www.cs.nott.ac.uk/~gmh/fold.pdf A tutorial on the universality and expressiveness of fold]]
  */
 @typeclass trait Foldable[F[_]] { self =>
@@ -28,6 +42,10 @@ import simulacrum._
 
   /**
    * Right associative fold on 'F' using the function 'f'.
+   *
+   * The default implementation is written in terms of
+   * `foldLazy`. Most instances will want to override this method for
+   * performance reasons.
    */
   def foldRight[A, B](fa: F[A], b: B)(f: (A, B) => B): B =
     foldLazy(fa, Lazy.eager(b)) { a =>
@@ -35,15 +53,7 @@ import simulacrum._
     }.force
 
   /**
-   * Apply f to each element of F and combine them using the Monoid[B].
-   */
-  def foldMap[A, B](fa: F[A])(f: A => B)(implicit B: Monoid[B]): B =
-    foldLeft(fa, B.empty) { (b, a) =>
-      B.combine(b, f(a))
-    }
-
-  /**
-   * Fold up F using the Monoid[A]
+   * Fold implemented using the given Monoid[A] instance.
    */
   def fold[A](fa: F[A])(implicit A: Monoid[A]): A =
     foldLeft(fa, A.empty) { (acc, a) =>
@@ -51,32 +61,79 @@ import simulacrum._
     }
 
   /**
-   * Traverse F in the Applicative G and ignore the return values of 'f'.
+   * Fold implemented by mapping `A` values into `B` and then
+   * combining them using the given `Monoid[B]` instance.
    */
-  def traverse_[G[_]: Applicative, A, B](fa: F[A])(f: A => G[B]): G[Unit] =
-    foldLeft(fa, Applicative[G].pure(())) { (acc, a) =>
-      Applicative[G].map2(acc, f(a)) { (_, _) => () }
+  def foldMap[A, B](fa: F[A])(f: A => B)(implicit B: Monoid[B]): B =
+    foldLeft(fa, B.empty) { (b, a) =>
+      B.combine(b, f(a))
     }
 
   /**
-   * Traverse F in the Applicative G ignoring all values in fga.
+   * Traverse `F[A]` using `Applicative[G]`.
+   *
+   * `A` values will be mapped into `G[B]` and combined using
+   * `Applicative#map2`.
+   *
+   * For example:
+   * {{{
+   *     def parseInt(s: String): Option[Int] = ...
+   *     val F = Foldable[List]
+   *     F.traverse_(List("333", "444"))(parseInt) // Some(())
+   *     F.traverse_(List("333", "zzz"))(parseInt) // None
+   * }}}
+   *
+   * This method is primarily useful when `G[_]` represents an action
+   * or effect, and the specific `A` aspect of `G[A]` is not otherwise
+   * needed.
+   */
+  def traverse_[G[_], A, B](fa: F[A])(f: A => G[B])(implicit G: Applicative[G]): G[Unit] =
+    foldLeft(fa, G.pure(())) { (acc, a) =>
+      G.map2(acc, f(a)) { (_, _) => () }
+    }
+
+  /**
+   * Sequence `F[G[A]]` using `Applicative[G]`.
+   *
+   * This is similar to `traverse_` except it operates on `F[G[A]]`
+   * values, so no additional functions are needed.
+   *
+   * For example:
+   *
+   * {{{
+   *     val F = Foldable[List]
+   *     F.sequence_(List(Option(1), Option(2), Option(3))) // Some(())
+   *     F.sequence_(List(Option(1), None, Option(3)))      // None
+   * }}}
    */
   def sequence_[G[_]: Applicative, A, B](fga: F[G[A]]): G[Unit] =
     traverse_(fga)(identity)
 
   /**
-   * Fold up F using the MonoidK instance for G. Like fold, but the value is of kind * -> *.
+   * Fold implemented using the given `MonoidK[G]` instance.
+   *
+   * This method is identical to fold, except that we use the universal monoid (`MonoidK[G]`)
+   * to get a `Monoid[G[A]]` instance.
+   *
+   * For example:
+   *
+   * {{{
+   *     val F = Foldable[List]
+   *     F.foldK(List(1 :: 2 :: Nil, 3 :: 4 :: 5 :: Nil))
+   *     // List(1, 2, 3, 4, 5)
+   * }}}
    */
   def foldK[G[_], A](fga: F[G[A]])(implicit G: MonoidK[G]): G[A] =
     fold(fga)(G.algebra)
 
   /**
-   * Compose this foldable instance with one for G creating Foldable[F[G]]
+   * Compose this `Foldable[F]` with a `Foldable[G]` to create
+   * a `Foldable[F[G]]` instance.
    */
-  def compose[G[_]](implicit GG: Foldable[G]): Foldable[λ[α => F[G[α]]]] =
+  def compose[G[_]](implicit G0: Foldable[G]): Foldable[λ[α => F[G[α]]]] =
     new CompositeFoldable[F, G] {
       implicit def F: Foldable[F] = self
-      implicit def G: Foldable[G] = GG
+      implicit def G: Foldable[G] = G0
     }
 }
 
@@ -104,6 +161,8 @@ trait CompositeFoldable[F[_], G[_]] extends Foldable[λ[α => F[G[α]]]] {
    */
   def foldLazy[A, B](fa: F[G[A]], b: Lazy[B])(f: A => Fold[B]): Lazy[B] =
     F.foldLazy(fa, b) { ga =>
-      Fold.Continue(b => G.foldLazy(ga, Lazy.eager(b))(a => f(a)).force)
+      Fold.Continue { b =>
+        G.foldLazy(ga, Lazy.eager(b))(f).force
+      }
     }
 }

--- a/core/src/main/scala/cats/Foldable.scala
+++ b/core/src/main/scala/cats/Foldable.scala
@@ -23,8 +23,11 @@ import simulacrum._
    * Right associative lazy fold on `F` using the folding function 'f'.
    *
    * This method evaluates `b` lazily (in some cases it will not be
-   * needed), and returns a lazy value. For more information about how
-   * this method works see the documentation for Fold[_].
+   * needed), and returns a lazy value. We are using `A => Fold[B]` to
+   * support laziness in a stack-safe way.
+   *
+   * For more detailed information about how this method works see the
+   * documentation for `Fold[_]`.
    */
   def foldLazy[A, B](fa: F[A], b: Lazy[B])(f: A => Fold[B]): Lazy[B]
 

--- a/core/src/main/scala/cats/Foldable.scala
+++ b/core/src/main/scala/cats/Foldable.scala
@@ -21,7 +21,7 @@ import simulacrum._
 
   /**
    * Right associative lazy fold on `F` using the folding function 'f'.
-   * 
+   *
    * This method evaluates `b` lazily (in some cases it will not be
    * needed), and returns a lazy value. For more information about how
    * this method works see the documentation for Fold[_].

--- a/core/src/main/scala/cats/syntax/foldable.scala
+++ b/core/src/main/scala/cats/syntax/foldable.scala
@@ -13,7 +13,7 @@ trait FoldableSyntax {
 class FoldableOps[F[_], A](fa: F[A])(implicit F: Foldable[F]) {
   def foldLeft[B](b: B)(f: (B, A) => B): B = F.foldLeft(fa, b)(f)
   def foldRight[B](b: B)(f: (A, B) => B): B = F.foldRight(fa, b)(f)
-  def foldRight[B](b: Lazy[B])(f: (A, Lazy[B]) => B): Lazy[B] = F.foldRight(fa, b)(f)
+  def foldLazy[B](b: Lazy[B])(f: A => Fold[B]): Lazy[B] = F.foldLazy(fa, b)(f)
   def foldMap[B: Monoid](f: A => B): B = F.foldMap(fa)(f)
   def fold(implicit A: Monoid[A]): A = F.fold(fa)
   def traverse_[G[_]: Applicative, B](f: A => G[B]): G[Unit] = F.traverse_(fa)(f)

--- a/data/src/main/scala/cats/data/Const.scala
+++ b/data/src/main/scala/cats/data/Const.scala
@@ -52,7 +52,7 @@ sealed abstract class ConstInstances extends ConstInstances0 {
 
     def foldLeft[A, B](fa: Const[C, A], b: B)(f: (B, A) => B): B = b
 
-    def foldRight[A, B](fa: Const[C, A], b: B)(f: (A, B) => B): B = b
+    override def foldRight[A, B](fa: Const[C, A], b: B)(f: (A, B) => B): B = b
 
     def foldLazy[A, B](fa: Const[C, A], b: Lazy[B])(f: A => Fold[B]): Lazy[B] = b
   }

--- a/data/src/main/scala/cats/data/Const.scala
+++ b/data/src/main/scala/cats/data/Const.scala
@@ -54,7 +54,7 @@ sealed abstract class ConstInstances extends ConstInstances0 {
 
     def foldRight[A, B](fa: Const[C, A], b: B)(f: (A, B) => B): B = b
 
-    def foldRight[A, B](fa: Const[C, A], b: Lazy[B])(f: (A, Lazy[B]) => B): Lazy[B] = b
+    def foldLazy[A, B](fa: Const[C, A], b: Lazy[B])(f: A => Fold[B]): Lazy[B] = b
   }
 
   implicit def constMonoid[A: Monoid, B]: Monoid[Const[A, B]] = new Monoid[Const[A, B]]{

--- a/data/src/main/scala/cats/data/Or.scala
+++ b/data/src/main/scala/cats/data/Or.scala
@@ -125,7 +125,7 @@ sealed abstract class OrInstances extends OrInstances1 {
   class OrInstances[A] extends Traverse[A Or ?] with Monad[A Or ?] {
     def traverse[F[_]: Applicative, B, C](fa: A Or B)(f: B => F[C]): F[A Or C] = fa.traverse(f)
     def foldLeft[B, C](fa: A Or B, b: C)(f: (C, B) => C): C = fa.foldLeft(b)(f)
-    def foldRight[B, C](fa: A Or B, b: C)(f: (B, C) => C): C = fa.foldRight(b)(f)
+    override def foldRight[B, C](fa: A Or B, b: C)(f: (B, C) => C): C = fa.foldRight(b)(f)
     def foldLazy[B, C](fa: A Or B, b: Lazy[C])(f: B => Fold[C]): Lazy[C] = fa.foldLazy(b)(f)
 
     def flatMap[B, C](fa: A Or B)(f: B => A Or C): A Or C = fa.flatMap(f)

--- a/data/src/main/scala/cats/data/Or.scala
+++ b/data/src/main/scala/cats/data/Or.scala
@@ -92,7 +92,8 @@ sealed abstract class Or[+A, +B] extends Product with Serializable {
 
   def foldRight[C](c: C)(f: (B, C) => C): C = fold(_ => c, f(_, c))
 
-  def foldRight[C](c: Lazy[C])(f: (B, Lazy[C]) => C): Lazy[C] = fold(_ => c, b => Lazy(f(b, c)))
+  def foldLazy[C](c: Lazy[C])(f: B => Fold[C]): Lazy[C] =
+    fold(_ => c, b => c.map(f(b).complete))
 
   def merge[AA >: A](implicit ev: B <:< AA): AA = fold(identity, ev.apply)
 
@@ -125,7 +126,7 @@ sealed abstract class OrInstances extends OrInstances1 {
     def traverse[F[_]: Applicative, B, C](fa: A Or B)(f: B => F[C]): F[A Or C] = fa.traverse(f)
     def foldLeft[B, C](fa: A Or B, b: C)(f: (C, B) => C): C = fa.foldLeft(b)(f)
     def foldRight[B, C](fa: A Or B, b: C)(f: (B, C) => C): C = fa.foldRight(b)(f)
-    def foldRight[B, C](fa: A Or B, b: Lazy[C])(f: (B, Lazy[C]) => C): Lazy[C] = fa.foldRight(b)(f)
+    def foldLazy[B, C](fa: A Or B, b: Lazy[C])(f: B => Fold[C]): Lazy[C] = fa.foldLazy(b)(f)
 
     def flatMap[B, C](fa: A Or B)(f: B => A Or C): A Or C = fa.flatMap(f)
     def pure[B](b: B): A Or B = Or.right(b)

--- a/std/src/main/scala/cats/std/list.scala
+++ b/std/src/main/scala/cats/std/list.scala
@@ -37,7 +37,7 @@ trait ListInstances {
       def foldLeft[A, B](fa: List[A], b: B)(f: (B, A) => B): B =
         fa.foldLeft(b)(f)
 
-      def foldRight[A, B](fa: List[A], b: B)(f: (A, B) => B): B =
+      override def foldRight[A, B](fa: List[A], b: B)(f: (A, B) => B): B =
         fa.foldRight(b)(f)
 
       def foldLazy[A, B](fa: List[A], b: Lazy[B])(f: A => Fold[B]): Lazy[B] =

--- a/std/src/main/scala/cats/std/list.scala
+++ b/std/src/main/scala/cats/std/list.scala
@@ -40,16 +40,8 @@ trait ListInstances {
       def foldRight[A, B](fa: List[A], b: B)(f: (A, B) => B): B =
         fa.foldRight(b)(f)
 
-      def foldRight[A, B](fa: List[A], b: Lazy[B])(f: (A, Lazy[B]) => B): Lazy[B] = {
-        // we use Lazy.byName(...) to avoid memoizing intermediate values.
-        def loop(as: List[A], b: Lazy[B]): Lazy[B] =
-          as match {
-            case Nil => b
-            case a :: rest => Lazy.byName(f(a, foldRight(rest, b)(f)))
-          }
-        // we memoize the first "step" with Lazy(...).
-        Lazy(loop(fa, b).force)
-      }
+      def foldLazy[A, B](fa: List[A], b: Lazy[B])(f: A => Fold[B]): Lazy[B] =
+        Fold.iterateRight(fa, b)(f)
 
       def traverse[G[_]: Applicative, A, B](fa: List[A])(f: A => G[B]): G[List[B]] = {
         val G = Applicative[G]

--- a/std/src/main/scala/cats/std/map.scala
+++ b/std/src/main/scala/cats/std/map.scala
@@ -9,23 +9,23 @@ trait MapInstances {
 
   implicit def mapInstance[K]: Traverse[Map[K, ?]] with FlatMap[Map[K, ?]] =
     new Traverse[Map[K, ?]] with FlatMap[Map[K, ?]] {
-      override def traverse[G[_] : Applicative, A, B](fa: Map[K, A])(f: (A) => G[B]): G[Map[K, B]] = {
+      def traverse[G[_] : Applicative, A, B](fa: Map[K, A])(f: (A) => G[B]): G[Map[K, B]] = {
         val G = Applicative[G]
         val gba = G.pure(Map.empty[K, B])
         val gbb = fa.foldLeft(gba)((buf, a) => G.map2(buf, f(a._2))({ case(x, y) => x + (a._1 -> y)}))
         G.map(gbb)(_.toMap)
       }
 
-      override def flatMap[A, B](fa: Map[K, A])(f: (A) => Map[K, B]): Map[K, B] =
+      def flatMap[A, B](fa: Map[K, A])(f: (A) => Map[K, B]): Map[K, B] =
         fa.flatMap { case (_, a) => f(a) }
 
-      override def foldLeft[A, B](fa: Map[K, A], b: B)(f: (B, A) => B): B =
+      def foldLeft[A, B](fa: Map[K, A], b: B)(f: (B, A) => B): B =
         fa.foldLeft(b) { case (x, (k, a)) => f(x, a)}
 
       override def foldRight[A, B](fa: Map[K, A], b: B)(f: (A, B) => B): B =
         fa.foldRight(b) { case ((k, a), z) => f(a, z)}
 
-      override def foldLazy[A, B](fa: Map[K, A], b: Lazy[B])(f: A => Fold[B]): Lazy[B] =
+      def foldLazy[A, B](fa: Map[K, A], b: Lazy[B])(f: A => Fold[B]): Lazy[B] =
         Fold.iterateRight(fa.values, b)(f)
     }
 }

--- a/std/src/main/scala/cats/std/map.scala
+++ b/std/src/main/scala/cats/std/map.scala
@@ -25,16 +25,7 @@ trait MapInstances {
       override def foldRight[A, B](fa: Map[K, A], b: B)(f: (A, B) => B): B =
         fa.foldRight(b) { case ((k, a), z) => f(a, z)}
 
-      override def foldRight[A, B](fa: Map[K, A], b: Lazy[B])(f: (A, Lazy[B]) => B): Lazy[B] = {
-        // we use Lazy.byName(...) to avoid memoizing intermediate values.
-        def loop(as: Map[K, A], b: Lazy[B]): Lazy[B] =
-          as.toList match {
-            case Nil => b
-            case a :: rest => Lazy.byName(f(a._2, foldRight(rest.toMap, b)(f)))
-          }
-        // we memoize the first "step" with Lazy(...).
-        Lazy(loop(fa, b).force)
-      }
+      override def foldLazy[A, B](fa: Map[K, A], b: Lazy[B])(f: A => Fold[B]): Lazy[B] =
+        Fold.iterateRight(fa.values, b)(f)
     }
-
 }

--- a/std/src/main/scala/cats/std/option.scala
+++ b/std/src/main/scala/cats/std/option.scala
@@ -37,10 +37,10 @@ trait OptionInstances {
           case Some(a) => f(a, b)
         }
 
-      def foldRight[A, B](fa: Option[A], b: Lazy[B])(f: (A, Lazy[B]) => B): Lazy[B] =
+      def foldLazy[A, B](fa: Option[A], b: Lazy[B])(f: A => Fold[B]): Lazy[B] =
         fa match {
           case None => b
-          case Some(a) => Lazy(f(a, b))
+          case Some(a) => b.map(f(a).complete)
         }
 
       def traverse[G[_]: Applicative, A, B](fa: Option[A])(f: A => G[B]): G[Option[B]] =

--- a/std/src/main/scala/cats/std/option.scala
+++ b/std/src/main/scala/cats/std/option.scala
@@ -31,7 +31,7 @@ trait OptionInstances {
           case Some(a) => f(b, a)
         }
 
-      def foldRight[A, B](fa: Option[A], b: B)(f: (A, B) => B): B =
+      override def foldRight[A, B](fa: Option[A], b: B)(f: (A, B) => B): B =
         fa match {
           case None => b
           case Some(a) => f(a, b)

--- a/std/src/main/scala/cats/std/set.scala
+++ b/std/src/main/scala/cats/std/set.scala
@@ -17,11 +17,7 @@ trait SetInstances extends algebra.std.SetInstances {
       def foldRight[A, B](fa: Set[A], b: B)(f: (A, B) => B): B =
         fa.foldRight(b)(f)
 
-      def foldRight[A, B](fa: Set[A], b: Lazy[B])(f: (A, Lazy[B]) => B): Lazy[B] = {
-        val it = fa.iterator
-        def loop(b: Lazy[B]): Lazy[B] =
-          if (it.hasNext) Lazy.byName(f(it.next, b)) else b
-        Lazy(loop(b).force)
-      }
+      def foldLazy[A, B](fa: Set[A], b: Lazy[B])(f: A => Fold[B]): Lazy[B] =
+        Fold.iterateRight(fa, b)(f)
     }
 }

--- a/std/src/main/scala/cats/std/set.scala
+++ b/std/src/main/scala/cats/std/set.scala
@@ -14,7 +14,7 @@ trait SetInstances extends algebra.std.SetInstances {
       def foldLeft[A, B](fa: Set[A], b: B)(f: (B, A) => B): B =
         fa.foldLeft(b)(f)
 
-      def foldRight[A, B](fa: Set[A], b: B)(f: (A, B) => B): B =
+      override def foldRight[A, B](fa: Set[A], b: B)(f: (A, B) => B): B =
         fa.foldRight(b)(f)
 
       def foldLazy[A, B](fa: Set[A], b: Lazy[B])(f: A => Fold[B]): Lazy[B] =

--- a/std/src/main/scala/cats/std/stream.scala
+++ b/std/src/main/scala/cats/std/stream.scala
@@ -29,11 +29,8 @@ trait StreamInstances {
         fa.foldLeft(b)(f)
 
       // note: this foldRight variant is eager not lazy
-      def foldRight[A, B](fa: Stream[A], b: B)(f: (A, B) => B): B =
-        fa match {
-          case Stream.Empty => b
-          case a #:: rest => f(a, foldRight(rest, b)(f))
-        }
+      override def foldRight[A, B](fa: Stream[A], b: B)(f: (A, B) => B): B =
+        fa.foldRight(b)(f)
 
       // this foldRight variant is lazy
       def foldLazy[A, B](fa: Stream[A], b: Lazy[B])(f: A => Fold[B]): Lazy[B] =

--- a/std/src/main/scala/cats/std/stream.scala
+++ b/std/src/main/scala/cats/std/stream.scala
@@ -36,16 +36,8 @@ trait StreamInstances {
         }
 
       // this foldRight variant is lazy
-      def foldRight[A, B](fa: Stream[A], b: Lazy[B])(f: (A, Lazy[B]) => B): Lazy[B] = {
-        // we use Lazy.byName(...) to avoid memoizing intermediate values.
-        def loop(as: Stream[A], b: Lazy[B]): Lazy[B] =
-          as match {
-            case Stream.Empty => b
-            case a #:: rest => Lazy.byName(f(a, foldRight(rest, b)(f)))
-          }
-        // we memoize the first "step" with Lazy(...).
-        Lazy(loop(fa, b).force)
-      }
+      def foldLazy[A, B](fa: Stream[A], b: Lazy[B])(f: A => Fold[B]): Lazy[B] =
+        Fold.iterateRight(fa, b)(f)
 
       def traverse[G[_]: Applicative, A, B](fa: Stream[A])(f: A => G[B]): G[Stream[B]] = {
         val G = Applicative[G]

--- a/std/src/main/scala/cats/std/vector.scala
+++ b/std/src/main/scala/cats/std/vector.scala
@@ -29,12 +29,8 @@ trait VectorInstances {
       def foldRight[A, B](fa: Vector[A], b: B)(f: (A, B) => B): B =
         fa.foldRight(b)(f)
 
-      def foldRight[A, B](fa: Vector[A], b: Lazy[B])(f: (A, Lazy[B]) => B): Lazy[B] = {
-        val it = fa.iterator
-        def loop(b: Lazy[B]): Lazy[B] =
-          if (it.hasNext) Lazy.byName(f(it.next, b)) else b
-        Lazy(loop(b).force)
-      }
+      def foldLazy[A, B](fa: Vector[A], b: Lazy[B])(f: A => Fold[B]): Lazy[B] =
+        Fold.iterateRight(fa, b)(f)
 
       def traverse[G[_]: Applicative, A, B](fa: Vector[A])(f: A => G[B]): G[Vector[B]] = {
         val G = Applicative[G]

--- a/std/src/main/scala/cats/std/vector.scala
+++ b/std/src/main/scala/cats/std/vector.scala
@@ -26,7 +26,7 @@ trait VectorInstances {
       def foldLeft[A, B](fa: Vector[A], b: B)(f: (B, A) => B): B =
         fa.foldLeft(b)(f)
 
-      def foldRight[A, B](fa: Vector[A], b: B)(f: (A, B) => B): B =
+      override def foldRight[A, B](fa: Vector[A], b: B)(f: (A, B) => B): B =
         fa.foldRight(b)(f)
 
       def foldLazy[A, B](fa: Vector[A], b: Lazy[B])(f: A => Fold[B]): Lazy[B] =

--- a/tests/src/test/scala/cats/tests/FoldableTests.scala
+++ b/tests/src/test/scala/cats/tests/FoldableTests.scala
@@ -1,0 +1,71 @@
+package cats.tests
+
+import org.scalatest.FunSuite
+
+import cats._
+import cats.implicits._
+
+class FoldableTests extends FunSuite {
+  import Fold.{Continue, Return, Pass}
+
+  // disable scalatest ===
+  override def convertToEqualizer[T](left: T) = ???
+
+  // TODO: remove this eventually
+  implicit val M: Monoid[Int] = new Monoid[Int] {
+    def empty: Int = 0
+    def combine(x: Int, y: Int): Int = x + y
+  }
+
+  // exists method written in terms of foldLazy
+  def exists[F[_]: Foldable, A: Eq](as: F[A], goal: A): Lazy[Boolean] =
+    Foldable[F].foldLazy(as, Lazy(false)) { a =>
+      if (a === goal) Return(true) else Pass
+    }
+
+  test("Foldable[List]") {
+    val F = Foldable[List]
+
+    // some basic sanity checks
+    val ns = (1 to 10).toList
+    val total = ns.sum
+    assert(F.foldLeft(ns, 0)(_ + _) == total)
+    assert(F.foldRight(ns, 0)(_ + _) == total)
+    assert(F.foldLazy(ns, Lazy(0))(x => Continue(x + _)).force == total)
+    assert(F.fold(ns) == total)
+
+    // more basic checks
+    val names = List("Aaron", "Betty", "Calvin", "Deirdra")
+    assert(F.foldMap(names)(_.length) == names.map(_.length).sum)
+
+    // test trampolining
+    val large = (1 to 10000).toList
+    assert(exists(large, 10000).force)
+
+    // safely build large lists
+    val larger = F.foldLazy(large, Lazy(List.empty[Int]))(x => Continue((x + 1) :: _))
+    assert(larger.force == large.map(_ + 1))
+  }
+
+  test("Foldable[Stream]") {
+    val F = Foldable[Stream]
+
+    def bomb[A]: A = sys.error("boom")
+    val dangerous = 0 #:: 1 #:: 2 #:: bomb[Stream[Int]]
+
+    // doesn't blow up - this also ensures it works for infinite streams.
+    assert(exists(dangerous, 2).force)
+
+    // lazy results don't blow up unless you call .force on them.
+    val doom: Lazy[Boolean] = exists(dangerous, -1)
+
+    // ensure that the Lazy[B] param to foldLazy is actually being
+    // handled lazily. it only needs to be evaluated if we reach the
+    // "end" of the fold.
+    val trap = Lazy(bomb[Boolean])
+    val result = F.foldLazy(1 #:: 2 #:: Stream.Empty, trap) { n =>
+      if (n == 2) Return(true) else Pass
+    }
+    assert(result.force)
+  }
+}


### PR DESCRIPTION
This method introduces a new data type, Fold[A]. This type
allows to programmer to decide whether to continue evaluating
the fold (and provide an appropriate continuation function),
or to return immediately.

This fixes #88 