### PR TITLE
Add API mapping metadata and update sbt-unidoc

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -54,6 +54,8 @@ lazy val disciplineDependencies = Seq(
 )
 
 lazy val docSettings = Seq(
+  autoAPIMappings := true,
+  apiURL := Some(url("https://non.github.io/cats/api/")),
   unidocProjectFilter in (ScalaUnidoc, unidoc) := inProjects(core, laws, data, std),
   site.addMappingsToSiteDir(mappings in (ScalaUnidoc, packageDoc), "api"),
   site.addMappingsToSiteDir(tut, ""),
@@ -121,7 +123,7 @@ lazy val data = project.dependsOn(macros, core)
   .settings(catsSettings: _*)
 
 lazy val publishSettings = Seq(
-  homepage := Some(url("http://github.com/non/cats")),
+  homepage := Some(url("https://github.com/non/cats")),
   licenses := Seq("MIT" -> url("http://opensource.org/licenses/MIT")),
   publishMavenStyle := true,
   publishArtifact in Test := false,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,7 @@ resolvers += Resolver.url(
     url("http://dl.bintray.com/content/tpolecat/sbt-plugin-releases"))(
         Resolver.ivyStylePatterns)
 
-addSbtPlugin("com.eed3si9n"      % "sbt-unidoc"             % "0.3.1")
+addSbtPlugin("com.eed3si9n"      % "sbt-unidoc"             % "0.3.2")
 addSbtPlugin("com.github.gseitz" % "sbt-release"            % "0.7.1")
 addSbtPlugin("com.typesafe.sbt"  % "sbt-pgp"                % "0.8")
 addSbtPlugin("com.typesafe.sbt"  % "sbt-ghpages"            % "0.5.3")


### PR DESCRIPTION
Enabling `autoAPIMappings` and adding `apiURL` means two things: first, the API docs URL will be added to the published POM, and any project that depends on cats can now (optionally) have references to cats types and methods automatically linked in its own API docs.

Second, once docs are published for algebra (and other cats dependencies), cats's documentation will get this same kind of automatic external linking. This didn't work with sbt-unidoc [until this morning's release](https://twitter.com/eed3si9n/status/564646946506567680), so I've also updated the sbt-unidoc version.

I've also included one tiny mostly unrelated change here—it would be best to use HTTPS for the homepage link, so I've changed that.