### PR TITLE
Disable API doc generation when publishing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: scala
 scala:
   - 2.11.5
 script:
-  - sbt ++$TRAVIS_SCALA_VERSION validate
+  - sbt ++$TRAVIS_SCALA_VERSION validate publishLocal
 notifications:
   webhooks:
     urls:

--- a/build.sbt
+++ b/build.sbt
@@ -126,6 +126,7 @@ lazy val publishSettings = Seq(
   homepage := Some(url("https://github.com/non/cats")),
   licenses := Seq("MIT" -> url("http://opensource.org/licenses/MIT")),
   publishMavenStyle := true,
+  publishArtifact in packageDoc := false,
   publishArtifact in Test := false,
   pomIncludeRepository := { _ => false },
   publishTo <<= version { (v: String) =>


### PR DESCRIPTION
Attempting to publish currently fails during Scaladoc generation with a lot of "Could not find any member to link for…" errors, due to the fact that we have links across subprojects in the API docs (and that we treat warnings as failures).

It seems like `autoAPIMappings` should fix this, but it currently doesn't have any effect. It's possible to make automatic mapping work in this situation by jumping through [this hoop](http://stackoverflow.com/a/23177275/334519), but the fact that we don't really care about the `doc` task (since we're using `unidoc`) means it's probably simplest just to remove it from publishing.

I've also added `publishLocal` to the Travis build to help ensure that we don't break publishing in the future. It could be added to `validate` command alias, but it has wider effects than what you'd normally think of as validation, so adding it as an extra step in the Travis script seemed like a better idea.