### PR TITLE
Publish API mappings metadata

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -55,7 +55,6 @@ lazy val disciplineDependencies = Seq(
 
 lazy val docSettings = Seq(
   autoAPIMappings := true,
-  apiURL := Some(url("https://non.github.io/cats/api/")),
   unidocProjectFilter in (ScalaUnidoc, unidoc) := inProjects(core, laws, data, std),
   site.addMappingsToSiteDir(mappings in (ScalaUnidoc, packageDoc), "api"),
   site.addMappingsToSiteDir(tut, ""),
@@ -125,6 +124,8 @@ lazy val data = project.dependsOn(macros, core)
 lazy val publishSettings = Seq(
   homepage := Some(url("https://github.com/non/cats")),
   licenses := Seq("MIT" -> url("http://opensource.org/licenses/MIT")),
+  autoAPIMappings := true,
+  apiURL := Some(url("https://non.github.io/cats/api/")),
   publishMavenStyle := true,
   publishArtifact in Test := false,
   pomIncludeRepository := { _ => false },


### PR DESCRIPTION
This is analogous to [this PR](https://github.com/non/algebra/pull/46) I just submitted for algebra. My #158 yesterday wasn't quite complete—it set up automatic API mapping to work for cats's dependencies, but not to publish the metadata for cats itself. I've confirmed that this fix publishes the metadata. Apologies for the noise—