### PR TITLE
Codegen demonstration for ApplyBuilder

### DIFF
--- a/core/build.sbt
+++ b/core/build.sbt
@@ -1,0 +1,42 @@
+lazy val maxArity = 12
+
+def genApplyBuilders(dir: File): Seq[File] = {
+  def builder(N: Int): String = {
+    val typeArgs = (1 to N).map(i => s"A$i").mkString(", ")
+    val termArgs = (1 to N).map(i => s"a$i").mkString(", ")
+
+    val next = if (N < maxArity) s"""
+      def |@|[Z](z: F[Z]): ApplyBuilder${N + 1}[Z] = new ApplyBuilder${N + 1}[Z](z)
+
+      ${builder(N + 1)}
+    """ else ""
+
+    s"""
+      private[syntax] class ApplyBuilder$N[A$N](a$N: F[A$N]) {
+        def apply[Z](f: F[($typeArgs) => Z])(implicit F: Apply[F]): F[Z] = F.apply$N($termArgs)(f)
+        def map[Z](f: ($typeArgs) => Z)(implicit F: Apply[F]): F[Z] = F.map$N($termArgs)(f)
+        def tupled[Z](implicit F: Apply[F]): F[($typeArgs)] = F.tuple$N($termArgs)
+        $next
+      }
+    """
+  }
+
+  val source = s"""
+    package cats
+    package syntax
+
+    private[syntax] class ApplyBuilder[F[_], A1](a1: F[A1]) {
+      def |@|[A2](a2: F[A2]): ApplyBuilder2[A2] = new ApplyBuilder2[A2](a2)
+
+      ${builder(2)}
+    }
+  """
+
+  val file = dir / "cats" / "syntax" / "ApplyBuilder.scala"
+
+  IO.write(file, source)
+
+  Seq(file)
+}
+
+sourceGenerators in Compile <+= (sourceManaged in Compile).map(genApplyBuilders)

--- a/core/src/main/scala/cats/syntax/apply.scala
+++ b/core/src/main/scala/cats/syntax/apply.scala
@@ -11,4 +11,5 @@ class ApplyOps[F[_], A](fa: F[A])(implicit F: Apply[F]) {
   def apply[B](f: F[A => B]): F[B] = F.apply(fa)(f)
   def apply2[B, Z](fb: F[B])(f: F[(A, B) => Z]): F[Z] = F.apply2(fa, fb)(f)
   def map2[B, Z](fb: F[B])(f: (A, B) => Z): F[Z] = F.map2(fa, fb)(f)
+  def |@|[B](fb: F[B]) = new ApplyBuilder[F, A](fa) |@| fb
 }


### PR DESCRIPTION
This is a quick demonstration of a codegen-based alternative to #174's macro annotations for #162. The generated source should probably be properly indented, etc. before this would be a candidate for merging.

The advantage over using macro annotations is simplicity—macro annotations are pretty big guns for a little boilerplate-removal problem. The big disadvantage is that it's easier to make syntax errors in these strings than it would be if we had quasiquotes (although of course any errors would be caught by the compiler immediately after code generation).

The same treatment could be applied to `ApplyArityFunctions`, and the result would only be a little more complex.