### PR TITLE
Add MonadLaws and organize laws in traits

### DIFF
--- a/core/src/main/scala/cats/Monad.scala
+++ b/core/src/main/scala/cats/Monad.scala
@@ -9,10 +9,7 @@ import simulacrum._
  *
  * See: [[http://homepages.inf.ed.ac.uk/wadler/papers/marktoberdorf/baastad.pdf Monads for functional programming]]
  *
- * Must obey the following laws:
- *  - flatMap(pure(a))(f) = f(a)
- *  - flatMap(fa)(identity) = fa
- *  - flatMap(flatMap(fa)(f))(g) = flatMap(fa)(a => flatMap(f(a))(g))
+ * Must obey the laws defined in [[laws.MonadLaws]].
  */
 trait Monad[F[_]] extends FlatMap[F] with Applicative[F] {
   override def map[A, B](fa: F[A])(f: A => B): F[B] =

--- a/laws/src/main/scala/cats/laws/ApplicativeLaws.scala
+++ b/laws/src/main/scala/cats/laws/ApplicativeLaws.scala
@@ -7,7 +7,9 @@ import cats.syntax.functor._
 /**
  * Laws that must be obeyed by any [[Applicative]].
  */
-class ApplicativeLaws[F[_]](implicit F: Applicative[F]) extends ApplyLaws[F] {
+trait ApplicativeLaws[F[_]] extends ApplyLaws[F] {
+  implicit override def F: Applicative[F]
+
   def applicativeIdentity[A](fa: F[A]): (F[A], F[A]) =
     fa.apply(F.pure((a: A) => a)) -> fa
 
@@ -29,4 +31,9 @@ class ApplicativeLaws[F[_]](implicit F: Applicative[F]) extends ApplyLaws[F] {
     val compose: (B => C) => (A => B) => (A => C) = _.compose
     fa.apply(fab.apply(fbc.apply(F.pure(compose)))) -> fa.apply(fab).apply(fbc)
   }
+}
+
+object ApplicativeLaws {
+  def apply[F[_]](implicit ev: Applicative[F]): ApplicativeLaws[F] =
+    new ApplicativeLaws[F] { def F = ev }
 }

--- a/laws/src/main/scala/cats/laws/ApplyLaws.scala
+++ b/laws/src/main/scala/cats/laws/ApplyLaws.scala
@@ -7,9 +7,16 @@ import cats.syntax.functor._
 /**
  * Laws that must be obeyed by any [[Apply]].
  */
-class ApplyLaws[F[_]](implicit F: Apply[F]) extends FunctorLaws[F] {
+trait ApplyLaws[F[_]] extends FunctorLaws[F] {
+  implicit override def F: Apply[F]
+
   def applyComposition[A, B, C](fa: F[A], fab: F[A => B], fbc: F[B => C]): (F[C], F[C]) = {
     val compose: (B => C) => (A => B) => (A => C) = _.compose
     fa.apply(fab).apply(fbc) -> fa.apply(fab.apply(fbc.map(compose)))
   }
+}
+
+object ApplyLaws {
+  def apply[F[_]](implicit ev: Apply[F]): ApplyLaws[F] =
+    new ApplyLaws[F] { def F = ev }
 }

--- a/laws/src/main/scala/cats/laws/CoFlatMapLaws.scala
+++ b/laws/src/main/scala/cats/laws/CoFlatMapLaws.scala
@@ -7,7 +7,9 @@ import cats.syntax.coflatMap._
 /**
  * Laws that must be obeyed by any [[CoFlatMap]].
  */
-class CoFlatMapLaws[F[_]](implicit F: CoFlatMap[F]) extends FunctorLaws[F] {
+trait CoFlatMapLaws[F[_]] extends FunctorLaws[F] {
+  implicit override def F: CoFlatMap[F]
+
   def coFlatMapAssociativity[A, B, C](fa: F[A], f: F[A] => B, g: F[B] => C): (F[C], F[C]) =
     fa.coflatMap(f).coflatMap(g) -> fa.coflatMap(x => g(x.coflatMap(f)))
 
@@ -19,4 +21,9 @@ class CoFlatMapLaws[F[_]](implicit F: CoFlatMap[F]) extends FunctorLaws[F] {
     val (cf, cg, ch) = (Cokleisli(f), Cokleisli(g), Cokleisli(h))
     (cf compose (cg compose ch)).run(fa) -> ((cf compose cg) compose ch).run(fa)
   }
+}
+
+object CoFlatMapLaws {
+  def apply[F[_]](implicit ev: CoFlatMap[F]): CoFlatMapLaws[F] =
+    new CoFlatMapLaws[F] { def F = ev }
 }

--- a/laws/src/main/scala/cats/laws/ComonadLaws.scala
+++ b/laws/src/main/scala/cats/laws/ComonadLaws.scala
@@ -7,10 +7,17 @@ import cats.syntax.comonad._
 /**
  * Laws that must be obeyed by any [[Comonad]].
  */
-class ComonadLaws[F[_]](implicit F: Comonad[F]) extends CoFlatMapLaws[F] {
+trait ComonadLaws[F[_]] extends CoFlatMapLaws[F] {
+  implicit override def F: Comonad[F]
+
   def comonadLeftIdentity[A](fa: F[A]): (F[A], F[A]) =
     fa.coflatMap(_.extract) -> fa
 
   def comonadRightIdentity[A, B](fa: F[A], f: F[A] => B): (B, B) =
     fa.coflatMap(f).extract -> f(fa)
+}
+
+object ComonadLaws {
+  def apply[F[_]](implicit ev: Comonad[F]): ComonadLaws[F] =
+    new ComonadLaws[F] { def F = ev }
 }

--- a/laws/src/main/scala/cats/laws/ContravariantLaws.scala
+++ b/laws/src/main/scala/cats/laws/ContravariantLaws.scala
@@ -6,10 +6,17 @@ import cats.syntax.contravariant._
 /**
  * Laws that must be obeyed by any [[cats.functor.Contravariant]].
  */
-class ContravariantLaws[F[_]](implicit F: Contravariant[F]) extends InvariantLaws[F] {
+trait ContravariantLaws[F[_]] extends InvariantLaws[F] {
+  implicit override def F: Contravariant[F]
+
   def contravariantIdentity[A](fa: F[A]): (F[A], F[A]) =
     fa.contramap(identity[A]) -> fa
 
   def contravariantComposition[A, B, C](fa: F[A], f: B => A, g: C => B): (F[C], F[C]) =
     fa.contramap(f).contramap(g) -> fa.contramap(f compose g)
+}
+
+object ContravariantLaws {
+  def apply[F[_]](implicit ev: Contravariant[F]): ContravariantLaws[F] =
+    new ContravariantLaws[F] { def F = ev }
 }

--- a/laws/src/main/scala/cats/laws/FlatMapLaws.scala
+++ b/laws/src/main/scala/cats/laws/FlatMapLaws.scala
@@ -9,7 +9,9 @@ import cats.syntax.functor._
 /**
  * Laws that must be obeyed by any [[FlatMap]].
  */
-class FlatMapLaws[F[_]](implicit F: FlatMap[F]) extends ApplyLaws[F] {
+trait FlatMapLaws[F[_]] extends ApplyLaws[F] {
+  implicit override def F: FlatMap[F]
+
   def flatMapAssociativity[A, B, C](fa: F[A], f: A => F[B], g: B => F[C]): (F[C], F[C]) =
     fa.flatMap(f).flatMap(g) -> fa.flatMap(a => f(a).flatMap(g))
 
@@ -24,4 +26,9 @@ class FlatMapLaws[F[_]](implicit F: FlatMap[F]) extends ApplyLaws[F] {
     val (kf, kg, kh) = (Kleisli(f), Kleisli(g), Kleisli(h))
     (kh compose (kg compose kf)).run(a) -> ((kh compose kg) compose kf).run(a)
   }
+}
+
+object FlatMapLaws {
+  def apply[F[_]](implicit ev: FlatMap[F]): FlatMapLaws[F] =
+    new FlatMapLaws[F] { def F = ev }
 }

--- a/laws/src/main/scala/cats/laws/FunctorLaws.scala
+++ b/laws/src/main/scala/cats/laws/FunctorLaws.scala
@@ -11,5 +11,5 @@ class FunctorLaws[F[_]](implicit F: Functor[F]) extends InvariantLaws[F] {
     fa.map(identity) -> fa
 
   def covariantComposition[A, B, C](fa: F[A], f: A => B, g: B => C): (F[C], F[C]) =
-    fa.map(f).map(g) -> fa.map(f andThen g)
+    fa.map(f).map(g) -> fa.map(g compose f)
 }

--- a/laws/src/main/scala/cats/laws/FunctorLaws.scala
+++ b/laws/src/main/scala/cats/laws/FunctorLaws.scala
@@ -6,10 +6,17 @@ import cats.syntax.functor._
 /**
  * Laws that must be obeyed by any [[Functor]].
  */
-class FunctorLaws[F[_]](implicit F: Functor[F]) extends InvariantLaws[F] {
+trait FunctorLaws[F[_]] extends InvariantLaws[F] {
+  implicit override def F: Functor[F]
+
   def covariantIdentity[A](fa: F[A]): (F[A], F[A]) =
     fa.map(identity) -> fa
 
   def covariantComposition[A, B, C](fa: F[A], f: A => B, g: B => C): (F[C], F[C]) =
     fa.map(f).map(g) -> fa.map(g compose f)
+}
+
+object FunctorLaws {
+  def apply[F[_]](implicit ev: Functor[F]): FunctorLaws[F] =
+    new FunctorLaws[F] { def F = ev }
 }

--- a/laws/src/main/scala/cats/laws/InvariantLaws.scala
+++ b/laws/src/main/scala/cats/laws/InvariantLaws.scala
@@ -6,10 +6,17 @@ import cats.syntax.invariant._
 /**
  * Laws that must be obeyed by any [[cats.functor.Invariant]].
  */
-class InvariantLaws[F[_]](implicit F: Invariant[F]) {
+trait InvariantLaws[F[_]] {
+  implicit def F: Invariant[F]
+
   def invariantIdentity[A](fa: F[A]): (F[A], F[A]) =
     fa.imap(identity[A])(identity[A]) -> fa
 
   def invariantComposition[A, B, C](fa: F[A], f1: A => B, f2: B => A, g1: B => C, g2: C => B): (F[C], F[C]) =
     fa.imap(f1)(f2).imap(g1)(g2) -> fa.imap(g1 compose f1)(f2 compose g2)
+}
+
+object InvariantLaws {
+  def apply[F[_]](implicit ev: Invariant[F]): InvariantLaws[F] =
+    new InvariantLaws[F] { def F = ev }
 }

--- a/laws/src/main/scala/cats/laws/InvariantLaws.scala
+++ b/laws/src/main/scala/cats/laws/InvariantLaws.scala
@@ -11,5 +11,5 @@ class InvariantLaws[F[_]](implicit F: Invariant[F]) {
     fa.imap(identity[A])(identity[A]) -> fa
 
   def invariantComposition[A, B, C](fa: F[A], f1: A => B, f2: B => A, g1: B => C, g2: C => B): (F[C], F[C]) =
-    fa.imap(f1)(f2).imap(g1)(g2) -> fa.imap(f1 andThen g1)(g2 andThen f2)
+    fa.imap(f1)(f2).imap(g1)(g2) -> fa.imap(g1 compose f1)(f2 compose g2)
 }

--- a/laws/src/main/scala/cats/laws/MonadLaws.scala
+++ b/laws/src/main/scala/cats/laws/MonadLaws.scala
@@ -7,7 +7,9 @@ import cats.syntax.flatMap._
 /**
  * Laws that must be obeyed by any [[Monad]].
  */
-class MonadLaws[F[_]](implicit F: Monad[F]) extends FlatMapLaws[F] {
+trait MonadLaws[F[_]] extends ApplicativeLaws[F] with FlatMapLaws[F] {
+  implicit override def F: Monad[F]
+
   def monadLeftIdentity[A, B](a: A, f: A => F[B]): (F[B], F[B]) =
     F.pure(a).flatMap(f) -> f(a)
 
@@ -27,4 +29,9 @@ class MonadLaws[F[_]](implicit F: Monad[F]) extends FlatMapLaws[F] {
    */
   def kleisliRightIdentity[A, B](a: A, f: A => F[B]): (F[B], F[B]) =
     (Kleisli(f) compose Kleisli(F.pure[A])).run(a) -> f(a)
+}
+
+object MonadLaws {
+  def apply[F[_]](implicit ev: Monad[F]): MonadLaws[F] =
+    new MonadLaws[F] { def F = ev }
 }

--- a/laws/src/main/scala/cats/laws/MonadLaws.scala
+++ b/laws/src/main/scala/cats/laws/MonadLaws.scala
@@ -1,0 +1,30 @@
+package cats.laws
+
+import cats.Monad
+import cats.arrow.Kleisli
+import cats.syntax.flatMap._
+
+/**
+ * Laws that must be obeyed by any [[Monad]].
+ */
+class MonadLaws[F[_]](implicit F: Monad[F]) extends FlatMapLaws[F] {
+  def monadLeftIdentity[A, B](a: A, f: A => F[B]): (F[B], F[B]) =
+    F.pure(a).flatMap(f) -> f(a)
+
+  def monadRightIdentity[A](fa: F[A]): (F[A], F[A]) =
+    fa.flatMap(F.pure) -> fa
+
+  /**
+   * `pure` is the left identity element under composition of
+   * [[cats.arrow.Kleisli]] arrows. This is analogous to [[monadLeftIdentity]].
+   */
+  def kleisliLeftIdentity[A, B](a: A, f: A => F[B]): (F[B], F[B]) =
+    (Kleisli(F.pure[B]) compose Kleisli(f)).run(a) -> f(a)
+
+  /**
+   * `pure` is the right identity element under composition of
+   * [[cats.arrow.Kleisli]] arrows. This is analogous to [[monadRightIdentity]].
+   */
+  def kleisliRightIdentity[A, B](a: A, f: A => F[B]): (F[B], F[B]) =
+    (Kleisli(f) compose Kleisli(F.pure[A])).run(a) -> f(a)
+}

--- a/laws/src/main/scala/cats/laws/MonadLaws.scala
+++ b/laws/src/main/scala/cats/laws/MonadLaws.scala
@@ -21,14 +21,14 @@ trait MonadLaws[F[_]] extends ApplicativeLaws[F] with FlatMapLaws[F] {
    * [[cats.arrow.Kleisli]] arrows. This is analogous to [[monadLeftIdentity]].
    */
   def kleisliLeftIdentity[A, B](a: A, f: A => F[B]): (F[B], F[B]) =
-    (Kleisli(F.pure[B]) compose Kleisli(f)).run(a) -> f(a)
+    (Kleisli(F.pure[A]) andThen Kleisli(f)).run(a) -> f(a)
 
   /**
    * `pure` is the right identity element under composition of
    * [[cats.arrow.Kleisli]] arrows. This is analogous to [[monadRightIdentity]].
    */
   def kleisliRightIdentity[A, B](a: A, f: A => F[B]): (F[B], F[B]) =
-    (Kleisli(f) compose Kleisli(F.pure[A])).run(a) -> f(a)
+    (Kleisli(f) andThen Kleisli(F.pure[B])).run(a) -> f(a)
 }
 
 object MonadLaws {

--- a/laws/src/main/scala/cats/laws/ProfunctorLaws.scala
+++ b/laws/src/main/scala/cats/laws/ProfunctorLaws.scala
@@ -6,7 +6,9 @@ import cats.syntax.profunctor._
 /**
  * Laws that must be obeyed by any [[cats.functor.Profunctor]].
  */
-class ProfunctorLaws[F[_, _]](implicit F: Profunctor[F]) {
+trait ProfunctorLaws[F[_, _]] {
+  implicit def F: Profunctor[F]
+
   def profunctorIdentity[A, B](fab: F[A, B]): (F[A, B], F[A, B]) =
     fab.dimap(identity[A])(identity[B]) -> fab
 
@@ -14,4 +16,9 @@ class ProfunctorLaws[F[_, _]](implicit F: Profunctor[F]) {
                                                     f2: A2 => A1, f1: A1 => A0,
                                                     g1: B0 => B1, g2: B1 => B2): (F[A2, B2], F[A2, B2]) =
     fab.dimap(f1)(g1).dimap(f2)(g2) -> fab.dimap(f1 compose f2)(g2 compose g1)
+}
+
+object ProfunctorLaws {
+  def apply[F[_, _]](implicit ev: Profunctor[F]): ProfunctorLaws[F] =
+    new ProfunctorLaws[F] { def F = ev }
 }

--- a/laws/src/main/scala/cats/laws/discipline/ComonadTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/ComonadTests.scala
@@ -27,7 +27,7 @@ trait ComonadTests[F[_], A, B] extends Laws {
   implicit def ArbFB: Arbitrary[F[B]] = ArbF.synthesize[B](ArbB)
 
   def coflatmap[C: Arbitrary](implicit F: CoFlatMap[F], FC: Eq[F[C]]) = {
-    val laws = new CoFlatMapLaws[F]
+    val laws = CoFlatMapLaws[F]
     new ComonadProperties(
       name = "coflatmap",
       parents = Nil,
@@ -39,7 +39,7 @@ trait ComonadTests[F[_], A, B] extends Laws {
   }
 
   def comonad[C: Arbitrary](implicit F: Comonad[F], FC: Eq[F[C]], B: Eq[B]) = {
-    val laws = new ComonadLaws[F]
+    val laws = ComonadLaws[F]
     new ComonadProperties(
       name = "comonad",
       parents = Seq(coflatmap[C]),

--- a/laws/src/main/scala/cats/laws/discipline/FunctorTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/FunctorTests.scala
@@ -25,7 +25,7 @@ trait FunctorTests[F[_], A] extends Laws {
   implicit def ArbFA: Arbitrary[F[A]] = ArbF.synthesize[A](ArbA)
 
   def invariant[B: Arbitrary, C: Arbitrary](implicit F: Invariant[F], FC: Eq[F[C]]) = {
-    val laws = new InvariantLaws[F]
+    val laws = InvariantLaws[F]
     new FunctorProperties(
       name = "functor",
       parents = Nil,
@@ -40,7 +40,7 @@ trait FunctorTests[F[_], A] extends Laws {
   }
 
   def covariant[B: Arbitrary, C: Arbitrary](implicit F: Functor[F], FC: Eq[F[C]]) = {
-    val laws = new FunctorLaws[F]
+    val laws = FunctorLaws[F]
     new FunctorProperties(
       name = "functor",
       parents = Seq(invariant[B, C]),
@@ -57,7 +57,7 @@ trait FunctorTests[F[_], A] extends Laws {
   def apply[B: Arbitrary, C: Arbitrary](implicit F: Apply[F], FC: Eq[F[C]]) = {
     implicit val ArbFAB: Arbitrary[F[A => B]] = ArbF.synthesize[A => B]
     implicit val ArbFBC: Arbitrary[F[B => C]] = ArbF.synthesize[B => C]
-    val laws = new ApplyLaws[F]
+    val laws = ApplyLaws[F]
     new FunctorProperties(
       name = "apply",
       parents = Seq(covariant[B, C]),
@@ -76,7 +76,7 @@ trait FunctorTests[F[_], A] extends Laws {
     implicit val ArbFAC: Arbitrary[F[A => C]] = ArbF.synthesize[A => C]
     implicit val ArbFAB: Arbitrary[F[A => B]] = ArbF.synthesize[A => B]
     implicit val ArbFBC: Arbitrary[F[B => C]] = ArbF.synthesize[B => C]
-    val laws = new ApplicativeLaws[F]
+    val laws = ApplicativeLaws[F]
     new FunctorProperties(
       name = "applicative",
       parents = Seq(apply[B, C]),


### PR DESCRIPTION
This one adds `MonadLaws`. In order to let `MonadLaws` inherit laws from both `ApplicativeLaws` and `FlatMapLaws`, I reorganized the laws into traits instead of classes. I also added corresponding companion objects with a single `apply` method to create `Laws` instances more easily.