### PR TITLE
Add Group instances for numbers.

### DIFF
--- a/core/src/main/scala/cats/Show.scala
+++ b/core/src/main/scala/cats/Show.scala
@@ -26,4 +26,7 @@ object Show {
       show[B](fa.show _ compose f)
   }
 
+  class ToStringShow[A] extends Show[A] {
+    def show(a: A): String = a.toString
+  }
 }

--- a/std/src/main/scala/cats/std/anyval.scala
+++ b/std/src/main/scala/cats/std/anyval.scala
@@ -1,6 +1,9 @@
 package cats
 package std
 
+import algebra.CommutativeGroup
+import algebra.ring.AdditiveCommutativeGroup
+
 trait AnyValInstances
   extends IntInstances
   with    ByteInstances
@@ -14,72 +17,127 @@ trait AnyValInstances
 
 trait IntInstances extends algebra.std.IntInstances {
 
-  implicit val intShow: Show[Int] = new Show[Int] {
-    def show(f: Int): String = f.toString
-  }
+  implicit val intShow: Show[Int] =
+    new Show.ToStringShow[Int]
+
+  implicit val intGroup: CommutativeGroup[Int] =
+    AdditiveCommutativeGroup[Int].additive
 
 }
 
 trait ByteInstances /* missing algebra typeclasses */ {
 
-  implicit val byteShow: Show[Byte] = new Show[Byte] {
-    def show(f: Byte): String = f.toString
-  }
+  implicit val byteShow: Show[Byte] =
+    new Show.ToStringShow[Byte]
 
+  // TODO: replace this minimal algebra with one from the algebra project
+  implicit val byteAlgebra: CommutativeGroup[Byte] with Order[Byte] =
+    new CommutativeGroup[Byte] with Order[Byte] {
+      def combine(x: Byte, y: Byte): Byte = (x + y).toByte
+      def empty: Byte = 0
+      def inverse(x: Byte): Byte = (-x).toByte
+      def compare(x: Byte, y: Byte): Int =
+        if (x < y) -1 else if (y < x) 1 else 0
+    }
 }
 
 trait CharInstances /* missing algebra typeclasses */ {
 
-  implicit val charShow: Show[Char] = new Show[Char] {
-    def show(f: Char): String = f.toString
-  }
+  implicit val charShow: Show[Char] =
+    new Show.ToStringShow[Char]
 
+  implicit val charOrder: Order[Char] =
+    new Order[Char] {
+      def compare(x: Char, y: Char): Int =
+        if (x < y) -1 else if (y < x) 1 else 0
+    }
 }
 
 trait ShortInstances /* missing algebra typeclasses */ {
 
-  implicit val shortShow: Show[Short] = new Show[Short] {
-    def show(f: Short): String = f.toString
-  }
+  implicit val shortShow: Show[Short] =
+    new Show.ToStringShow[Short]
+
+  // TODO: replace this minimal algebra with one from the algebra project
+  implicit val shortAlgebra: CommutativeGroup[Short] with Order[Short] =
+    new CommutativeGroup[Short] with Order[Short] {
+      def combine(x: Short, y: Short): Short = (x + y).toShort
+      def empty: Short = 0
+      def inverse(x: Short): Short = (-x).toShort
+      def compare(x: Short, y: Short): Int =
+        if (x < y) -1 else if (y < x) 1 else 0
+    }
 
 }
 
 trait LongInstances /* missing algebra typeclasses */ {
 
-  implicit val longShow: Show[Long] = new Show[Long] {
-    def show(f: Long): String = f.toString
-  }
+  implicit val longShow: Show[Long] =
+    new Show.ToStringShow[Long]
 
+  // TODO: replace this minimal algebra with one from the algebra project
+  implicit val longAlgebra: CommutativeGroup[Long] with Order[Long] =
+    new CommutativeGroup[Long] with Order[Long] {
+      def combine(x: Long, y: Long): Long = x + y
+      def empty: Long = 0L
+      def inverse(x: Long): Long = -x
+      def compare(x: Long, y: Long): Int =
+        if (x < y) -1 else if (y < x) 1 else 0
+    }
 }
 
 trait FloatInstances /* missing algebra typeclasses */ {
 
-  implicit val floatShow: Show[Float] = new Show[Float] {
-    def show(f: Float): String = f.toString
-  }
+  implicit val floatShow: Show[Float] =
+    new Show.ToStringShow[Float]
+
+  // TODO: replace this minimal algebra with one from the algebra project
+  implicit val floatAlgebra: CommutativeGroup[Float] with Order[Float] =
+    new CommutativeGroup[Float] with Order[Float] {
+      def combine(x: Float, y: Float): Float = x + y
+      def empty: Float = 1F
+      def inverse(x: Float): Float = -x
+      def compare(x: Float, y: Float): Int =
+        java.lang.Float.compare(x, y)
+    }
 
 }
 
 trait DoubleInstances /* missing algebra typeclasses */ {
 
-  implicit val doubleShow: Show[Double] = new Show[Double] {
-    def show(f: Double): String = f.toString
-  }
+  implicit val doubleShow: Show[Double] =
+    new Show.ToStringShow[Double]
+
+  // TODO: replace this minimal algebra with one from the algebra project
+  implicit val doubleAlgebra: CommutativeGroup[Double] with Order[Double] =
+    new CommutativeGroup[Double] with Order[Double] {
+      def combine(x: Double, y: Double): Double = x + y
+      def empty: Double = 1D
+      def inverse(x: Double): Double = -x
+      def compare(x: Double, y: Double): Int =
+        java.lang.Double.compare(x, y)
+    }
 
 }
 
 trait BooleanInstances extends algebra.std.BooleanInstances {
 
-  implicit val booleanShow: Show[Boolean] = new Show[Boolean] {
-    def show(f: Boolean): String = f.toString
-  }
+  implicit val booleanShow: Show[Boolean] =
+    new Show.ToStringShow[Boolean]
 
 }
 
 trait UnitInstances /* missing algebra typeclasses */ {
 
-  implicit val unitShow: Show[Unit] = new Show[Unit] {
-    def show(f: Unit): String = ().toString
-  }
+  implicit val unitShow: Show[Unit] =
+    new Show.ToStringShow[Unit]
+
+  implicit val unitAlgebra: CommutativeGroup[Unit] with Order[Unit] =
+    new CommutativeGroup[Unit] with Order[Unit] {
+      def combine(x: Unit, y: Unit): Unit = ()
+      def empty: Unit = ()
+      def inverse(x: Unit): Unit = ()
+      def compare(x: Unit, y: Unit): Int = 0
+    }
 
 }

--- a/std/src/main/scala/cats/std/bigDecimal.scala
+++ b/std/src/main/scala/cats/std/bigDecimal.scala
@@ -2,7 +2,6 @@ package cats
 package std
 
 trait BigDecimalInstances {
-  implicit val bigDecimalShow: Show[BigDecimal] = new Show[BigDecimal] {
-    def show(f: BigDecimal): String = f.toString
-  }
+  implicit val bigDecimalShow: Show[BigDecimal] =
+    new Show.ToStringShow[BigDecimal]
 }

--- a/std/src/main/scala/cats/std/bigInt.scala
+++ b/std/src/main/scala/cats/std/bigInt.scala
@@ -2,7 +2,6 @@ package cats
 package std
 
 trait BigIntInstances extends algebra.std.BigIntInstances {
-  implicit val bigIntShow: Show[BigInt] = new Show[BigInt] {
-    def show(f: BigInt): String = f.toString
-  }
+  implicit val bigIntShow: Show[BigInt] =
+    new Show.ToStringShow[BigInt]
 }

--- a/std/src/main/scala/cats/std/string.scala
+++ b/std/src/main/scala/cats/std/string.scala
@@ -2,9 +2,6 @@ package cats
 package std
 
 trait StringInstances extends algebra.std.StringInstances {
-
-  implicit val stringShow: Show[String] = new Show[String] {
-    def show(s: String): String = s
-  }
-
+  implicit val stringShow: Show[String] =
+    new Show.ToStringShow[String]
 }


### PR DESCRIPTION
In the long run Algebra will provide these instances,
but the situation right now is complex, so we will
paper things over here in Cats-land.

It also introduces a Show.ToStringShow[A] class that
can be used to provide Show[A] instances for concrete
types (this replaces many boilerplate definitions).