### PR TITLE
Change top, aggregating project id to cats.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -89,7 +89,7 @@ lazy val macros = project
   .settings(catsSettings: _*)
 
 lazy val core = project.dependsOn(macros)
-  .settings(moduleName := "cats")
+  .settings(moduleName := "cats-core")
   .settings(catsSettings: _*)
 
 lazy val laws = project.dependsOn(macros, core, data)

--- a/build.sbt
+++ b/build.sbt
@@ -78,7 +78,7 @@ lazy val docs = project
   .settings(tutSettings: _*)
   .dependsOn(core)
 
-lazy val aggregate = project.in(file("."))
+lazy val cats = project.in(file("."))
   .settings(catsSettings: _*)
   .settings(noPublishSettings: _*)
   .aggregate(macros, core, laws, tests, docs, data, std, bench)

--- a/build.sbt
+++ b/build.sbt
@@ -82,7 +82,6 @@ lazy val cats = project.in(file("."))
   .settings(catsSettings: _*)
   .settings(noPublishSettings: _*)
   .aggregate(macros, core, laws, tests, docs, data, std, bench)
-  .dependsOn(macros, core, laws, tests, docs, data, std, bench)
 
 lazy val macros = project
   .settings(moduleName := "cats-macros")

--- a/build.sbt
+++ b/build.sbt
@@ -82,6 +82,7 @@ lazy val cats = project.in(file("."))
   .settings(catsSettings: _*)
   .settings(noPublishSettings: _*)
   .aggregate(macros, core, laws, tests, docs, data, std, bench)
+  .dependsOn(macros, core, laws, tests, docs, data, std, bench)
 
 lazy val macros = project
   .settings(moduleName := "cats-macros")


### PR DESCRIPTION
My initial motive is so that's what it reads in IntelliJ, but it's also
(possibly) nicer for certain commands in the sbt shell.