### PR TITLE
Minor laws cleanup

### DIFF
--- a/laws/src/main/scala/cats/laws/ApplicativeLaws.scala
+++ b/laws/src/main/scala/cats/laws/ApplicativeLaws.scala
@@ -23,9 +23,9 @@ trait ApplicativeLaws[F[_]] extends ApplyLaws[F] {
     fa.map(f) <-> fa.apply(F.pure(f))
 
   /**
-   * This law is [[applyComposition]] stated in terms of [[Applicative.pure]].
-   * It is a combination of [[applyComposition]] and [[applicativeMap]] and
-   * hence not strictly necessary.
+   * This law is [[applyComposition]] stated in terms of `pure`. It is a
+   * combination of [[applyComposition]] and [[applicativeMap]] and hence not
+   * strictly necessary.
    */
   def applicativeComposition[A, B, C](fa: F[A], fab: F[A => B], fbc: F[B => C]): IsEq[F[C]] = {
     val compose: (B => C) => (A => B) => (A => C) = _.compose

--- a/laws/src/main/scala/cats/laws/CoflatMapLaws.scala
+++ b/laws/src/main/scala/cats/laws/CoflatMapLaws.scala
@@ -15,11 +15,11 @@ trait CoflatMapLaws[F[_]] extends FunctorLaws[F] {
 
   /**
    * The composition of [[cats.data.Cokleisli]] arrows is associative. This is
-   * analogous to the associativity law of [[CoflatMap.coflatMap]].
+   * analogous to [[coflatMapAssociativity]].
    */
   def cokleisliAssociativity[A, B, C, D](f: F[A] => B, g: F[B] => C, h: F[C] => D, fa: F[A]): IsEq[D] = {
     val (cf, cg, ch) = (Cokleisli(f), Cokleisli(g), Cokleisli(h))
-    ((ch compose cg) compose cf).run(fa) <-> (ch compose (cg compose cf)).run(fa)
+    ((cf andThen cg) andThen ch).run(fa) <-> (cf andThen (cg andThen ch)).run(fa)
   }
 }
 

--- a/laws/src/main/scala/cats/laws/ComonadLaws.scala
+++ b/laws/src/main/scala/cats/laws/ComonadLaws.scala
@@ -1,6 +1,7 @@
 package cats.laws
 
 import cats.Comonad
+import cats.data.Cokleisli
 import cats.syntax.coflatMap._
 import cats.syntax.comonad._
 
@@ -15,6 +16,20 @@ trait ComonadLaws[F[_]] extends CoflatMapLaws[F] {
 
   def comonadRightIdentity[A, B](fa: F[A], f: F[A] => B): IsEq[B] =
     fa.coflatMap(f).extract <-> f(fa)
+
+  /**
+   * `extract` is the left identity element under left-to-right composition of
+   * [[cats.data.Cokleisli]] arrows. This is analogous to [[comonadLeftIdentity]].
+   */
+  def cokleisliLeftIdentity[A, B](fa: F[A], f: F[A] => B): IsEq[B] =
+    (Cokleisli(F.extract[A]) andThen Cokleisli(f)).run(fa) <-> f(fa)
+
+  /**
+   * `extract` is the right identity element under left-to-right composition of
+   * [[cats.data.Cokleisli]] arrows. This is analogous to [[comonadRightIdentity]].
+   */
+  def cokleisliRightIdentity[A, B](fa: F[A], f: F[A] => B): IsEq[B] =
+    (Cokleisli(f) andThen Cokleisli(F.extract[B])).run(fa) <-> f(fa)
 }
 
 object ComonadLaws {

--- a/laws/src/main/scala/cats/laws/ComposeLaws.scala
+++ b/laws/src/main/scala/cats/laws/ComposeLaws.scala
@@ -3,11 +3,14 @@ package cats.laws
 import cats.arrow.Compose
 import cats.syntax.compose._
 
+/**
+ * Laws that must be obeyed by any [[cats.arrow.Compose]].
+ */
 trait ComposeLaws[F[_, _]] {
   implicit def F: Compose[F]
 
-  def composeAssociativity[A, B, C, D](fab: F[A, B], fbc: F[B, C], fcd: F[C, D]): (F[A, D], F[A, D]) =
-    ((fab andThen fbc) andThen fcd) -> (fab andThen (fbc andThen fcd))
+  def composeAssociativity[A, B, C, D](fab: F[A, B], fbc: F[B, C], fcd: F[C, D]): IsEq[F[A, D]] =
+    ((fab andThen fbc) andThen fcd) <-> (fab andThen (fbc andThen fcd))
 }
 
 object ComposeLaws {

--- a/laws/src/main/scala/cats/laws/FlatMapLaws.scala
+++ b/laws/src/main/scala/cats/laws/FlatMapLaws.scala
@@ -20,11 +20,11 @@ trait FlatMapLaws[F[_]] extends ApplyLaws[F] {
 
   /**
    * The composition of [[cats.data.Kleisli]] arrows is associative. This is
-   * analogous to the associativity law of [[FlatMap.flatMap]].
+   * analogous to [[flatMapAssociativity]].
    */
   def kleisliAssociativity[A, B, C, D](f: A => F[B], g: B => F[C], h: C => F[D], a: A): IsEq[F[D]] = {
     val (kf, kg, kh) = (Kleisli(f), Kleisli(g), Kleisli(h))
-    (kh compose (kg compose kf)).run(a) <-> ((kh compose kg) compose kf).run(a)
+    ((kf andThen kg) andThen kh).run(a) <-> (kf andThen (kg andThen kh)).run(a)
   }
 }
 

--- a/laws/src/main/scala/cats/laws/FunctorLaws.scala
+++ b/laws/src/main/scala/cats/laws/FunctorLaws.scala
@@ -13,7 +13,7 @@ trait FunctorLaws[F[_]] extends InvariantLaws[F] {
     fa.map(identity) <-> fa
 
   def covariantComposition[A, B, C](fa: F[A], f: A => B, g: B => C): IsEq[F[C]] =
-    fa.map(f).map(g) <-> fa.map(g compose f)
+    fa.map(f).map(g) <-> fa.map(f andThen g)
 }
 
 object FunctorLaws {

--- a/laws/src/main/scala/cats/laws/MonadLaws.scala
+++ b/laws/src/main/scala/cats/laws/MonadLaws.scala
@@ -17,14 +17,14 @@ trait MonadLaws[F[_]] extends ApplicativeLaws[F] with FlatMapLaws[F] {
     fa.flatMap(F.pure) <-> fa
 
   /**
-   * `pure` is the left identity element under composition of
+   * `pure` is the left identity element under left-to-right composition of
    * [[cats.data.Kleisli]] arrows. This is analogous to [[monadLeftIdentity]].
    */
   def kleisliLeftIdentity[A, B](a: A, f: A => F[B]): IsEq[F[B]] =
     (Kleisli(F.pure[A]) andThen Kleisli(f)).run(a) <-> f(a)
 
   /**
-   * `pure` is the right identity element under composition of
+   * `pure` is the right identity element under left-to-right composition of
    * [[cats.data.Kleisli]] arrows. This is analogous to [[monadRightIdentity]].
    */
   def kleisliRightIdentity[A, B](a: A, f: A => F[B]): IsEq[F[B]] =


### PR DESCRIPTION
This changes some minor stuff in the laws:
 * use `andThen` in associativity laws since I think they are easier to read
   with left-to-right composition
 * add the Comonad identity laws with Cokleisli; analogous to the Monad
   identity laws with Kleisli
 * use IsEq in ComposeLaws
 * link consistently to other laws with Scaladoc links