### PR TITLE
Split discipline tests and add FlatMap and MonadTests

### DIFF
--- a/laws/src/main/scala/cats/laws/discipline/ApplicativeTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/ApplicativeTests.scala
@@ -1,0 +1,37 @@
+package cats.laws
+package discipline
+
+import cats.{Applicative, Eq}
+import org.scalacheck.Arbitrary
+import org.scalacheck.Prop._
+
+trait ApplicativeTests[F[_]] extends ApplyTests[F] {
+  def laws: ApplicativeLaws[F]
+
+  def applicative[A: Arbitrary, B: Arbitrary, C: Arbitrary](implicit
+    ArbF: ArbitraryK[F],
+    EqFA: Eq[F[A]],
+    EqFB: Eq[F[B]],
+    EqFC: Eq[F[C]]
+  ): RuleSet = {
+    implicit def ArbFA: Arbitrary[F[A]] = ArbF.synthesize[A]
+    implicit def ArbFAB: Arbitrary[F[A => B]] = ArbF.synthesize[A => B]
+
+    new RuleSet {
+      def name = "applicative"
+      def bases = Nil
+      def parents = Seq(apply[A, B, C])
+      def props = Seq(
+        "applicative identity" -> forAll(laws.applicativeIdentity[A] _),
+        "applicative homomorphism" -> forAll(laws.applicativeHomomorphism[A, B] _),
+        "applicative interchange" -> forAll(laws.applicativeInterchange[A, B] _),
+        "applicative map" -> forAll(laws.applicativeMap[A, B] _)
+      )
+    }
+  }
+}
+
+object ApplicativeTests {
+  def apply[F[_]: Applicative]: ApplicativeTests[F] =
+    new ApplicativeTests[F] { def laws = ApplicativeLaws[F] }
+}

--- a/laws/src/main/scala/cats/laws/discipline/ApplyTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/ApplyTests.scala
@@ -1,0 +1,34 @@
+package cats.laws
+package discipline
+
+import cats.{Apply, Eq}
+import org.scalacheck.Arbitrary
+import org.scalacheck.Prop._
+
+trait ApplyTests[F[_]] extends FunctorTests[F] {
+  def laws: ApplyLaws[F]
+
+  def apply[A: Arbitrary, B: Arbitrary, C: Arbitrary](implicit
+    ArbF: ArbitraryK[F],
+    EqFA: Eq[F[A]],
+    EqFC: Eq[F[C]]
+  ): RuleSet = {
+    implicit def ArbFA: Arbitrary[F[A]] = ArbF.synthesize[A]
+    implicit def ArbFAB: Arbitrary[F[A => B]] = ArbF.synthesize[A => B]
+    implicit def ArbFBC: Arbitrary[F[B => C]] = ArbF.synthesize[B => C]
+
+    new RuleSet {
+      def name = "apply"
+      def bases = Nil
+      def parents = Seq(functor[A, B, C])
+      def props = Seq(
+        "apply composition" -> forAll(laws.applyComposition[A, B, C] _)
+      )
+    }
+  }
+}
+
+object ApplyTests {
+  def apply[F[_]: Apply]: ApplyTests[F] =
+    new ApplyTests[F] { def laws = ApplyLaws[F] }
+}

--- a/laws/src/main/scala/cats/laws/discipline/CoflatMapTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/CoflatMapTests.scala
@@ -1,0 +1,33 @@
+package cats.laws
+package discipline
+
+import cats.{CoflatMap, Eq}
+import org.scalacheck.Arbitrary
+import org.scalacheck.Prop._
+import org.typelevel.discipline.Laws
+
+trait CoflatMapTests[F[_]] extends Laws {
+  def laws: CoflatMapLaws[F]
+
+  def coflatMap[A: Arbitrary, B: Arbitrary, C: Arbitrary](implicit
+    ArbF: ArbitraryK[F],
+    EqFA: Eq[F[A]],
+    EqFC: Eq[F[C]]
+  ): RuleSet = {
+    implicit def ArbFA: Arbitrary[F[A]] = ArbF.synthesize[A]
+
+    new RuleSet {
+      def name = "coflatMap"
+      def bases = Nil
+      def parents = Nil
+      def props = Seq(
+        "coflatMap associativity" -> forAll(laws.coflatMapAssociativity[A, B, C] _)
+      )
+    }
+  }
+}
+
+object CoflatMapTests {
+  def apply[F[_]: CoflatMap]: CoflatMapTests[F] =
+    new CoflatMapTests[F] { def laws = CoflatMapLaws[F] }
+}

--- a/laws/src/main/scala/cats/laws/discipline/ComonadTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/ComonadTests.scala
@@ -1,52 +1,34 @@
-package cats.laws.discipline
+package cats.laws
+package discipline
 
-import cats._
-import cats.laws.{CoflatMapLaws, ComonadLaws}
+import cats.{Comonad, Eq}
+import org.scalacheck.Arbitrary
 import org.scalacheck.Prop._
-import org.scalacheck.{Arbitrary, Prop}
-import org.typelevel.discipline.Laws
 
-object ComonadTests {
-  def apply[F[_]: ArbitraryK, A: Arbitrary, B: Arbitrary](implicit eqfa: Eq[F[A]]): ComonadTests[F, A, B] =
-    new ComonadTests[F, A, B] {
-      def EqFA = eqfa
-      def ArbA = implicitly[Arbitrary[A]]
-      def ArbB = implicitly[Arbitrary[B]]
-      def ArbF = implicitly[ArbitraryK[F]]
+trait ComonadTests[F[_]] extends CoflatMapTests[F] {
+  def laws: ComonadLaws[F]
+
+  def comonad[A: Arbitrary, B: Arbitrary, C: Arbitrary](implicit
+    ArbF: ArbitraryK[F],
+    EqB: Eq[B],
+    EqFA: Eq[F[A]],
+    EqFC: Eq[F[C]]
+  ): RuleSet = {
+    implicit def ArbFA: Arbitrary[F[A]] = ArbF.synthesize[A]
+
+    new RuleSet {
+      def name = "comonad"
+      def bases = Nil
+      def parents = Seq(coflatMap[A, B, C])
+      def props = Seq(
+        "comonad left identity" -> forAll(laws.comonadLeftIdentity[A] _),
+        "comonad right identity" -> forAll(laws.comonadRightIdentity[A, B] _)
+      )
     }
+  }
 }
 
-trait ComonadTests[F[_], A, B] extends Laws {
-
-  implicit def EqFA: Eq[F[A]]
-  def ArbF: ArbitraryK[F]
-  implicit def ArbA: Arbitrary[A]
-  implicit def ArbB: Arbitrary[B]
-  implicit def ArbFA: Arbitrary[F[A]] = ArbF.synthesize[A](ArbA)
-  implicit def ArbFB: Arbitrary[F[B]] = ArbF.synthesize[B](ArbB)
-
-  def coflatmap[C: Arbitrary](implicit F: CoflatMap[F], FC: Eq[F[C]]) = {
-    val laws = CoflatMapLaws[F]
-    new ComonadProperties(
-      name = "coflatMap",
-      parents = Nil,
-      "associativity" -> forAll(laws.coflatMapAssociativity[A, B, C] _))
-  }
-
-  def comonad[C: Arbitrary](implicit F: Comonad[F], FC: Eq[F[C]], B: Eq[B]) = {
-    val laws = ComonadLaws[F]
-    new ComonadProperties(
-      name = "comonad",
-      parents = Seq(coflatmap[C]),
-      "left identity" -> forAll(laws.comonadLeftIdentity[A] _),
-      "right identity" -> forAll(laws.comonadRightIdentity[A, B] _))
-  }
-
-  class ComonadProperties(
-    val name: String,
-    val parents: Seq[ComonadProperties],
-    val props: (String, Prop)*
-  ) extends RuleSet {
-    val bases = Nil
-  }
+object ComonadTests {
+  def apply[F[_]: Comonad]: ComonadTests[F] =
+    new ComonadTests[F] { def laws = ComonadLaws[F] }
 }

--- a/laws/src/main/scala/cats/laws/discipline/FlatMapTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/FlatMapTests.scala
@@ -1,0 +1,37 @@
+package cats.laws
+package discipline
+
+import cats.{Eq, FlatMap}
+import org.scalacheck.Arbitrary
+import org.scalacheck.Prop._
+
+trait FlatMapTests[F[_]] extends ApplyTests[F] {
+  def laws: FlatMapLaws[F]
+
+  def flatMap[A: Arbitrary, B: Arbitrary, C: Arbitrary](implicit
+    ArbF: ArbitraryK[F],
+    EqFA: Eq[F[A]],
+    EqFB: Eq[F[B]],
+    EqFC: Eq[F[C]]
+  ): RuleSet = {
+    implicit def ArbFA: Arbitrary[F[A]] = ArbF.synthesize[A]
+    implicit def ArbFB: Arbitrary[F[B]] = ArbF.synthesize[B]
+    implicit def ArbFC: Arbitrary[F[C]] = ArbF.synthesize[C]
+    implicit def ArbFAB: Arbitrary[F[A => B]] = ArbF.synthesize[A => B]
+
+    new RuleSet {
+      def name = "flatMap"
+      def bases = Nil
+      def parents = Seq(apply[A, B, C])
+      def props = Seq(
+        "flatMap associativity" -> forAll(laws.flatMapAssociativity[A, B, C] _),
+        "flatMap consistent apply" -> forAll(laws.flatMapConsistentApply[A, B] _)
+      )
+    }
+  }
+}
+
+object FlatMapTests {
+  def apply[F[_]: FlatMap]: FlatMapTests[F] =
+    new FlatMapTests[F] { def laws = FlatMapLaws[F] }
+}

--- a/laws/src/main/scala/cats/laws/discipline/FunctorTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/FunctorTests.scala
@@ -1,76 +1,33 @@
-package cats.laws.discipline
+package cats.laws
+package discipline
 
-import cats._
-import cats.functor._
-import cats.laws.{ApplicativeLaws, ApplyLaws, FunctorLaws, InvariantLaws}
+import cats.{Eq, Functor}
+import org.scalacheck.Arbitrary
 import org.scalacheck.Prop._
-import org.scalacheck.{Arbitrary, Prop}
-import org.typelevel.discipline.Laws
 
-object FunctorTests {
-  def apply[F[_]: ArbitraryK, A: Arbitrary](implicit eqfa: Eq[F[A]]): FunctorTests[F, A] =
-    new FunctorTests[F, A] {
-      def EqFA = eqfa
-      def ArbA = implicitly[Arbitrary[A]]
-      def ArbF = implicitly[ArbitraryK[F]]
+trait FunctorTests[F[_]] extends InvariantTests[F] {
+  def laws: FunctorLaws[F]
+
+  def functor[A: Arbitrary, B: Arbitrary, C: Arbitrary](implicit
+    ArbF: ArbitraryK[F],
+    EqFA: Eq[F[A]],
+    EqFC: Eq[F[C]]
+  ): RuleSet = {
+    implicit def ArbFA: Arbitrary[F[A]] = ArbF.synthesize[A]
+
+    new RuleSet {
+      def name = "functor"
+      def bases = Nil
+      def parents = Seq(invariant[A, B, C])
+      def props = Seq(
+        "covariant identity" -> forAll(laws.covariantIdentity[A] _),
+        "covariant composition" -> forAll(laws.covariantComposition[A, B, C] _)
+      )
     }
+  }
 }
 
-trait FunctorTests[F[_], A] extends Laws {
-
-  implicit def EqFA: Eq[F[A]]
-  def ArbF: ArbitraryK[F]
-  implicit def ArbA: Arbitrary[A]
-  implicit def ArbFA: Arbitrary[F[A]] = ArbF.synthesize[A](ArbA)
-
-  def invariant[B: Arbitrary, C: Arbitrary](implicit F: Invariant[F], FC: Eq[F[C]]) = {
-    val laws = InvariantLaws[F]
-    new FunctorProperties(
-      name = "functor",
-      parents = Nil,
-      "invariant identity" -> forAll(laws.invariantIdentity[A] _),
-      "invariant composition" -> forAll(laws.invariantComposition[A, B, C] _))
-  }
-
-  def covariant[B: Arbitrary, C: Arbitrary](implicit F: Functor[F], FC: Eq[F[C]]) = {
-    val laws = FunctorLaws[F]
-    new FunctorProperties(
-      name = "functor",
-      parents = Seq(invariant[B, C]),
-      "covariant identity" -> forAll(laws.covariantIdentity[A] _),
-      "covariant composition" -> forAll(laws.covariantComposition[A, B, C] _))
-  }
-
-  def apply[B: Arbitrary, C: Arbitrary](implicit F: Apply[F], FC: Eq[F[C]]) = {
-    implicit val ArbFAB: Arbitrary[F[A => B]] = ArbF.synthesize[A => B]
-    implicit val ArbFBC: Arbitrary[F[B => C]] = ArbF.synthesize[B => C]
-    val laws = ApplyLaws[F]
-    new FunctorProperties(
-      name = "apply",
-      parents = Seq(covariant[B, C]),
-      "apply composition" -> forAll(laws.applyComposition[A, B, C] _))
-  }
-
-  def applicative[B: Arbitrary, C: Arbitrary](implicit F: Applicative[F], FC: Eq[F[C]]) = {
-    implicit val ArbFAC: Arbitrary[F[A => C]] = ArbF.synthesize[A => C]
-    implicit val ArbFAB: Arbitrary[F[A => B]] = ArbF.synthesize[A => B]
-    implicit val ArbFBC: Arbitrary[F[B => C]] = ArbF.synthesize[B => C]
-    val laws = ApplicativeLaws[F]
-    new FunctorProperties(
-      name = "applicative",
-      parents = Seq(apply[B, C]),
-      "applicative identity" -> forAll(laws.applicativeIdentity[A] _),
-      "applicative homomorphism" -> forAll(laws.applicativeHomomorphism[A, C] _),
-      "applicative interchange" -> forAll(laws.applicativeInterchange[A, C] _),
-      "applicative map" -> forAll(laws.applicativeMap[A, C] _),
-      "applicative composition" -> forAll(laws.applicativeComposition[A, B, C] _))
-    }
-
-  class FunctorProperties(
-    val name: String,
-    val parents: Seq[FunctorProperties],
-    val props: (String, Prop)*
-  ) extends RuleSet {
-    val bases = Nil
-  }
+object FunctorTests {
+  def apply[F[_]: Functor]: FunctorTests[F] =
+    new FunctorTests[F] { def laws = FunctorLaws[F] }
 }

--- a/laws/src/main/scala/cats/laws/discipline/InvariantTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/InvariantTests.scala
@@ -1,0 +1,35 @@
+package cats.laws
+package discipline
+
+import cats.Eq
+import cats.functor.Invariant
+import org.scalacheck.Arbitrary
+import org.scalacheck.Prop._
+import org.typelevel.discipline.Laws
+
+trait InvariantTests[F[_]] extends Laws {
+  def laws: InvariantLaws[F]
+
+  def invariant[A: Arbitrary, B: Arbitrary, C: Arbitrary](implicit
+    ArbF: ArbitraryK[F],
+    EqFA: Eq[F[A]],
+    EqFC: Eq[F[C]]
+  ): RuleSet = {
+    implicit def ArbFA: Arbitrary[F[A]] = ArbF.synthesize[A]
+
+    new RuleSet {
+      def name = "invariant"
+      def bases = Nil
+      def parents = Nil
+      def props = Seq(
+        "invariant identity" -> forAll(laws.invariantIdentity[A] _),
+        "invariant composition" -> forAll(laws.invariantComposition[A, B, C] _)
+      )
+    }
+  }
+}
+
+object InvariantTests {
+  def apply[F[_]: Invariant]: InvariantTests[F] =
+    new InvariantTests[F] { def laws = InvariantLaws[F] }
+}

--- a/laws/src/main/scala/cats/laws/discipline/MonadTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/MonadTests.scala
@@ -1,0 +1,35 @@
+package cats.laws
+package discipline
+
+import cats.{Eq, Monad}
+import org.scalacheck.Arbitrary
+import org.scalacheck.Prop._
+
+trait MonadTests[F[_]] extends ApplicativeTests[F] with FlatMapTests[F] {
+  def laws: MonadLaws[F]
+
+  def monad[A: Arbitrary, B: Arbitrary, C: Arbitrary](implicit
+    ArbF: ArbitraryK[F],
+    EqFA: Eq[F[A]],
+    EqFB: Eq[F[B]],
+    EqFC: Eq[F[C]]
+  ): RuleSet = {
+    implicit def ArbFA: Arbitrary[F[A]] = ArbF.synthesize[A]
+    implicit def ArbFB: Arbitrary[F[B]] = ArbF.synthesize[B]
+
+    new RuleSet {
+      def name = "monad"
+      def bases = Nil
+      def parents = Seq(applicative[A, B, C], flatMap[A, B, C])
+      def props = Seq(
+        "monad left identity" -> forAll(laws.monadLeftIdentity[A, B] _),
+        "monad right identity" -> forAll(laws.monadRightIdentity[A] _)
+      )
+    }
+  }
+}
+
+object MonadTests {
+  def apply[F[_]: Monad]: MonadTests[F] =
+    new MonadTests[F] { def laws = MonadLaws[F] }
+}

--- a/tests/src/test/scala/cats/tests/CokleisliTests.scala
+++ b/tests/src/test/scala/cats/tests/CokleisliTests.scala
@@ -2,7 +2,7 @@ package cats.tests
 
 import algebra.Eq
 import cats.data.Cokleisli
-import cats.laws.discipline.FunctorTests
+import cats.laws.discipline.ApplicativeTests
 import cats.laws.discipline.eq._
 import cats.std.int._
 import org.scalacheck.Arbitrary
@@ -15,5 +15,5 @@ class CokleisliTests extends FunSuite with Discipline {
   implicit def cokleisliEq[F[_], A, B](implicit A: Arbitrary[F[A]], FB: Eq[B]): Eq[Cokleisli[F, A, B]] =
     Eq.by[Cokleisli[F, A, B], F[A] => B](_.run)
 
-  checkAll("Cokleisli[Option,Int, Int]", FunctorTests[Cokleisli[Option, Int, ?], Int].applicative[Int, Int])
+  checkAll("Cokleisli[Option,Int, Int]", ApplicativeTests[Cokleisli[Option, Int, ?]].applicative[Int, Int, Int])
 }

--- a/tests/src/test/scala/cats/tests/ConstTests.scala
+++ b/tests/src/test/scala/cats/tests/ConstTests.scala
@@ -1,13 +1,13 @@
 package cats.tests
 
 import cats.data.Const
-import cats.laws.discipline.FunctorTests
+import cats.laws.discipline.ApplicativeTests
 import org.scalatest.FunSuite
 import org.typelevel.discipline.scalatest.Discipline
 import algebra.std.string._
 
 class ConstTests extends FunSuite with Discipline {
 
-  checkAll("Const[String, Int]", FunctorTests[Const[String, ?], Int].applicative[Int, Int])
+  checkAll("Const[String, Int]", ApplicativeTests[Const[String, ?]].applicative[Int, Int, Int])
 
 }

--- a/tests/src/test/scala/cats/tests/FutureTests.scala
+++ b/tests/src/test/scala/cats/tests/FutureTests.scala
@@ -16,6 +16,6 @@ class FutureTests extends FunSuite with Discipline {
   implicit val eqv: Eq[Future[Int]] = futureEq(1.second)
   implicit val comonad: Comonad[Future] = futureComonad(1.second)
 
-  checkAll("Future[Int]", FunctorTests[Future, Int].applicative[Int, Int])
-  checkAll("Future[Int]", ComonadTests[Future, Int, Int].comonad[Int])
+  checkAll("Future[Int]", ApplicativeTests[Future].applicative[Int, Int, Int])
+  checkAll("Future[Int]", ComonadTests[Future].comonad[Int, Int, Int])
 }

--- a/tests/src/test/scala/cats/tests/KleisliTests.scala
+++ b/tests/src/test/scala/cats/tests/KleisliTests.scala
@@ -2,7 +2,7 @@ package cats.tests
 
 import algebra.Eq
 import cats.data.Kleisli
-import cats.laws.discipline.FunctorTests
+import cats.laws.discipline.ApplicativeTests
 import cats.laws.discipline.eq._
 import cats.std.int._
 import cats.std.option._
@@ -16,5 +16,5 @@ class KleisliTests extends FunSuite with Discipline {
   implicit def kleisliEq[F[_], A, B](implicit A: Arbitrary[A], FB: Eq[F[B]]): Eq[Kleisli[F, A, B]] =
     Eq.by[Kleisli[F, A, B], A => F[B]](_.run)
 
-  checkAll("Kleisli[Option,Int, Int]", FunctorTests[Kleisli[Option, Int, ?], Int].applicative[Int, Int])
+  checkAll("Kleisli[Option,Int, Int]", ApplicativeTests[Kleisli[Option, Int, ?]].applicative[Int, Int, Int])
 }

--- a/tests/src/test/scala/cats/tests/OrTests.scala
+++ b/tests/src/test/scala/cats/tests/OrTests.scala
@@ -2,12 +2,12 @@ package cats.tests
 
 import algebra.std.int._
 import algebra.std.string._
-import cats.laws.discipline.FunctorTests
+import cats.laws.discipline.MonadTests
 import org.scalatest.FunSuite
 import org.typelevel.discipline.scalatest.Discipline
 
 import cats.data.Or
 
 class OrTests extends FunSuite with Discipline {
-  checkAll("Or[String, Int]", FunctorTests[String Or ?, Int].applicative[Int, Int])
+  checkAll("Or[String, Int]", MonadTests[String Or ?].monad[Int, Int, Int])
 }

--- a/tests/src/test/scala/cats/tests/StdTests.scala
+++ b/tests/src/test/scala/cats/tests/StdTests.scala
@@ -1,8 +1,7 @@
 package cats.tests
 
 import algebra.laws._
-import cats.laws.discipline.FunctorTests$
-import cats.laws.discipline.{ComonadTests, FunctorTests}
+import cats.laws.discipline.{ComonadTests, MonadTests}
 import org.typelevel.discipline.scalatest.Discipline
 import org.scalatest.FunSuite
 
@@ -15,9 +14,9 @@ import cats.std.list._
 import cats.std.option._
 
 class StdTests extends FunSuite with Discipline {
-  checkAll("Function0[Int]", FunctorTests[Function0, Int].applicative[Int, Int])
-  checkAll("Function0[Int]", ComonadTests[Function0, Int, Int].comonad[Int])
-  checkAll("Option[Int]", FunctorTests[Option, Int].applicative[Int, Int])
-  checkAll("Option[String]", FunctorTests[Option, String].applicative[Int, Int])
-  checkAll("List[Int]", FunctorTests[List, Int].applicative[Int, Int])
+  checkAll("Function0[Int]", ComonadTests[Function0].comonad[Int, Int, Int])
+  checkAll("Function0[Int]", MonadTests[Function0].monad[Int, Int, Int])
+  checkAll("Option[Int]", MonadTests[Option].monad[Int, Int, Int])
+  checkAll("Option[String]", MonadTests[Option].monad[String, Int, Int])
+  checkAll("List[Int]", MonadTests[List].monad[Int, Int, Int])
 }


### PR DESCRIPTION
This adds `FlatMapTests` and `MonadTests` so that we can finally check the `FlatMap` and `Monad` laws and it splits the existing `FunctorTests` and `ComonadTests` into separate tests for each typeclass so that each typeclass has its own `Laws` and `Tests` traits. The split results in a little bit more code but IMO makes those `Tests` traits a lot clearer and I think it should now also be easier to just add another `Tests` trait.

The discipline tests are implemented similarly to those in @mpilquist's Structures 