### PR TITLE
Add laws/tests for MonadFilter

### DIFF
--- a/laws/src/main/scala/cats/laws/MonadFilterLaws.scala
+++ b/laws/src/main/scala/cats/laws/MonadFilterLaws.scala
@@ -1,0 +1,22 @@
+package cats.laws
+
+import cats.MonadFilter
+import cats.syntax.flatMap._
+
+/**
+ * Laws that must be obeyed by any [[MonadFilter]].
+ */
+trait MonadFilterLaws[F[_]] extends MonadLaws[F] {
+  implicit override def F: MonadFilter[F]
+
+  def monadFilterLeftEmpty[A, B](f: A => F[B]): IsEq[F[B]] =
+    F.empty[A].flatMap(f) <-> F.empty[B]
+
+  def monadFilterRightEmpty[A, B](fa: F[A]): IsEq[F[B]] =
+    fa.flatMap(_ => F.empty[B]) <-> F.empty[B]
+}
+
+object MonadFilterLaws {
+  def apply[F[_]](implicit ev: MonadFilter[F]): MonadFilterLaws[F] =
+    new MonadFilterLaws[F] { def F = ev }
+}

--- a/laws/src/main/scala/cats/laws/discipline/MonadFilterTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/MonadFilterTests.scala
@@ -1,0 +1,35 @@
+package cats.laws
+package discipline
+
+import cats.{Eq, MonadFilter}
+import org.scalacheck.Arbitrary
+import org.scalacheck.Prop._
+
+trait MonadFilterTests[F[_]] extends MonadTests[F] {
+  def laws: MonadFilterLaws[F]
+
+  def monadFilter[A: Arbitrary, B: Arbitrary, C: Arbitrary](implicit
+    ArbF: ArbitraryK[F],
+    EqFA: Eq[F[A]],
+    EqFB: Eq[F[B]],
+    EqFC: Eq[F[C]]
+  ): RuleSet = {
+    implicit def ArbFA: Arbitrary[F[A]] = ArbF.synthesize[A]
+    implicit def ArbFB: Arbitrary[F[B]] = ArbF.synthesize[B]
+
+    new RuleSet {
+      def name = "monadFilter"
+      def bases = Nil
+      def parents = Seq(monad[A, B, C])
+      def props = Seq(
+        "monadFilter left empty" -> forAll(laws.monadFilterLeftEmpty[A, B] _),
+        "monadFilter right empty" -> forAll(laws.monadFilterRightEmpty[A, B] _)
+      )
+    }
+  }
+}
+
+object MonadFilterTests {
+  def apply[F[_]: MonadFilter]: MonadFilterTests[F] =
+    new MonadFilterTests[F] { def laws = MonadFilterLaws[F] }
+}

--- a/tests/src/test/scala/cats/tests/StdTests.scala
+++ b/tests/src/test/scala/cats/tests/StdTests.scala
@@ -1,7 +1,8 @@
 package cats.tests
 
 import algebra.laws._
-import cats.laws.discipline.{ComonadTests, MonadTests}
+import cats.MonadFilter
+import cats.laws.discipline.{ComonadTests, MonadTests, MonadFilterTests}
 import org.typelevel.discipline.scalatest.Discipline
 import org.scalatest.FunSuite
 
@@ -16,7 +17,7 @@ import cats.std.option._
 class StdTests extends FunSuite with Discipline {
   checkAll("Function0[Int]", ComonadTests[Function0].comonad[Int, Int, Int])
   checkAll("Function0[Int]", MonadTests[Function0].monad[Int, Int, Int])
-  checkAll("Option[Int]", MonadTests[Option].monad[Int, Int, Int])
-  checkAll("Option[String]", MonadTests[Option].monad[String, Int, Int])
-  checkAll("List[Int]", MonadTests[List].monad[Int, Int, Int])
+  checkAll("Option[Int]", MonadFilterTests[Option].monadFilter[Int, Int, Int])
+  checkAll("Option[String]", MonadFilterTests[Option].monadFilter[String, Int, Int])
+  checkAll("List[Int]", MonadFilterTests[List].monadFilter[Int, Int, Int])
 }


### PR DESCRIPTION
This fixes one half of #135, namely adding laws and tests for `MonadFilter`.