### PR TITLE
Add SplitLaws, SplitTests, and SplitSyntax

### DIFF
--- a/core/src/main/scala/cats/syntax/all.scala
+++ b/core/src/main/scala/cats/syntax/all.scala
@@ -19,4 +19,5 @@ trait AllSyntax
     with ProfunctorSyntax
     with SemigroupSyntax
     with ShowSyntax
+    with SplitSyntax
     with StrongSyntax

--- a/core/src/main/scala/cats/syntax/package.scala
+++ b/core/src/main/scala/cats/syntax/package.scala
@@ -20,5 +20,6 @@ package object syntax {
   object profunctor extends ProfunctorSyntax
   object semigroup extends SemigroupSyntax
   object show extends ShowSyntax
+  object split extends SplitSyntax
   object strong extends StrongSyntax
 }

--- a/core/src/main/scala/cats/syntax/split.scala
+++ b/core/src/main/scala/cats/syntax/split.scala
@@ -1,0 +1,14 @@
+package cats
+package syntax
+
+import cats.arrow.Split
+
+trait SplitSyntax {
+  // TODO: use simulacrum instances eventually
+  implicit def splitSyntax[F[_, _]: Split, A, B](fab: F[A, B]): SplitOps[F, A, B] =
+    new SplitOps[F, A, B](fab)
+}
+
+class SplitOps[F[_, _], A, B](fab: F[A, B])(implicit F: Split[F]) {
+  def split[C, D](fcd: F[C, D]): F[(A, C), (B, D)] = F.split(fab, fcd)
+}

--- a/laws/src/main/scala/cats/laws/SplitLaws.scala
+++ b/laws/src/main/scala/cats/laws/SplitLaws.scala
@@ -1,0 +1,21 @@
+package cats.laws
+
+import cats.arrow.Split
+import cats.syntax.compose._
+import cats.syntax.split._
+
+/**
+ * Laws that must be obeyed by any [[cats.arrow.Split]].
+ */
+trait SplitLaws[F[_, _]] extends ComposeLaws[F] {
+  implicit override def F: Split[F]
+
+  def splitInterchange[A1, A2, A3, B1, B2, B3](f1: F[A1, A2], f2: F[A2, A3],
+                                               g1: F[B1, B2], g2: F[B2, B3]): IsEq[F[(A1, B1), (A3, B3)]] =
+    ((f1 split g1) andThen (f2 split g2)) <-> ((f1 andThen f2) split (g1 andThen g2))
+}
+
+object SplitLaws {
+  def apply[F[_, _]](implicit ev: Split[F]): SplitLaws[F] =
+    new SplitLaws[F] { def F = ev }
+}

--- a/laws/src/main/scala/cats/laws/discipline/Eq.scala
+++ b/laws/src/main/scala/cats/laws/discipline/Eq.scala
@@ -16,4 +16,11 @@ object eq {
       samples.forall(s => B.eqv(f(s), g(s)) )
     }
   }
+
+  implicit def tuple2Eq[A, B](implicit A: Eq[A], B: Eq[B]): Eq[(A, B)] =
+    new Eq[(A, B)] {
+      def eqv(x: (A, B), y: (A, B)): Boolean =
+        A.eqv(x._1, y._1) && B.eqv(x._2, y._2)
+    }
+
 }

--- a/laws/src/main/scala/cats/laws/discipline/SplitTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/SplitTests.scala
@@ -1,0 +1,34 @@
+package cats.laws
+package discipline
+
+import cats.Eq
+import cats.arrow.Split
+import org.scalacheck.Arbitrary
+import org.scalacheck.Prop._
+
+trait SplitTests[F[_, _]] extends ComposeTests[F] {
+  def laws: SplitLaws[F]
+
+  def split[A, B, C, D, E, G](implicit
+    ArbFAB: Arbitrary[F[A, B]],
+    ArbFBC: Arbitrary[F[B, C]],
+    ArbFCD: Arbitrary[F[C, D]],
+    ArbFDE: Arbitrary[F[D, E]],
+    ArbFEG: Arbitrary[F[E, G]],
+    EqFAD: Eq[F[A, D]],
+    EqFADCG: Eq[F[(A, D),(C, G)]]
+  ): RuleSet =
+    new RuleSet {
+      def name = "split"
+      def bases = Nil
+      def parents = Seq(compose[A, B, C, D])
+      def props = Seq(
+        "split interchange" -> forAll(laws.splitInterchange[A, B, C, D, E, G] _)
+      )
+    }
+}
+
+object SplitTests {
+  def apply[F[_, _]: Split]: SplitTests[F] =
+    new SplitTests[F] { def laws = SplitLaws[F] }
+}

--- a/tests/src/test/scala/cats/tests/FunctionTests.scala
+++ b/tests/src/test/scala/cats/tests/FunctionTests.scala
@@ -7,4 +7,5 @@ class FunctionTests extends CatsSuite {
   checkAll("Function0[Int]", ComonadTests[Function0].comonad[Int, Int, Int])
   checkAll("Function0[Int]", MonadTests[Function0].monad[Int, Int, Int])
   checkAll("Function1[Int, Int]", CategoryTests[Function1].category[Int, Int, Int, Int])
+  checkAll("Function1[Int, Int]", SplitTests[Function1].split[Int, Int, Int, Int, Int, Int])
 }


### PR DESCRIPTION
This PR adds `SplitLaws`, `SplitTests`, and `SplitSyntax`. I'm submitting this PR although I'm not totally confident that the `splitInterchange` law I've defined is sound. I just tried to relate `split` with `andThen` in a minimal fashion. I've not seen this law anywhere else and I still want to check if it can be derived from the [arrow laws](https://hackage.haskell.org/package/base-4.7.0.2/docs/Control-Arrow.html).

Anyone know where `Split` is originally coming from and which laws it should obey?