### PR TITLE
add 1.some, none[Int] sytntax

### DIFF
--- a/core/src/main/scala/cats/syntax/all.scala
+++ b/core/src/main/scala/cats/syntax/all.scala
@@ -1,7 +1,8 @@
 package cats.syntax
 
 trait AllSyntax
-    extends ApplySyntax
+    extends AnySyntax
+    with ApplySyntax
     with BifunctorSyntax
     with CoflatMapSyntax
     with ComonadSyntax
@@ -15,6 +16,7 @@ trait AllSyntax
     with MonadCombineSyntax
     with MonadFilterSyntax
     with OrderSyntax
+    with OptionSyntax
     with PartialOrderSyntax
     with ProfunctorSyntax
     with SemigroupSyntax

--- a/core/src/main/scala/cats/syntax/any.scala
+++ b/core/src/main/scala/cats/syntax/any.scala
@@ -1,0 +1,11 @@
+package cats
+package syntax
+
+trait AnySyntax {
+  implicit def anySyntax[A](a: A): AnyOps[A] =
+    new AnyOps[A](a)
+}
+
+class AnyOps[A](val a: A) extends AnyVal {
+  def some: Option[A] = Some(a)
+}

--- a/core/src/main/scala/cats/syntax/option.scala
+++ b/core/src/main/scala/cats/syntax/option.scala
@@ -1,0 +1,6 @@
+package cats
+package syntax
+
+trait OptionSyntax {
+  def none[A]: Option[A] = None
+}

--- a/core/src/main/scala/cats/syntax/package.scala
+++ b/core/src/main/scala/cats/syntax/package.scala
@@ -2,6 +2,7 @@ package cats
 
 package object syntax {
   object all extends AllSyntax
+  object any extends AnySyntax
   object apply extends ApplySyntax
   object bifunctor extends BifunctorSyntax
   object coflatMap extends CoflatMapSyntax
@@ -16,6 +17,7 @@ package object syntax {
   object monadCombine extends MonadCombineSyntax
   object monadFilter extends MonadFilterSyntax
   object order extends OrderSyntax
+  object option extends OptionSyntax
   object partialOrder extends PartialOrderSyntax
   object profunctor extends ProfunctorSyntax
   object semigroup extends SemigroupSyntax


### PR DESCRIPTION
This adds the syntax many of us are used to as scalaz users that lets us say:

    1.some
    none[Int]

in order to create values which are typed as Option instead of None/Some.