### PR TITLE
Do not let std depend on laws

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -106,7 +106,7 @@ lazy val laws = project.dependsOn(macros, core, data)
     )
   )
 
-lazy val std = project.dependsOn(macros, core, laws)
+lazy val std = project.dependsOn(macros, core)
   .settings(moduleName := "cats-std")
   .settings(catsSettings: _*)
   .settings(


### PR DESCRIPTION
It seems unnecessary to me to let `std` depend on `laws`.