### PR TITLE
Swap effect order of apply2 and map2

### DIFF
--- a/core/src/main/scala/cats/Apply.scala
+++ b/core/src/main/scala/cats/Apply.scala
@@ -19,7 +19,7 @@ trait Apply[F[_]] extends Functor[F] with ApplyArityFunctions[F] { self =>
    * apply2 is a binary version of apply, defined in terms of apply.
    */
   def apply2[A, B, Z](fa: F[A], fb: F[B])(f: F[(A, B) => Z]): F[Z] =
-    apply(fa)(apply(fb)(map(f)(f => (b: B) => (a: A) => f(a, b))))
+    apply(fb)(apply(fa)(map(f)(f => (a: A) => (b: B) => f(a, b))))
 
   /**
    * Applies the pure (binary) function f to the effectful values fa and fb.
@@ -27,7 +27,7 @@ trait Apply[F[_]] extends Functor[F] with ApplyArityFunctions[F] { self =>
    * map2 can be seen as a binary version of [[cats.Functor]]#map.
    */
   def map2[A, B, Z](fa: F[A], fb: F[B])(f: (A, B) => Z): F[Z] =
-    apply(fa)(map(fb)(b => (a: A) => f(a, b)))
+    apply(fb)(map(fa)(a => (b: B) => f(a, b)))
 
   /**
    * Two sequentially dependent Applys can be composed.

--- a/project/Boilerplate.scala
+++ b/project/Boilerplate.scala
@@ -148,7 +148,7 @@ object Boilerplate {
       def allArgs = (0 until arity) map { "a" + _ } mkString ","
 
       val map = if (arity == 3) {
-        "- apply(f0)(map2(f1, f2)((b, c) => a => f(a, b, c)))"
+        "- apply(f2)(map2(f0, f1)((a, b) => c => f(a, b, c)))"
       }  else {
         block"""
           -    map2(tuple$a($fArgsA), tuple$b($fArgsB)) {

--- a/std/src/main/scala/cats/std/list.scala
+++ b/std/src/main/scala/cats/std/list.scala
@@ -44,13 +44,10 @@ trait ListInstances {
       def foldLazy[A, B](fa: List[A], b: Lazy[B])(f: A => Fold[B]): Lazy[B] =
         Fold.iterateRight(fa, b)(f)
 
-      def traverse[G[_]: Applicative, A, B](fa: List[A])(f: A => G[B]): G[List[B]] = {
-        val G = Applicative[G]
-        val init = G.pure(ListBuffer.empty[B])
-        val gbuf = fa.foldLeft(init) { (gbuf, a) =>
-          G.map2(f(a), gbuf)((b, buf) => buf += b)
-        }
-        G.map(gbuf)(_.toList)
+      def traverse[G[_], A, B](fa: List[A])(f: A => G[B])(implicit G: Applicative[G]): G[List[B]] = {
+        val gba = G.pure(ListBuffer.empty[B])
+        val gbb = fa.foldLeft(gba)((buf, a) => G.map2(buf, f(a))(_ += _))
+        G.map(gbb)(_.toList)
       }
     }
 

--- a/tests/src/test/scala/cats/tests/RegressionTests.scala
+++ b/tests/src/test/scala/cats/tests/RegressionTests.scala
@@ -49,4 +49,20 @@ class RegressionTests extends CatsSuite {
     // ensure that side-effects occurred in "correct" order
     assert(buf.toList == names)
   }
+
+  test("#167: confirm apply2 order") {
+    val twelve = Apply[State[String, ?]].apply2(
+      State[String, Unit](s => ((), s + "1")),
+      State[String, Unit](s => ((), s + "2"))
+    )(State.instance[String].pure((_: Unit, _: Unit) => ())).run("")._2
+    assert(twelve == "12")
+  }
+
+  test("#167: confirm map2 order") {
+    val twelve = Apply[State[String, ?]].map2(
+      State[String, Unit](s => ((), s + "1")),
+      State[String, Unit](s => ((), s + "2"))
+    )((_: Unit, _: Unit) => ()).run("")._2
+    assert(twelve == "12")
+  }
 }

--- a/tests/src/test/scala/cats/tests/RegressionTests.scala
+++ b/tests/src/test/scala/cats/tests/RegressionTests.scala
@@ -65,4 +65,13 @@ class RegressionTests extends CatsSuite {
     )((_: Unit, _: Unit) => ()).run("")._2
     assert(twelve == "12")
   }
+
+  test("#167: confirm map3 order") {
+    val oneTwoThree = Apply[State[String, ?]].map3(
+      State[String, Unit](s => ((), s + "1")),
+      State[String, Unit](s => ((), s + "2")),
+      State[String, Unit](s => ((), s + "3"))
+    )((_: Unit, _: Unit, _: Unit) => ()).run("")._2
+    assert(oneTwoThree == "123")
+  }
 }


### PR DESCRIPTION
Fixes #167

I think one thing that everyone agrees on is that if we are going to
require a predictable order of effects with apply2, map2, traverse, etc
that order should be left to right.