### PR TITLE
Upgrades to sbt-pgp 1.0.0. This is recommended for sbt versions 0.13.5+

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,7 +5,7 @@ resolvers += Resolver.url(
 
 addSbtPlugin("com.eed3si9n"      % "sbt-unidoc"             % "0.3.2")
 addSbtPlugin("com.github.gseitz" % "sbt-release"            % "0.7.1")
-addSbtPlugin("com.typesafe.sbt"  % "sbt-pgp"                % "0.8")
+addSbtPlugin("com.jsuereth"      % "sbt-pgp"                % "1.0.0")
 addSbtPlugin("com.typesafe.sbt"  % "sbt-ghpages"            % "0.5.3")
 addSbtPlugin("com.typesafe.sbt"  % "sbt-site"               % "0.8.1")
 addSbtPlugin("org.tpolecat"      % "tut-plugin"             % "0.3.2")


### PR DESCRIPTION
Was there a reason `sbt-pgp` version `0.8.3` was being used? According to [the docs](http://www.scala-sbt.org/sbt-pgp/), version `1.0.0` is acceptable for sbt versions 0.13.5+, and we're on sbt version 0.13.7.

Quick background /cc @milessabin and @ceedubs 

This turned out to actually be the cause of my sbt build issues earlier today. `0.8.3` brings in `dispatch-http_2.9.1` while `1.0.0` brings in `dispatch-http_2.10`. I had a global plugin using `1.0.0`, while the cats project was using `0.8.3`. And this caused the "conflicting cross-version suffixes" sbt build issue I was seeing.