### PR TITLE
Add ArrowLaws and ArrowTests

### DIFF
--- a/laws/src/main/scala/cats/laws/ArrowLaws.scala
+++ b/laws/src/main/scala/cats/laws/ArrowLaws.scala
@@ -1,0 +1,44 @@
+package cats.laws
+
+import cats.arrow.Arrow
+import cats.std.function._
+import cats.syntax.compose._
+import cats.syntax.split._
+import cats.syntax.strong._
+
+/**
+ * Laws that must be obeyed by any [[cats.arrow.Arrow]].
+ */
+trait ArrowLaws[F[_, _]] extends CategoryLaws[F] with SplitLaws[F] with StrongLaws[F] {
+  implicit override def F: Arrow[F]
+
+  def arrowIdentity[A]: IsEq[F[A, A]] =
+    F.lift(identity[A]) <-> F.id[A]
+
+  def arrowComposition[A, B, C](f: A => B, g: B => C): IsEq[F[A, C]] =
+    F.lift(f andThen g) <-> (F.lift(f) andThen F.lift(g))
+
+  def arrowExtension[A, B, C](g: A => B): IsEq[F[(A, C), (B, C)]] =
+    F.lift(g).first[C] <-> F.lift(g split identity[C])
+
+  def arrowFunctor[A, B, C, D](f: F[A, B], g: F[B, C]): IsEq[F[(A, D), (C, D)]] =
+    (f andThen g).first[D] <-> (f.first[D] andThen g.first[D])
+
+  def arrowExchange[A, B, C, D, E](f: F[A, B], g: C => D): IsEq[F[(A, C), (B, D)]] =
+    (f.first[C] andThen F.lift(identity[B] _ split g)) <-> (F.lift(identity[A] _ split g) andThen f.first[D])
+
+  def arrowUnit[A, B, C](f: F[A, B]): IsEq[F[(A, C), B]] =
+    (f.first[C] andThen F.lift(fst[B, C])) <-> (F.lift(fst[A, C]) andThen f)
+
+  def arrowAssociation[A, B, C, D](f: F[A, B]): IsEq[F[((A, C), D), (B, (C, D))]] =
+    (f.first[C].first[D] andThen F.lift(assoc[B, C, D])) <-> (F.lift(assoc[A, C, D]) andThen f.first[(C, D)])
+
+  private def fst[A, B](p: (A, B)): A = p._1
+
+  private def assoc[A, B, C](p: ((A, B), C)): (A, (B, C)) = (p._1._1, (p._1._2, p._2))
+}
+
+object ArrowLaws {
+  def apply[F[_, _]](implicit ev: Arrow[F]): ArrowLaws[F] =
+    new ArrowLaws[F] { def F = ev }
+}

--- a/laws/src/main/scala/cats/laws/discipline/ArrowTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/ArrowTests.scala
@@ -1,0 +1,55 @@
+package cats.laws
+package discipline
+
+import cats.Eq
+import cats.arrow.Arrow
+import org.scalacheck.Arbitrary
+import org.scalacheck.Prop._
+
+trait ArrowTests[F[_, _]] extends CategoryTests[F] with SplitTests[F] with StrongTests[F] {
+  def laws: ArrowLaws[F]
+
+  def arrow[A: Arbitrary, B: Arbitrary, C: Arbitrary, D: Arbitrary, E: Arbitrary, G: Arbitrary](implicit
+    ArbFAB: Arbitrary[F[A, B]],
+    ArbFBC: Arbitrary[F[B, C]],
+    ArbFCD: Arbitrary[F[C, D]],
+    ArbFDE: Arbitrary[F[D, E]],
+    ArbFEG: Arbitrary[F[E, G]],
+    EqFAA: Eq[F[A, A]],
+    EqFAB: Eq[F[A, B]],
+    EqFAC: Eq[F[A, C]],
+    EqFAD: Eq[F[A, D]],
+    EqFAG: Eq[F[A, G]],
+    EqFACB: Eq[F[(A, C), B]],
+    EqFACBC: Eq[F[(A, C), (B, C)]],
+    EqFACBD: Eq[F[(A, C), (B, D)]],
+    EqFADCD: Eq[F[(A, D), (C, D)]],
+    EqFADCG: Eq[F[(A, D), (C, G)]],
+    EqFAEDE: Eq[F[(A, E), (D, E)]],
+    EqFEAED: Eq[F[(E, A), (E, D)]],
+    EqFACDBCD: Eq[F[((A, C), D),(B, (C, D))]]
+  ): RuleSet =
+    new RuleSet {
+      def name = "arrow"
+      def bases = Nil
+      def parents = Seq(
+        category[A, B, C, D],
+        split[A, B, C, D, E, G],
+        strong[A, B, C, D, E, G]
+      )
+      def props = Seq(
+        "arrow identity" -> laws.arrowIdentity[A],
+        "arrow composition" -> forAll(laws.arrowComposition[A, B, C] _),
+        "arrow extension" -> forAll(laws.arrowExtension[A, B, C] _),
+        "arrow functor" -> forAll(laws.arrowFunctor[A, B, C, D] _),
+        "arrow exchange" -> forAll(laws.arrowExchange[A, B, C, D, E] _),
+        "arrow unit" -> forAll(laws.arrowUnit[A, B, C] _),
+        "arrow association" -> forAll(laws.arrowAssociation[A, B, C, D] _)
+      )
+    }
+}
+
+object ArrowTests {
+  def apply[F[_, _]: Arrow]: ArrowTests[F] =
+    new ArrowTests[F] { def laws = ArrowLaws[F] }
+}

--- a/tests/src/test/scala/cats/tests/FunctionTests.scala
+++ b/tests/src/test/scala/cats/tests/FunctionTests.scala
@@ -6,7 +6,5 @@ import cats.laws.discipline.eq._
 class FunctionTests extends CatsSuite {
   checkAll("Function0[Int]", ComonadTests[Function0].comonad[Int, Int, Int])
   checkAll("Function0[Int]", MonadTests[Function0].monad[Int, Int, Int])
-  checkAll("Function1[Int, Int]", CategoryTests[Function1].category[Int, Int, Int, Int])
-  checkAll("Function1[Int, Int]", SplitTests[Function1].split[Int, Int, Int, Int, Int, Int])
-  checkAll("Function1[Int, Int]", StrongTests[Function1].strong[Int, Int, Int, Int, Int, Int])
+  checkAll("Function1[Int, Int]", ArrowTests[Function1].arrow[Int, Int, Int, Int, Int, Int])
 }


### PR DESCRIPTION
Finally, the `ArrowLaws`. The laws and their names come from http://haskell.cs.yale.edu/wp-content/uploads/2012/06/FromJFP.pdf and https://wiki.haskell.org/Typeclassopedia#Laws_7

Btw: I can't believe I'm seriously proposing to add a function with 24 implicit parameters... 