### PR TITLE
Add Arrow instance for Kleisli

### DIFF
--- a/data/src/main/scala/cats/data/Kleisli.scala
+++ b/data/src/main/scala/cats/data/Kleisli.scala
@@ -76,34 +76,8 @@ sealed trait KleisliFunctions {
 }
 
 sealed abstract class KleisliInstances extends KleisliInstances0 {
-  implicit def kleisliArrow[F[_]](implicit F: Monad[F]): Arrow[Kleisli[F, ?, ?]] = new Arrow[Kleisli[F, ?, ?]] {
-    def lift[A, B](f: A => B): Kleisli[F, A, B] =
-      Kleisli(a => F.pure(f(a)))
-
-    def id[A]: Kleisli[F, A, A] =
-      Kleisli(a => F.pure(a))
-
-    def split[A, B, C, D](f: Kleisli[F, A, B], g: Kleisli[F, C, D]): Kleisli[F, (A, C), (B, D)] =
-      Kleisli{ case (a, c) => F.flatMap(f.run(a))(b => F.map(g.run(c))(d => (b, d))) }
-
-    def compose[A, B, C](f: Kleisli[F, B, C], g: Kleisli[F, A, B]): Kleisli[F, A, C] =
-      f.compose(g)
-
-    def first[A, B, C](fa: Kleisli[F, A, B]): Kleisli[F, (A, C), (B, C)] =
-      fa.first[C]
-
-    override def second[A, B, C](fa: Kleisli[F, A, B]): Kleisli[F, (C, A), (C, B)] =
-      fa.second[C]
-
-    override def lmap[A, B, C](fab: Kleisli[F, A, B])(f: C => A): Kleisli[F, C, B] =
-      fab.lmap(f)
-
-    override def rmap[A, B, C](fab: Kleisli[F, A, B])(f: B => C): Kleisli[F, A, C] =
-      fab.map(f)
-
-    override def dimap[A, B, C, D](fab: Kleisli[F, A, B])(f: C => A)(g: B => D): Kleisli[F, C, D] =
-      fab.dimap(f)(g)
-  }
+  implicit def kleisliArrow[F[_]](implicit ev: Monad[F]): Arrow[Kleisli[F, ?, ?]] =
+    new KleisliArrow[F] { def F: Monad[F] = ev }
 
   implicit def kleisliMonad[F[_]: Monad, A]: Monad[Kleisli[F, A, ?]] = new Monad[Kleisli[F, A, ?]] {
     def pure[B](x: B): Kleisli[F, A, B] =
@@ -115,22 +89,8 @@ sealed abstract class KleisliInstances extends KleisliInstances0 {
 }
 
 sealed abstract class KleisliInstances0 extends KleisliInstances1 {
-  implicit def kleisliStrong[F[_]: Functor]: Strong[Kleisli[F, ?, ?]] = new Strong[Kleisli[F, ?, ?]]{
-    override def lmap[A, B, C](fab: Kleisli[F, A, B])(f: C => A): Kleisli[F, C, B] =
-      fab.lmap(f)
-
-    override def rmap[A, B, C](fab: Kleisli[F, A, B])(f: B => C): Kleisli[F, A, C] =
-      fab.map(f)
-
-    override def dimap[A, B, C, D](fab: Kleisli[F, A, B])(f: C => A)(g: B => D): Kleisli[F, C, D] =
-      fab.dimap(f)(g)
-
-    def first[A, B, C](fa: Kleisli[F, A, B]): Kleisli[F, (A, C), (B, C)] =
-      fa.first[C]
-
-    def second[A, B, C](fa: Kleisli[F, A, B]): Kleisli[F, (C, A), (C, B)] =
-      fa.second[C]
-  }
+  implicit def kleisliStrong[F[_]](implicit ev: Functor[F]): Strong[Kleisli[F, ?, ?]] =
+    new KleisliStrong[F] { def F: Functor[F] = ev }
 
   implicit def kleisliFlatMap[F[_]: FlatMap, A]: FlatMap[Kleisli[F, A, ?]] = new FlatMap[Kleisli[F, A, ?]] {
     def flatMap[B, C](fa: Kleisli[F, A, B])(f: B => Kleisli[F, A, C]): Kleisli[F, A, C] =
@@ -166,4 +126,42 @@ sealed abstract class KleisliInstances3 {
     def map[B, C](fa: Kleisli[F, A, B])(f: B => C): Kleisli[F, A, C] =
       fa.map(f)
   }
+}
+
+private trait KleisliArrow[F[_]] extends Arrow[Kleisli[F, ?, ?]] with KleisliStrong[F] {
+  implicit def F: Monad[F]
+
+  def lift[A, B](f: A => B): Kleisli[F, A, B] =
+    Kleisli(a => F.pure(f(a)))
+
+  def id[A]: Kleisli[F, A, A] =
+    Kleisli(a => F.pure(a))
+
+  def split[A, B, C, D](f: Kleisli[F, A, B], g: Kleisli[F, C, D]): Kleisli[F, (A, C), (B, D)] =
+    Kleisli{ case (a, c) => F.flatMap(f.run(a))(b => F.map(g.run(c))(d => (b, d))) }
+
+  def compose[A, B, C](f: Kleisli[F, B, C], g: Kleisli[F, A, B]): Kleisli[F, A, C] =
+    f.compose(g)
+
+  override def second[A, B, C](fa: Kleisli[F, A, B]): Kleisli[F, (C, A), (C, B)] =
+    super[KleisliStrong].second(fa)
+}
+
+private trait KleisliStrong[F[_]] extends Strong[Kleisli[F, ?, ?]] {
+  implicit def F: Functor[F]
+
+  override def lmap[A, B, C](fab: Kleisli[F, A, B])(f: C => A): Kleisli[F, C, B] =
+    fab.lmap(f)
+
+  override def rmap[A, B, C](fab: Kleisli[F, A, B])(f: B => C): Kleisli[F, A, C] =
+    fab.map(f)
+
+  override def dimap[A, B, C, D](fab: Kleisli[F, A, B])(f: C => A)(g: B => D): Kleisli[F, C, D] =
+    fab.dimap(f)(g)
+
+  def first[A, B, C](fa: Kleisli[F, A, B]): Kleisli[F, (A, C), (B, C)] =
+    fa.first[C]
+
+  def second[A, B, C](fa: Kleisli[F, A, B]): Kleisli[F, (C, A), (C, B)] =
+    fa.second[C]
 }

--- a/tests/src/test/scala/cats/tests/KleisliTests.scala
+++ b/tests/src/test/scala/cats/tests/KleisliTests.scala
@@ -13,5 +13,5 @@ class KleisliTests extends CatsSuite {
     Eq.by[Kleisli[F, A, B], A => F[B]](_.run)
 
   checkAll("Kleisli[Option, Int, Int]", ApplicativeTests[Kleisli[Option, Int, ?]].applicative[Int, Int, Int])
-  checkAll("Kleisli[Option, Int, Int]", StrongTests[Kleisli[Option, ?, ?]].strong[Int, Int, Int, Int, Int, Int])
+  checkAll("Kleisli[Option, Int, Int]", ArrowTests[Kleisli[Option, ?, ?]].arrow[Int, Int, Int, Int, Int, Int])
 }


### PR DESCRIPTION
This adds `Arrow[Kleisli[F, ?, ?]]` and lowers the priority of `Strong[Kleisli[F, ?, ?]]` to not have ambiguous implicits.