### PR TITLE
Updated links in applicative.md

### DIFF
--- a/docs/src/main/tut/applicative.md
+++ b/docs/src/main/tut/applicative.md
@@ -8,7 +8,7 @@ scaladoc: "#cats.Applicative"
 # Applicative
 
 Applicative functors are a simple extension of the [Apply
-functor](apply.html) which adds a single method, `pure`:
+functor](apply.md) which adds a single method, `pure`:
 
 ```scala
     def pure[A](x: A): F[A]
@@ -28,7 +28,7 @@ Applicative[Option].pure(1)
 Applicative[List].pure(1)
 ```
 
-Like [Functor](functor.html) and [Apply](apply.html), Applicative
+Like [Functor](functor.md) and [Apply](apply.md), Applicative
 functors also composes naturally with other Applicative functors. When
 you compose one Applicative with another, the resulting `pure`
 operation will lift the passed value into one context, and the result


### PR DESCRIPTION
Functor and Apply had links to non-existing .html files, which led to 404.