### PR TITLE
Add Strong instance for Cokleisli

### DIFF
--- a/data/src/main/scala/cats/data/Cokleisli.scala
+++ b/data/src/main/scala/cats/data/Cokleisli.scala
@@ -1,7 +1,7 @@
 package cats.data
 
-import cats.functor.Profunctor
-import cats.{Monad, CoflatMap, Functor}
+import cats.functor.{Profunctor, Strong}
+import cats.{CoflatMap, Comonad, Functor, Monad}
 
 final case class Cokleisli[F[_], A, B](run: F[A] => B) { self =>
 
@@ -25,6 +25,12 @@ final case class Cokleisli[F[_], A, B](run: F[A] => B) { self =>
 
   def andThen[C](c: Cokleisli[F, B, C])(implicit F: CoflatMap[F]): Cokleisli[F, A, C] =
     c compose this
+
+  def first[C](implicit F: Comonad[F]): Cokleisli[F, (A, C), (B, C)] =
+    Cokleisli(fac => run(F.map(fac)(_._1)) -> F.extract(F.map(fac)(_._2)))
+
+  def second[C](implicit F: Comonad[F]): Cokleisli[F, (C, A), (C, B)] =
+    Cokleisli(fca => F.extract(F.map(fca)(_._1)) -> run(F.map(fca)(_._2)))
 }
 
 object Cokleisli extends CokleisliInstances with CokleisliFunctions {
@@ -38,17 +44,9 @@ sealed trait CokleisliFunctions {
     Cokleisli(f)
 }
 
-sealed abstract class CokleisliInstances {
-  implicit def cokleisliProfunctor[F[_]: Functor]: Profunctor[Cokleisli[F, ?, ?]] = new Profunctor[Cokleisli[F, ?, ?]] {
-    def dimap[A, B, C, D](fab: Cokleisli[F, A, B])(f: C => A)(g: B => D): Cokleisli[F, C, D] =
-      fab.dimap(f)(g)
-
-    override def lmap[A, B, C](fab: Cokleisli[F, A, B])(f: C => A): Cokleisli[F, C, B] =
-      fab.lmap(f)
-
-    override def rmap[A, B, C](fab: Cokleisli[F, A, B])(f: B => C): Cokleisli[F, A, C] =
-      fab.map(f)
-  }
+sealed abstract class CokleisliInstances extends CokleisliInstances0 {
+  implicit def cokleisliStrong[F[_]](implicit ev: Comonad[F]): Strong[Cokleisli[F, ?, ?]] =
+    new CokleisliStrong[F] { def F: Comonad[F] = ev }
 
   implicit def cokleisliMonad[F[_], A]: Monad[Cokleisli[F, A, ?]] = new Monad[Cokleisli[F, A, ?]] {
     def pure[B](x: B): Cokleisli[F, A, B] =
@@ -60,4 +58,32 @@ sealed abstract class CokleisliInstances {
     override def map[B, C](fa: Cokleisli[F, A, B])(f: B => C): Cokleisli[F, A, C] =
       fa.map(f)
   }
+}
+
+sealed abstract class CokleisliInstances0 {
+  implicit def cokleisliProfunctor[F[_]](implicit ev: Functor[F]): Profunctor[Cokleisli[F, ?, ?]] =
+    new CokleisliProfunctor[F] { def F: Functor[F] = ev }
+}
+
+private trait CokleisliStrong[F[_]] extends Strong[Cokleisli[F, ?, ?]] with CokleisliProfunctor[F] {
+  implicit def F: Comonad[F]
+
+  def first[A, B, C](fa: Cokleisli[F, A, B]): Cokleisli[F, (A, C), (B, C)] =
+    fa.first[C]
+
+  def second[A, B, C](fa: Cokleisli[F, A, B]): Cokleisli[F, (C, A), (C, B)] =
+    fa.second[C]
+}
+
+private trait CokleisliProfunctor[F[_]] extends Profunctor[Cokleisli[F, ?, ?]] {
+  implicit def F: Functor[F]
+
+  def dimap[A, B, C, D](fab: Cokleisli[F, A, B])(f: C => A)(g: B => D): Cokleisli[F, C, D] =
+    fab.dimap(f)(g)
+
+  override def lmap[A, B, C](fab: Cokleisli[F, A, B])(f: C => A): Cokleisli[F, C, B] =
+    fab.lmap(f)
+
+  override def rmap[A, B, C](fab: Cokleisli[F, A, B])(f: B => C): Cokleisli[F, A, C] =
+    fab.map(f)
 }


### PR DESCRIPTION
This adds `Strong[Cokleisli[F, ?, ?]]`. It does not contain a test yet because I'm struggling to get this to compile:
```scala
checkAll("Cokleisli[NonEmptyList, Int, Int]", StrongTests[Cokleisli[NonEmptyList, ?, ?]].strong[Int, Int, Int, Int, Int, Int])
```
which fails with
```
[error] cats/tests/src/test/scala/cats/tests/CokleisliTests.scala:20: could not find implicit value for evidence parameter of type cats.functor.Strong[[X_kp1, X_kp2]cats.data.Cokleisli[[A]cats.data.OneAnd[A,[+A]List[A]],X_kp1,X_kp2]]
[error]   checkAll("Cokleisli[NonEmptyList, Int, Int]", StrongTests[Cokleisli[NonEmptyList, ?, ?]].strong[Int, Int, Int, Int, Int, Int])
```
Any help here would be greatly appreciated!