### PR TITLE
Prefix laws with the name of their typeclass

### DIFF
--- a/laws/src/main/scala/cats/laws/MonoidKLaws.scala
+++ b/laws/src/main/scala/cats/laws/MonoidKLaws.scala
@@ -7,10 +7,10 @@ package laws
 trait MonoidKLaws[F[_]] extends SemigroupKLaws[F] {
   override implicit def F: MonoidK[F]
 
-  def leftIdentity[A](a: F[A]): IsEq[F[A]] =
+  def monoidKLeftIdentity[A](a: F[A]): IsEq[F[A]] =
     F.combine(F.empty, a) <-> a
 
-  def rightIdentity[A](a: F[A]): IsEq[F[A]] =
+  def monoidKRightIdentity[A](a: F[A]): IsEq[F[A]] =
     F.combine(a, F.empty) <-> a
 }
 

--- a/laws/src/main/scala/cats/laws/SemigroupKLaws.scala
+++ b/laws/src/main/scala/cats/laws/SemigroupKLaws.scala
@@ -7,7 +7,7 @@ package laws
 trait SemigroupKLaws[F[_]] {
   implicit def F: SemigroupK[F]
 
-  def associative[A](a: F[A], b: F[A], c: F[A]): IsEq[F[A]] =
+  def semigroupKAssociative[A](a: F[A], b: F[A], c: F[A]): IsEq[F[A]] =
    F.combine(F.combine(a, b), c) <-> F.combine(a, F.combine(b, c))
 }
 

--- a/laws/src/main/scala/cats/laws/discipline/MonoidKTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/MonoidKTests.scala
@@ -19,8 +19,8 @@ trait MonoidKTests[F[_]] extends SemigroupKTests[F] {
       val bases = Nil
       val parents = Seq(semigroupK[A])
       val props = Seq(
-        "left identity" -> forAll(laws.leftIdentity[A] _),
-        "right identity" -> forAll(laws.rightIdentity[A] _)
+        "monoidK left identity" -> forAll(laws.monoidKLeftIdentity[A] _),
+        "monoidK right identity" -> forAll(laws.monoidKRightIdentity[A] _)
       )
     }
   }

--- a/laws/src/main/scala/cats/laws/discipline/SemigroupKTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/SemigroupKTests.scala
@@ -20,7 +20,7 @@ trait SemigroupKTests[F[_]] extends Laws {
       val bases = Nil
       val parents = Nil
       val props = Seq(
-        "associative" -> forAll(laws.associative[A] _)
+        "semigroupK associative" -> forAll(laws.semigroupKAssociative[A] _)
       )
     }
   }

--- a/tests/src/test/scala/cats/tests/OptionTests.scala
+++ b/tests/src/test/scala/cats/tests/OptionTests.scala
@@ -1,9 +1,8 @@
 package cats.tests
 
-import cats.laws.discipline.{CoflatMapTests, MonadCombineTests, AlternativeTests}
+import cats.laws.discipline.{CoflatMapTests, MonadCombineTests}
 
 class OptionTests extends CatsSuite {
   checkAll("Option[Int]", CoflatMapTests[Option].coflatMap[Int, Int, Int])
   checkAll("Option[Int]", MonadCombineTests[Option].monadCombine[Int, Int, Int])
-  checkAll("Option[Int]", AlternativeTests[Option].alternative[Int, String, Int])
 }


### PR DESCRIPTION
Since laws are mixed in, this helps preventing name clashes, and it makes the Scaladoc more clear since the laws are then grouped by their typeclass, see:
http://non.github.io/cats/api/#cats.laws.MonadCombineLaws

The second commit removes an unnecessary test because the `alternative` `RuleSet` is included in the `monadCombine` `RuleSet`.