### PR TITLE
Swap order of G[_] and A in Applicative.sequence

### DIFF
--- a/core/src/main/scala/cats/Applicative.scala
+++ b/core/src/main/scala/cats/Applicative.scala
@@ -39,7 +39,7 @@ trait Applicative[F[_]] extends Apply[F] { self =>
   def traverse[A, G[_], B](value: G[A])(f: A => F[B])(implicit G: Traverse[G]): F[G[B]] =
     G.traverse(value)(f)(this)
 
-  def sequence[A, G[_]: Traverse](as: G[F[A]]): F[G[A]] =
+  def sequence[G[_]: Traverse, A](as: G[F[A]]): F[G[A]] =
     traverse(as)(a => a)
 
 }


### PR DESCRIPTION
Fixes #285.

Scalaz has a style convention that kinds always go before types in
method signatures. Should we adopt the same convention?