### PR TITLE
Add State/StateT

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -85,8 +85,8 @@ lazy val docs = project
 lazy val cats = project.in(file("."))
   .settings(catsSettings)
   .settings(noPublishSettings)
-  .aggregate(macros, core, laws, tests, docs, free, std, bench)
-  .dependsOn(macros, core, laws, tests, docs, free, std, bench)
+  .aggregate(macros, core, laws, tests, docs, free, std, bench, state)
+  .dependsOn(macros, core, laws, tests, docs, free, std, bench, state)
 
 lazy val macros = project
   .settings(moduleName := "cats-macros")
@@ -134,6 +134,11 @@ lazy val bench = project.dependsOn(macros, core, free, std, laws)
 lazy val free = project.dependsOn(macros, core)
   .settings(moduleName := "cats-free")
   .settings(catsSettings)
+
+lazy val state = project.dependsOn(macros, core, free, tests % "test -> test")
+  .settings(moduleName := "cats-state")
+  .settings(catsSettings)
+  .settings(noPublishSettings)
 
 lazy val publishSettings = Seq(
   homepage := Some(url("https://github.com/non/cats")),

--- a/state/src/main/scala/cats/state/State.scala
+++ b/state/src/main/scala/cats/state/State.scala
@@ -1,0 +1,132 @@
+package cats
+package state
+
+import cats.free.Trampoline
+import cats.data.Kleisli
+
+/**
+ * `State[F, S, A]` is similar to `Kleisli[F, S, A]` in that it takes an `S`
+ * argument and produces an `A` value wrapped in `F`. However, it also produces
+ * an `S` value representing the updated state (which is wrapped in the `F`
+ * context along with the `A` value.
+ */
+final class StateT[F[_], S, A](val runF: F[S => F[(S, A)]]) {
+
+  def flatMap[B](fas: A => StateT[F, S, B])(implicit F: Monad[F]): StateT[F, S, B] =
+    StateT(s =>
+      F.flatMap(runF) { fsf =>
+        F.flatMap(fsf(s)) { case (s, a) =>
+          fas(a).run(s)
+        }
+      })
+
+  def map[B](fab: A => B)(implicit F: Monad[F]): StateT[F, S, B] =
+    StateT(s =>
+      F.flatMap(runF) { f =>
+        F.map(f(s)) { case (s, a) =>
+          (s, fab(a))
+        }
+      })
+
+  /**
+   * Run with the provided initial state value
+   */
+  def run(initial: S)(implicit F: FlatMap[F]): F[(S, A)] =
+    F.flatMap(runF)(f => f(initial))
+
+  /**
+   * Run with the provided initial state value and return the final state
+   * (discarding the final value).
+   */
+  def runS(s: S)(implicit F: FlatMap[F]): F[S] = F.map(run(s))(_._1)
+
+  /**
+   * Run with the provided initial state value and return the final value
+   * (discarding the final state).
+   */
+  def runA(s: S)(implicit F: FlatMap[F]): F[A] = F.map(run(s))(_._2)
+
+  /**
+   * Run with `S`'s empty monoid value as the initial state.
+   */
+  def runEmpty(implicit S: Monoid[S], F: FlatMap[F]) = run(S.empty)
+
+  /**
+   * Run with `S`'s empty monoid value as the initial state and return the final
+   * state (discarding the final value).
+   */
+  def runEmptyS(implicit S: Monoid[S], F: FlatMap[F]) = runS(S.empty)
+
+  /**
+   * Run with `S`'s empty monoid value as the initial state and return the final
+   * state (discarding the final value).
+   */
+  def runEmptyA(implicit S: Monoid[S], F: FlatMap[F]) = runA(S.empty)
+
+  /**
+   * Like [[map]], but also allows the state (`S`) value to be modified.
+   */
+  def transform[B](f: (S, A) => (S, B))(implicit F: Monad[F]): StateT[F, S, B] =
+    transformF { fsa =>
+      F.map(fsa){ case (s, a) => f(s, a) }
+    }
+
+  /**
+   * Like [[transform]], but allows the context to change from `F` to `G`.
+   */
+  def transformF[G[_], B](f: F[(S, A)] => G[(S, B)])(implicit F: FlatMap[F], G: Applicative[G]): StateT[G, S, B] =
+    StateT(s => f(run(s)))
+
+  /**
+   * Modify the state (`S`) component.
+   */
+  def modify(f: S => S)(implicit F: Monad[F]): StateT[F, S, A] =
+    transform((s, a) => (f(s), a))
+
+}
+
+object StateT {
+  def apply[F[_], S, A](f: S => F[(S, A)])(implicit F: Applicative[F]): StateT[F, S, A] =
+    new StateT(F.pure(f))
+
+  def applyF[F[_], S, A](runF: F[S => F[(S, A)]]): StateT[F, S, A] =
+    new StateT(runF)
+
+  def pure[F[_], S, A](a: A)(implicit F: Applicative[F]): StateT[F, S, A] =
+    StateT(s => F.pure((s, a)))
+
+  implicit def stateTMonad[F[_], S](implicit F: Monad[F]): Monad[StateT[F, S, ?]] = new Monad[StateT[F, S, ?]] {
+
+    def pure[A](a: A) = StateT.pure(a)
+
+    def flatMap[A, B](fa: StateT[F, S, A])(f: A => StateT[F, S, B]) =
+      fa.flatMap(f)
+
+    override def map[A, B](fa: StateT[F, S, A])(f: A => B) = fa.map(f)
+  }
+}
+
+object State {
+  def apply[S, A](f: S => (S, A)): State[S, A] =
+    StateT.applyF(Trampoline.done((s: S) => Trampoline.done(f(s))))
+
+  /**
+   * Modify the input state and return Unit.
+   */
+  def modify[S](f: S => S): State[S, Unit] = State(s => (f(s), ()))
+
+  /**
+   * Extract a value from the input state, without modifying the state.
+   */
+  def extract[S, T](f: S => T): State[S, T] = State(s => (s, f(s)))
+
+  /**
+   * Return the input state without modifying it.
+   */
+  def get[S]: State[S, S] = extract(identity)
+
+  /**
+   * Set the state to `s` and return Unit.
+   */
+  def set[S](s: S): State[S, Unit] = State(_ => (s, ()))
+}

--- a/state/src/main/scala/cats/state/State.scala
+++ b/state/src/main/scala/cats/state/State.scala
@@ -20,13 +20,8 @@ final class StateT[F[_], S, A](val runF: F[S => F[(S, A)]]) {
         }
       })
 
-  def map[B](fab: A => B)(implicit F: Monad[F]): StateT[F, S, B] =
-    StateT(s =>
-      F.flatMap(runF) { f =>
-        F.map(f(s)) { case (s, a) =>
-          (s, fab(a))
-        }
-      })
+  def map[B](f: A => B)(implicit F: Monad[F]): StateT[F, S, B] =
+    transform { case (s, a) => (s, f(a)) }
 
   /**
    * Run with the provided initial state value
@@ -49,19 +44,19 @@ final class StateT[F[_], S, A](val runF: F[S => F[(S, A)]]) {
   /**
    * Run with `S`'s empty monoid value as the initial state.
    */
-  def runEmpty(implicit S: Monoid[S], F: FlatMap[F]) = run(S.empty)
+  def runEmpty(implicit S: Monoid[S], F: FlatMap[F]): F[(S, A)] = run(S.empty)
 
   /**
    * Run with `S`'s empty monoid value as the initial state and return the final
    * state (discarding the final value).
    */
-  def runEmptyS(implicit S: Monoid[S], F: FlatMap[F]) = runS(S.empty)
+  def runEmptyS(implicit S: Monoid[S], F: FlatMap[F]): F[S] = runS(S.empty)
 
   /**
    * Run with `S`'s empty monoid value as the initial state and return the final
    * state (discarding the final value).
    */
-  def runEmptyA(implicit S: Monoid[S], F: FlatMap[F]) = runA(S.empty)
+  def runEmptyA(implicit S: Monoid[S], F: FlatMap[F]): F[A] = runA(S.empty)
 
   /**
    * Like [[map]], but also allows the state (`S`) value to be modified.

--- a/state/src/main/scala/cats/state/State.scala
+++ b/state/src/main/scala/cats/state/State.scala
@@ -85,7 +85,7 @@ final class StateT[F[_], S, A](val runF: F[S => F[(S, A)]]) {
 
 }
 
-object StateT {
+object StateT extends StateTInstances {
   def apply[F[_], S, A](f: S => F[(S, A)])(implicit F: Applicative[F]): StateT[F, S, A] =
     new StateT(F.pure(f))
 
@@ -94,7 +94,9 @@ object StateT {
 
   def pure[F[_], S, A](a: A)(implicit F: Applicative[F]): StateT[F, S, A] =
     StateT(s => F.pure((s, a)))
+}
 
+sealed abstract class StateTInstances extends StateTInstances0 {
   implicit def stateTMonad[F[_], S](implicit F: Monad[F]): Monad[StateT[F, S, ?]] = new Monad[StateT[F, S, ?]] {
 
     def pure[A](a: A) = StateT.pure(a)
@@ -104,6 +106,13 @@ object StateT {
 
     override def map[A, B](fa: StateT[F, S, A])(f: A => B) = fa.map(f)
   }
+}
+
+sealed abstract class StateTInstances0 {
+  // The Functor[Function0] is currently in std.
+  // Should we move it to core? Issue #258
+  implicit def stateMonad[S](implicit F: Functor[Function0]): Monad[State[S, ?]] =
+    StateT.stateTMonad[Trampoline, S]
 }
 
 object State {

--- a/state/src/main/scala/cats/state/package.scala
+++ b/state/src/main/scala/cats/state/package.scala
@@ -1,0 +1,7 @@
+package cats
+
+import free.Trampoline
+
+package object state {
+  type State[S, A] = StateT[Trampoline, S, A]
+}

--- a/state/src/test/scala/cats/state/StateTests.scala
+++ b/state/src/test/scala/cats/state/StateTests.scala
@@ -1,0 +1,48 @@
+package cats
+package state
+
+import cats.tests.CatsSuite
+import cats.laws.discipline.{ArbitraryK, MonadTests, MonoidKTests, SerializableTests}
+import cats.laws.discipline.arbitrary._
+import cats.laws.discipline.eq._
+import org.scalacheck.{Arbitrary, Gen}
+
+class StateTests extends CatsSuite {
+  import StateTests._
+
+  test("basic state usage"){
+    assert(add1.run(1).run == (2 -> 1))
+  }
+
+  test("traversing state is stack-safe"){
+    val ns = (0 to 100000).toList
+    // syntax doesn't work here. Should look into why
+    val x = Traverse[List].traverse[State[Int, ?], Int, Int](ns)(_ => add1)
+    assert(x.runS(0).run == 100001)
+  }
+
+  checkAll("StateT[Option, Int, Int]", MonadTests[StateT[Option, Int, ?]].monad[Int, Int, Int])
+  checkAll("Monad[StateT[Option, Int, ?]]", SerializableTests.serializable(Monad[StateT[Option, Int, ?]]))
+}
+
+object StateTests {
+
+  // This seems unnecessarily complicated. I think having our laws require
+  // ArbitraryK is overly constraining.
+  // It seems like I should just be able to use an Arbitrary[StateT[F, S, A]]
+  // that is derived from an Arbitrary[F[S => F[(S, A)]]]
+  implicit def stateArbitrary[F[_], S, A](implicit F: ArbitraryK[F], S: Arbitrary[S], A: Arbitrary[A]): Arbitrary[StateT[F, S, A]] =
+    Arbitrary(for {
+      sa <- F.synthesize[(S, A)].arbitrary
+      f <- F.synthesize[S => F[(S, A)]](Arbitrary(Gen.const(_ => sa))).arbitrary
+    } yield StateT.applyF(f))
+
+  implicit def stateArbitraryK[F[_], S](implicit F: ArbitraryK[F], S: Arbitrary[S]): ArbitraryK[StateT[F, S, ?]] =
+    new ArbitraryK[StateT[F, S, ?]]{ def synthesize[A: Arbitrary]: Arbitrary[StateT[F, S, A]] = stateArbitrary[F, S, A] }
+
+  implicit def stateEq[F[_], S, A](implicit S: Arbitrary[S], FSA: Eq[F[(S, A)]], F: FlatMap[F]): Eq[StateT[F, S, A]] =
+    Eq.by[StateT[F, S, A], S => F[(S, A)]](state =>
+      s => state.run(s))
+
+  val add1: State[Int, Int] = State(n => (n + 1, n))
+}

--- a/tests/src/test/scala/cats/tests/XorTTests.scala
+++ b/tests/src/test/scala/cats/tests/XorTTests.scala
@@ -8,5 +8,5 @@ import cats.laws.discipline.arbitrary._
 class XorTTests extends CatsSuite {
   checkAll("XorT[List, String, Int]", MonadTests[XorT[List, String, ?]].monad[Int, Int, Int])
   checkAll("XorT[List, String, Int]", MonoidKTests[XorT[List, String, ?]].monoidK[Int])
-  checkAll("Monad[List, String, ?]]", SerializableTests.serializable(Monad[XorT[List, String, ?]]))
+  checkAll("Monad[XorT[List, String, ?]]", SerializableTests.serializable(Monad[XorT[List, String, ?]]))
 }


### PR DESCRIPTION
Fixes #122.

To avoid stack overflows, a couple design choices were made that make
State more complicated than it seems like it should be.

State wraps F[S => F[(S, A)]] instead of the more familiar S => F[(S, A)]. This allows for effective trampolining.

State[S, A] is a type alias for StateT[Trampoline, S, A] to avoid stack
overflows that are easy to hit if Id is used instead of Trampoline.

State is currently in its own module because it depends on Free (for
trampolining) but doesn't seem to belong in the Free module. Since it's
tough to avoid trampolining in FP Scala, we may want to reconsider
whether Free should be in core.

There is a brief ScalaDoc comment on StateT, but a proper markdown file
should probably be created. If this gets merged, I can send a follow-up
PR with some more documentation.