### PR TITLE
Require explicit return types on public methods

### DIFF
--- a/core/src/main/scala/cats/Functor.scala
+++ b/core/src/main/scala/cats/Functor.scala
@@ -31,8 +31,8 @@ import functor.Contravariant
    */
   override def composeWithContravariant[G[_]](implicit GG: Contravariant[G]): Contravariant[Lambda[X => F[G[X]]]] =
     new Functor.ContravariantComposite[F, G] {
-      def F = self
-      def G = GG
+      def F: Functor[F] = self
+      def G: Contravariant[G] = GG
     }
 
   override def composeWithFunctor[G[_]: Functor]: Functor[Lambda[X => F[G[X]]]] = compose[G]

--- a/core/src/main/scala/cats/Unapply.scala
+++ b/core/src/main/scala/cats/Unapply.scala
@@ -45,7 +45,7 @@ object Unapply {
       type M[X] = F[X]
       type A = AA
       override def TC: TC[F] = tc
-      override def subst = identity
+      override def subst: F[AA] => M[A] = identity
   }
 
   // the type we will instantiate when we find a typeclass instance
@@ -67,14 +67,14 @@ object Unapply {
      type M[X] = F[X, B]
      type A = AA
      def TC: TC[F[?, B]] = tc
-     def subst = identity
+     def subst: F[AA, B] => M[A] = identity
    }
 
    implicit def unapply2right[TC[_[_]], F[_,_], AA, B](implicit tc: TC[F[AA,?]]): Aux2Right[TC,F[AA,B], F, AA, B] = new Unapply[TC, F[AA,B]] {
      type M[X] = F[AA, X]
      type A = B
      def TC: TC[F[AA, ?]] = tc
-     def subst = identity
+     def subst: F[AA, B] => M[A] = identity
    }
 
   // STEW: I'm not sure why these Nothing cases are needed and aren't
@@ -84,14 +84,14 @@ object Unapply {
      type M[X] = F[X, Nothing]
      type A = AA
      def TC: TC[F[?, Nothing]] = tc
-     def subst = identity
+     def subst: F[AA, Nothing] => M[A] = identity
    }
 
   implicit def unapply2rightN[TC[_[_]], F[+_,_], B](implicit tc: TC[F[Nothing,?]]): Aux2Right[TC,F[Nothing,B], F, Nothing, B] = new Unapply[TC, F[Nothing,B]] {
      type M[X] = F[Nothing, X]
      type A = B
      def TC: TC[F[Nothing, ?]] = tc
-     def subst = identity
+     def subst: F[Nothing, B] => M[A] = identity
    }
 
   // the type we will instantiate when we find a typeclass instance
@@ -122,13 +122,13 @@ object Unapply {
      type M[X] = F[AA, X, C]
      type A = B
      def TC: TC[F[AA, ?, C]] = tc
-     def subst = identity
+     def subst: F[AA, B, C] => M[A] = identity
    }
 
   implicit def unapply3MTright[TC[_[_]], F[_[_],_,_], AA[_], B, C](implicit tc: TC[F[AA,B,?]]): Aux3MTRight[TC,F[AA,B,C], F, AA, B, C] = new Unapply[TC, F[AA,B,C]] {
      type M[X] = F[AA, B, X]
      type A = C
      def TC: TC[F[AA, B, ?]] = tc
-     def subst = identity
+     def subst: F[AA, B, C] => M[A] = identity
    }
 }

--- a/core/src/main/scala/cats/arrow/Arrow.scala
+++ b/core/src/main/scala/cats/arrow/Arrow.scala
@@ -11,7 +11,7 @@ trait Arrow[F[_, _]] extends Split[F] with Strong[F] with Category[F] { self =>
     compose(lift(g), andThen(lift(f), fab))
 
   def second[A, B, C](fa: F[A, B]): F[(C, A), (C, B)] = {
-    def swap[X, Y] = lift[(X, Y), (Y, X)] { case (x, y) => (y, x) }
+    def swap[X, Y]: F[(X, Y), (Y, X)] = lift[(X, Y), (Y, X)] { case (x, y) => (y, x) }
     compose(swap, compose(first[A, B, C](fa), swap))
   }
 }

--- a/core/src/main/scala/cats/arrow/Category.scala
+++ b/core/src/main/scala/cats/arrow/Category.scala
@@ -10,14 +10,14 @@ trait Category[F[_, _]] extends Compose[F] { self =>
 
   override def algebraK: MonoidK[λ[α => F[α, α]]] =
     new MonoidK[λ[α => F[α, α]]] {
-      def empty[A] = id
-      def combine[A](f1: F[A, A], f2: F[A, A]) = self.compose(f1, f2)
+      def empty[A]: F[A, A] = id
+      def combine[A](f1: F[A, A], f2: F[A, A]): F[A, A] = self.compose(f1, f2)
     }
 
   override def algebra[A]: Monoid[F[A, A]] =
     new Monoid[F[A, A]] {
       def empty: F[A, A] = id
-      def combine(f1: F[A, A], f2: F[A, A]) = self.compose(f1, f2)
+      def combine(f1: F[A, A], f2: F[A, A]): F[A, A] = self.compose(f1, f2)
     }
 }
 

--- a/core/src/main/scala/cats/arrow/Compose.scala
+++ b/core/src/main/scala/cats/arrow/Compose.scala
@@ -12,12 +12,12 @@ trait Compose[F[_, _]] extends Serializable { self =>
 
   def algebraK: SemigroupK[λ[α => F[α, α]]] =
     new SemigroupK[λ[α => F[α, α]]] {
-      def combine[A](f1: F[A, A], f2: F[A, A]) = self.compose(f1, f2)
+      def combine[A](f1: F[A, A], f2: F[A, A]): F[A, A] = self.compose(f1, f2)
     }
 
   def algebra[A]: Semigroup[F[A, A]] =
     new Semigroup[F[A, A]] {
-      def combine(f1: F[A, A], f2: F[A, A]) = self.compose(f1, f2)
+      def combine(f1: F[A, A], f2: F[A, A]): F[A, A] = self.compose(f1, f2)
     }
 }
 

--- a/core/src/main/scala/cats/data/OneAnd.scala
+++ b/core/src/main/scala/cats/data/OneAnd.scala
@@ -63,12 +63,12 @@ trait OneAndInstances {
     Show.show[OneAnd[A, F]](_.show)
 
   implicit def oneAndFunctor[F[_]](F: Functor[F]): Functor[OneAnd[?,F]] = new Functor[OneAnd[?,F]] {
-    override def map[A, B](fa: OneAnd[A,F])(f: A => B) =
+    override def map[A, B](fa: OneAnd[A,F])(f: A => B): OneAnd[B, F] =
       OneAnd(f(fa.head), F.map(fa.tail)(f))
   }
 
   implicit def oneAndSemigroupK[F[_] : MonadCombine]: SemigroupK[OneAnd[?,F]] = new SemigroupK[OneAnd[?,F]] {
-    def combine[A](a: OneAnd[A, F], b: OneAnd[A, F]) = a combine b
+    def combine[A](a: OneAnd[A, F], b: OneAnd[A, F]): OneAnd[A, F] = a combine b
   }
 
   implicit def oneAndFoldable[F[_]](implicit foldable: Foldable[F]): Foldable[OneAnd[?,F]] = new Foldable[OneAnd[?,F]] {
@@ -92,15 +92,15 @@ trait OneAndInstances {
   }
 
   implicit def oneAndMonad[F[_]](implicit monad: MonadCombine[F]): Comonad[OneAnd[?, F]] with Monad[OneAnd[?, F]] = new Comonad[OneAnd[?, F]] with Monad[OneAnd[?, F]] {
-    def extract[A](x: OneAnd[A,F]) = x.head
+    def extract[A](x: OneAnd[A,F]): A = x.head
 
-    def coflatMap[A, B](fa: OneAnd[A,F])(f: OneAnd[A,F] => B) =
+    def coflatMap[A, B](fa: OneAnd[A,F])(f: OneAnd[A,F] => B): OneAnd[B, F] =
       OneAnd(f(fa), monad.empty)
 
-    override def map[A, B](fa: OneAnd[A,F])(f: A => B) =
+    override def map[A, B](fa: OneAnd[A,F])(f: A => B): OneAnd[B, F] =
       OneAnd(f(fa.head), monad.map(fa.tail)(f))
 
-    def pure[A](x: A) = OneAnd(x, monad.empty)
+    def pure[A](x: A): OneAnd[A, F] = OneAnd(x, monad.empty)
 
     private def unwrap[A](fa: OneAnd[A, F]) = monad.combine(monad.pure(fa.head), fa.tail)
 

--- a/core/src/main/scala/cats/data/Validated.scala
+++ b/core/src/main/scala/cats/data/Validated.scala
@@ -177,7 +177,7 @@ sealed abstract class ValidatedInstances extends ValidatedInstances1 {
     def pure[A](a: A): Validated[E,A] = Validated.valid(a)
     override def map[A, B](fa: Validated[E,A])(f: A => B): Validated[E, B] = fa.map(f)
 
-    override def apply[A,B](fa: Validated[E,A])(f: Validated[E,A=>B]) =
+    override def apply[A,B](fa: Validated[E,A])(f: Validated[E,A=>B]): Validated[E, B] =
       (fa,f) match {
         case (Valid(a),Valid(f)) => Valid(f(a))
         case (e @ Invalid(_), Valid(_)) => e

--- a/core/src/main/scala/cats/data/XorT.scala
+++ b/core/src/main/scala/cats/data/XorT.scala
@@ -105,7 +105,7 @@ abstract class XorTInstances extends XorTInstances1 {
   implicit def xorTEq[F[_], L, R](implicit e: Eq[F[L Xor R]]): Eq[XorT[F, L, R]] =
     // TODO Use Eq.instance on next algebra upgrade
     new Eq[XorT[F, L, R]] {
-      def eqv(x: XorT[F, L, R], y: XorT[F, L, R]) = e.eqv(x.value, y.value)
+      def eqv(x: XorT[F, L, R], y: XorT[F, L, R]): Boolean = e.eqv(x.value, y.value)
     }
 
   implicit def xorTShow[F[_], L, R](implicit sh: Show[F[L Xor R]]): Show[XorT[F, L, R]] =
@@ -127,7 +127,7 @@ private[data] abstract class XorTInstances1 extends XorTInstances2 {
     implicit val L0 = L
     new MonoidK[XorT[F, L, ?]] with XorTSemigroupK[F, L] {
       implicit val F = F0; implicit val L = L0
-      def empty[A] = XorT.left(F.pure(L.empty))(F)
+      def empty[A]: XorT[F, L, A] = XorT.left(F.pure(L.empty))(F)
     }
   }
 }

--- a/core/src/main/scala/cats/data/package.scala
+++ b/core/src/main/scala/cats/data/package.scala
@@ -5,12 +5,12 @@ package object data {
   type NonEmptyVector[A] = OneAnd[A, Vector]
   type NonEmptyStream[A] = OneAnd[A, Stream]
 
-  def NonEmptyList[A](head: A, tail: List[A] = Nil) = OneAnd[A, List](head, tail)
-  def NonEmptyList[A](head: A, tail: A*) = OneAnd[A, List](head, tail.toList)
+  def NonEmptyList[A](head: A, tail: List[A] = Nil): NonEmptyList[A] = OneAnd(head, tail)
+  def NonEmptyList[A](head: A, tail: A*): NonEmptyList[A] = OneAnd[A, List](head, tail.toList)
 
-  def NonEmptyVector[A](head: A, tail: Vector[A] = Vector.empty) = OneAnd[A, Vector](head, tail)
-  def NonEmptyVector[A](head: A, tail: A*) = OneAnd[A, Vector](head, tail.toVector)
+  def NonEmptyVector[A](head: A, tail: Vector[A] = Vector.empty): NonEmptyVector[A] = OneAnd(head, tail)
+  def NonEmptyVector[A](head: A, tail: A*): NonEmptyVector[A] = OneAnd(head, tail.toVector)
 
-  def NonEmptyStream[A](head: A, tail: Stream[A] = Stream.empty) = OneAnd[A, Stream](head, tail)
-  def NonEmptyStream[A](head: A, tail: A*) = OneAnd[A, Stream](head, tail.toStream)
+  def NonEmptyStream[A](head: A, tail: Stream[A] = Stream.empty): NonEmptyStream[A] = OneAnd(head, tail)
+  def NonEmptyStream[A](head: A, tail: A*): NonEmptyStream[A] = OneAnd(head, tail.toStream)
 }

--- a/core/src/main/scala/cats/functor/Contravariant.scala
+++ b/core/src/main/scala/cats/functor/Contravariant.scala
@@ -10,17 +10,21 @@ import simulacrum._
   def contramap[A, B](fa: F[A])(f: B => A): F[B]
   override def imap[A, B](fa: F[A])(f: A => B)(fi: B => A): F[B] = contramap(fa)(fi)
 
-  def compose[G[_]: Contravariant]: Functor[Lambda[X => F[G[X]]]] =
+  def compose[G[_]](implicit G: Contravariant[G]): Functor[Lambda[X => F[G[X]]]] = {
+    val G0 = G
     new Contravariant.Composite[F, G] {
-      def F = self
-      def G = Contravariant[G]
+      def F: Contravariant[F] = self
+      def G: Contravariant[G] = G0
     }
+  }
 
-  override def composeWithFunctor[G[_]: Functor]: Contravariant[Lambda[X => F[G[X]]]] =
+  override def composeWithFunctor[G[_]](implicit G: Functor[G]): Contravariant[Lambda[X => F[G[X]]]] = {
+    val G0 = G
     new Contravariant.CovariantComposite[F, G] {
-      def F = self
-      def G = Functor[G]
+      def F: Contravariant[F] = self
+      def G: Functor[G] = G0
     }
+  }
 }
 
 object Contravariant {

--- a/core/src/main/scala/cats/syntax/apply.scala
+++ b/core/src/main/scala/cats/syntax/apply.scala
@@ -19,15 +19,15 @@ trait ApplySyntax extends ApplySyntax1 {
 }
 
 abstract class ApplyOps[F[_], A] extends Apply.Ops[F, A] {
-  def |@|[B](fb: F[B]) = new ApplyBuilder[F] |@| self |@| fb
+  def |@|[B](fb: F[B]): ApplyBuilder[F]#ApplyBuilder2[A, B] = new ApplyBuilder[F] |@| self |@| fb
 
   /**
    * combine both contexts but only return the right value
    */
-  def *>[B](fb: F[B]) = typeClassInstance.map2(self, fb)((a,b) => b)
+  def *>[B](fb: F[B]): F[B] = typeClassInstance.map2(self, fb)((a,b) => b)
 
   /**
    * combine both contexts but only return the left value
    */
-  def <*[B](fb: F[B]) = typeClassInstance.map2(self, fb)((a,b) => a)
+  def <*[B](fb: F[B]): F[A] = typeClassInstance.map2(self, fb)((a,b) => a)
 }

--- a/free/src/main/scala/cats/free/Coyoneda.scala
+++ b/free/src/main/scala/cats/free/Coyoneda.scala
@@ -26,7 +26,7 @@ sealed abstract class Coyoneda[F[_], A] extends Serializable { self =>
   /** Converts to `Yoneda[F,A]` given that `F` is a functor */
   final def toYoneda(implicit F: Functor[F]): Yoneda[F, A] =
     new Yoneda[F, A] {
-      def apply[B](f: A => B) = F.map(fi)(k andThen f)
+      def apply[B](f: A => B): F[B] = F.map(fi)(k andThen f)
     }
 
   /**
@@ -79,6 +79,6 @@ object Coyoneda {
    */
   implicit def coyonedaFunctor[F[_]]: Functor[Coyoneda[F, ?]] =
     new Functor[Coyoneda[F, ?]] {
-      def map[A, B](cfa: Coyoneda[F, A])(f: A => B) = cfa map f
+      def map[A, B](cfa: Coyoneda[F, A])(f: A => B): Coyoneda[F, B] = cfa map f
     }
 }

--- a/free/src/main/scala/cats/free/Free.scala
+++ b/free/src/main/scala/cats/free/Free.scala
@@ -53,9 +53,9 @@ object Free {
    */
   implicit def freeMonad[S[_]:Functor]: Monad[Free[S, ?]] =
     new Monad[Free[S, ?]] {
-      def pure[A](a: A) = Pure(a)
-      override def map[A, B](fa: Free[S, A])(f: A => B) = fa map f
-      def flatMap[A, B](a: Free[S, A])(f: A => Free[S, B]) = a flatMap f
+      def pure[A](a: A): Free[S, A] = Pure(a)
+      override def map[A, B](fa: Free[S, A])(f: A => B): Free[S, B] = fa map f
+      def flatMap[A, B](a: Free[S, A])(f: A => Free[S, B]): Free[S, B] = a flatMap f
     }
 }
 

--- a/free/src/main/scala/cats/free/Yoneda.scala
+++ b/free/src/main/scala/cats/free/Yoneda.scala
@@ -26,7 +26,7 @@ abstract class Yoneda[F[_], A] extends Serializable { self =>
    */
   def map[B](f: A => B): Yoneda[F, B] =
     new Yoneda[F, B] {
-      def apply[C](g: B => C) = self(f andThen g)
+      def apply[C](g: B => C): F[C] = self(f andThen g)
     }
 
   // import Id._
@@ -44,15 +44,15 @@ object Yoneda {
    */
   implicit def yonedaFunctor[F[_]]: Functor[Yoneda[F, ?]] =
     new Functor[Yoneda[F, ?]] {
-      def map[A, B](ya: Yoneda[F,A])(f: A => B) = ya map f
+      def map[A, B](ya: Yoneda[F,A])(f: A => B): Yoneda[F, B] = ya map f
     }
 
   /**
    * `F[A]` converts to `Yoneda[F, A]` for any functor `F`.
    */
-  def apply[F[_]: Functor, A](fa: F[A]): Yoneda[F, A] =
+  def apply[F[_], A](fa: F[A])(implicit F: Functor[F]): Yoneda[F, A] =
     new Yoneda[F, A] {
-      def apply[B](f: A => B) = Functor[F].map(fa)(f)
+      def apply[B](f: A => B): F[B] = F.map(fa)(f)
     }
 }
 

--- a/laws/src/main/scala/cats/laws/AlternativeLaws.scala
+++ b/laws/src/main/scala/cats/laws/AlternativeLaws.scala
@@ -5,7 +5,7 @@ import cats.syntax.all._
 
 trait AlternativeLaws[F[_]] extends ApplicativeLaws[F] with MonoidKLaws[F] {
   implicit override def F: Alternative[F]
-  implicit def algebra[A] = F.algebra[A]
+  implicit def algebra[A]: Monoid[F[A]] = F.algebra[A]
 
   def alternativeRightAbsorption[A, B](ff: F[A => B]): IsEq[F[B]] =
     (F.empty[A] apply ff) <-> F.empty[B]
@@ -20,5 +20,5 @@ trait AlternativeLaws[F[_]] extends ApplicativeLaws[F] with MonoidKLaws[F] {
 
 object AlternativeLaws {
   def apply[F[_]](implicit ev: Alternative[F]): AlternativeLaws[F] =
-    new AlternativeLaws[F] { def F = ev }
+    new AlternativeLaws[F] { def F: Alternative[F] = ev }
 }

--- a/laws/src/main/scala/cats/laws/ApplicativeLaws.scala
+++ b/laws/src/main/scala/cats/laws/ApplicativeLaws.scala
@@ -35,5 +35,5 @@ trait ApplicativeLaws[F[_]] extends ApplyLaws[F] {
 
 object ApplicativeLaws {
   def apply[F[_]](implicit ev: Applicative[F]): ApplicativeLaws[F] =
-    new ApplicativeLaws[F] { def F = ev }
+    new ApplicativeLaws[F] { def F: Applicative[F] = ev }
 }

--- a/laws/src/main/scala/cats/laws/ApplyLaws.scala
+++ b/laws/src/main/scala/cats/laws/ApplyLaws.scala
@@ -18,5 +18,5 @@ trait ApplyLaws[F[_]] extends FunctorLaws[F] {
 
 object ApplyLaws {
   def apply[F[_]](implicit ev: Apply[F]): ApplyLaws[F] =
-    new ApplyLaws[F] { def F = ev }
+    new ApplyLaws[F] { def F: Apply[F] = ev }
 }

--- a/laws/src/main/scala/cats/laws/ArrowLaws.scala
+++ b/laws/src/main/scala/cats/laws/ArrowLaws.scala
@@ -41,5 +41,5 @@ trait ArrowLaws[F[_, _]] extends CategoryLaws[F] with SplitLaws[F] with StrongLa
 
 object ArrowLaws {
   def apply[F[_, _]](implicit ev: Arrow[F]): ArrowLaws[F] =
-    new ArrowLaws[F] { def F = ev }
+    new ArrowLaws[F] { def F: Arrow[F] = ev }
 }

--- a/laws/src/main/scala/cats/laws/CategoryLaws.scala
+++ b/laws/src/main/scala/cats/laws/CategoryLaws.scala
@@ -19,5 +19,5 @@ trait CategoryLaws[F[_, _]] extends ComposeLaws[F] {
 
 object CategoryLaws {
   def apply[F[_, _]](implicit ev: Category[F]): CategoryLaws[F] =
-    new CategoryLaws[F] { def F = ev }
+    new CategoryLaws[F] { def F: Category[F] = ev }
 }

--- a/laws/src/main/scala/cats/laws/CoflatMapLaws.scala
+++ b/laws/src/main/scala/cats/laws/CoflatMapLaws.scala
@@ -25,5 +25,5 @@ trait CoflatMapLaws[F[_]] extends FunctorLaws[F] {
 
 object CoflatMapLaws {
   def apply[F[_]](implicit ev: CoflatMap[F]): CoflatMapLaws[F] =
-    new CoflatMapLaws[F] { def F = ev }
+    new CoflatMapLaws[F] { def F: CoflatMap[F] = ev }
 }

--- a/laws/src/main/scala/cats/laws/ComonadLaws.scala
+++ b/laws/src/main/scala/cats/laws/ComonadLaws.scala
@@ -34,5 +34,5 @@ trait ComonadLaws[F[_]] extends CoflatMapLaws[F] {
 
 object ComonadLaws {
   def apply[F[_]](implicit ev: Comonad[F]): ComonadLaws[F] =
-    new ComonadLaws[F] { def F = ev }
+    new ComonadLaws[F] { def F: Comonad[F] = ev }
 }

--- a/laws/src/main/scala/cats/laws/ComposeLaws.scala
+++ b/laws/src/main/scala/cats/laws/ComposeLaws.scala
@@ -16,5 +16,5 @@ trait ComposeLaws[F[_, _]] {
 
 object ComposeLaws {
   def apply[F[_, _]](implicit ev: Compose[F]): ComposeLaws[F] =
-    new ComposeLaws[F] { def F = ev }
+    new ComposeLaws[F] { def F: Compose[F] = ev }
 }

--- a/laws/src/main/scala/cats/laws/ContravariantLaws.scala
+++ b/laws/src/main/scala/cats/laws/ContravariantLaws.scala
@@ -19,5 +19,5 @@ trait ContravariantLaws[F[_]] extends InvariantLaws[F] {
 
 object ContravariantLaws {
   def apply[F[_]](implicit ev: Contravariant[F]): ContravariantLaws[F] =
-    new ContravariantLaws[F] { def F = ev }
+    new ContravariantLaws[F] { def F: Contravariant[F] = ev }
 }

--- a/laws/src/main/scala/cats/laws/FlatMapLaws.scala
+++ b/laws/src/main/scala/cats/laws/FlatMapLaws.scala
@@ -30,5 +30,5 @@ trait FlatMapLaws[F[_]] extends ApplyLaws[F] {
 
 object FlatMapLaws {
   def apply[F[_]](implicit ev: FlatMap[F]): FlatMapLaws[F] =
-    new FlatMapLaws[F] { def F = ev }
+    new FlatMapLaws[F] { def F: FlatMap[F] = ev }
 }

--- a/laws/src/main/scala/cats/laws/FunctorLaws.scala
+++ b/laws/src/main/scala/cats/laws/FunctorLaws.scala
@@ -18,5 +18,5 @@ trait FunctorLaws[F[_]] extends InvariantLaws[F] {
 
 object FunctorLaws {
   def apply[F[_]](implicit ev: Functor[F]): FunctorLaws[F] =
-    new FunctorLaws[F] { def F = ev }
+    new FunctorLaws[F] { def F: Functor[F] = ev }
 }

--- a/laws/src/main/scala/cats/laws/InvariantLaws.scala
+++ b/laws/src/main/scala/cats/laws/InvariantLaws.scala
@@ -19,5 +19,5 @@ trait InvariantLaws[F[_]] {
 
 object InvariantLaws {
   def apply[F[_]](implicit ev: Invariant[F]): InvariantLaws[F] =
-    new InvariantLaws[F] { def F = ev }
+    new InvariantLaws[F] { def F: Invariant[F] = ev }
 }

--- a/laws/src/main/scala/cats/laws/MonadCombineLaws.scala
+++ b/laws/src/main/scala/cats/laws/MonadCombineLaws.scala
@@ -15,5 +15,5 @@ trait MonadCombineLaws[F[_]] extends MonadFilterLaws[F] with AlternativeLaws[F] 
 
 object MonadCombineLaws {
   def apply[F[_]](implicit ev: MonadCombine[F]): MonadCombineLaws[F] =
-    new MonadCombineLaws[F] { def F = ev }
+    new MonadCombineLaws[F] { def F: MonadCombine[F] = ev }
 }

--- a/laws/src/main/scala/cats/laws/MonadFilterLaws.scala
+++ b/laws/src/main/scala/cats/laws/MonadFilterLaws.scala
@@ -18,5 +18,5 @@ trait MonadFilterLaws[F[_]] extends MonadLaws[F] {
 
 object MonadFilterLaws {
   def apply[F[_]](implicit ev: MonadFilter[F]): MonadFilterLaws[F] =
-    new MonadFilterLaws[F] { def F = ev }
+    new MonadFilterLaws[F] { def F: MonadFilter[F] = ev }
 }

--- a/laws/src/main/scala/cats/laws/MonadLaws.scala
+++ b/laws/src/main/scala/cats/laws/MonadLaws.scala
@@ -33,5 +33,5 @@ trait MonadLaws[F[_]] extends ApplicativeLaws[F] with FlatMapLaws[F] {
 
 object MonadLaws {
   def apply[F[_]](implicit ev: Monad[F]): MonadLaws[F] =
-    new MonadLaws[F] { def F = ev }
+    new MonadLaws[F] { def F: Monad[F] = ev }
 }

--- a/laws/src/main/scala/cats/laws/MonoidKLaws.scala
+++ b/laws/src/main/scala/cats/laws/MonoidKLaws.scala
@@ -16,5 +16,5 @@ trait MonoidKLaws[F[_]] extends SemigroupKLaws[F] {
 
 object MonoidKLaws {
   def apply[F[_]](implicit ev: MonoidK[F]): MonoidKLaws[F] =
-    new MonoidKLaws[F] { def F = ev }
+    new MonoidKLaws[F] { def F: MonoidK[F] = ev }
 }

--- a/laws/src/main/scala/cats/laws/ProfunctorLaws.scala
+++ b/laws/src/main/scala/cats/laws/ProfunctorLaws.scala
@@ -21,5 +21,5 @@ trait ProfunctorLaws[F[_, _]] {
 
 object ProfunctorLaws {
   def apply[F[_, _]](implicit ev: Profunctor[F]): ProfunctorLaws[F] =
-    new ProfunctorLaws[F] { def F = ev }
+    new ProfunctorLaws[F] { def F: Profunctor[F] = ev }
 }

--- a/laws/src/main/scala/cats/laws/SemigroupKLaws.scala
+++ b/laws/src/main/scala/cats/laws/SemigroupKLaws.scala
@@ -13,5 +13,5 @@ trait SemigroupKLaws[F[_]] {
 
 object SemigroupKLaws {
   def apply[F[_]](implicit ev: SemigroupK[F]): SemigroupKLaws[F] =
-    new SemigroupKLaws[F] { def F = ev }
+    new SemigroupKLaws[F] { def F: SemigroupK[F] = ev }
 }

--- a/laws/src/main/scala/cats/laws/SplitLaws.scala
+++ b/laws/src/main/scala/cats/laws/SplitLaws.scala
@@ -18,5 +18,5 @@ trait SplitLaws[F[_, _]] extends ComposeLaws[F] {
 
 object SplitLaws {
   def apply[F[_, _]](implicit ev: Split[F]): SplitLaws[F] =
-    new SplitLaws[F] { def F = ev }
+    new SplitLaws[F] { def F: Split[F] = ev }
 }

--- a/laws/src/main/scala/cats/laws/StrongLaws.scala
+++ b/laws/src/main/scala/cats/laws/StrongLaws.scala
@@ -21,5 +21,5 @@ trait StrongLaws[F[_, _]] extends ProfunctorLaws[F] {
 
 object StrongLaws {
   def apply[F[_, _]](implicit ev: Strong[F]): StrongLaws[F] =
-    new StrongLaws[F] { def F = ev }
+    new StrongLaws[F] { def F: Strong[F] = ev }
 }

--- a/laws/src/main/scala/cats/laws/discipline/AlternativeTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/AlternativeTests.scala
@@ -4,7 +4,8 @@ package discipline
 
 import cats.laws.AlternativeLaws
 import org.scalacheck.Arbitrary
-import org.scalacheck.Prop._
+import org.scalacheck.Prop
+import Prop._
 
 trait AlternativeTests[F[_]] extends ApplicativeTests[F] with MonoidKTests[F]  {
   def laws:AlternativeLaws[F]
@@ -19,13 +20,16 @@ trait AlternativeTests[F[_]] extends ApplicativeTests[F] with MonoidKTests[F]  {
     implicit def ArbFA: Arbitrary[F[A]] = ArbF.synthesize[A]
 
     new RuleSet {
-      val name = "alternative"
-      val bases = Nil
-      val parents = Seq(monoidK[A], applicative[A,B,C])
-      val props = Seq(
-        "left distributivity" -> forAll(laws.alternativeLeftDistributivity[A,B](_, _, _)),
-        "right distributivity" -> forAll(laws.alternativeRightDistributivity[A,B](_, _, _)),
-        "right absorption" -> forAll(laws.alternativeRightAbsorption[A,B](_))
+      val name: String = "alternative"
+      val bases: Seq[(String, RuleSet)] = Nil
+      val parents: Seq[RuleSet] = Seq(monoidK[A], applicative[A,B,C])
+      val props: Seq[(String, Prop)] = Seq(
+        "left distributivity" -> forAll((fa1: F[A], fa2: F[A], fab: A => B) =>
+          laws.alternativeLeftDistributivity[A,B](fa1, fa2, fab)),
+        "right distributivity" -> forAll((fa: F[A], fab1: F[A => B], fab2: F[A => B]) =>
+          laws.alternativeRightDistributivity[A,B](fa, fab1, fab2)),
+        "right absorption" -> forAll((fab: F[A => B]) =>
+          laws.alternativeRightAbsorption[A,B](fab))
       )
     }
 }
@@ -34,5 +38,5 @@ trait AlternativeTests[F[_]] extends ApplicativeTests[F] with MonoidKTests[F]  {
 
 object AlternativeTests {
   def apply[F[_]: Alternative]: AlternativeTests[F] =
-    new AlternativeTests[F] { def laws = AlternativeLaws[F] }
+    new AlternativeTests[F] { def laws: AlternativeLaws[F] = AlternativeLaws[F] }
 }

--- a/laws/src/main/scala/cats/laws/discipline/ApplicativeTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/ApplicativeTests.scala
@@ -3,7 +3,8 @@ package laws
 package discipline
 
 import org.scalacheck.Arbitrary
-import org.scalacheck.Prop._
+import org.scalacheck.Prop
+import Prop._
 
 trait ApplicativeTests[F[_]] extends ApplyTests[F] {
   def laws: ApplicativeLaws[F]
@@ -18,10 +19,10 @@ trait ApplicativeTests[F[_]] extends ApplyTests[F] {
     implicit def ArbFAB: Arbitrary[F[A => B]] = ArbF.synthesize[A => B]
 
     new RuleSet {
-      def name = "applicative"
-      def bases = Nil
-      def parents = Seq(apply[A, B, C])
-      def props = Seq(
+      def name: String = "applicative"
+      def bases: Seq[(String, RuleSet)] = Nil
+      def parents: Seq[RuleSet] = Seq(apply[A, B, C])
+      def props: Seq[(String, Prop)] = Seq(
         "applicative identity" -> forAll(laws.applicativeIdentity[A] _),
         "applicative homomorphism" -> forAll(laws.applicativeHomomorphism[A, B] _),
         "applicative interchange" -> forAll(laws.applicativeInterchange[A, B] _),
@@ -33,5 +34,5 @@ trait ApplicativeTests[F[_]] extends ApplyTests[F] {
 
 object ApplicativeTests {
   def apply[F[_]: Applicative]: ApplicativeTests[F] =
-    new ApplicativeTests[F] { def laws = ApplicativeLaws[F] }
+    new ApplicativeTests[F] { def laws: ApplicativeLaws[F] = ApplicativeLaws[F] }
 }

--- a/laws/src/main/scala/cats/laws/discipline/ApplicativeTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/ApplicativeTests.scala
@@ -18,17 +18,13 @@ trait ApplicativeTests[F[_]] extends ApplyTests[F] {
     implicit def ArbFA: Arbitrary[F[A]] = ArbF.synthesize[A]
     implicit def ArbFAB: Arbitrary[F[A => B]] = ArbF.synthesize[A => B]
 
-    new RuleSet {
-      def name: String = "applicative"
-      def bases: Seq[(String, RuleSet)] = Nil
-      def parents: Seq[RuleSet] = Seq(apply[A, B, C])
-      def props: Seq[(String, Prop)] = Seq(
-        "applicative identity" -> forAll(laws.applicativeIdentity[A] _),
-        "applicative homomorphism" -> forAll(laws.applicativeHomomorphism[A, B] _),
-        "applicative interchange" -> forAll(laws.applicativeInterchange[A, B] _),
-        "applicative map" -> forAll(laws.applicativeMap[A, B] _)
-      )
-    }
+    new DefaultRuleSet(
+      name = "applicative",
+      parent = Some(apply[A, B, C]),
+      "applicative identity" -> forAll(laws.applicativeIdentity[A] _),
+      "applicative homomorphism" -> forAll(laws.applicativeHomomorphism[A, B] _),
+      "applicative interchange" -> forAll(laws.applicativeInterchange[A, B] _),
+      "applicative map" -> forAll(laws.applicativeMap[A, B] _))
   }
 }
 

--- a/laws/src/main/scala/cats/laws/discipline/ApplyTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/ApplyTests.scala
@@ -3,7 +3,8 @@ package laws
 package discipline
 
 import org.scalacheck.Arbitrary
-import org.scalacheck.Prop._
+import org.scalacheck.Prop
+import Prop._
 
 trait ApplyTests[F[_]] extends FunctorTests[F] {
   def laws: ApplyLaws[F]
@@ -18,10 +19,10 @@ trait ApplyTests[F[_]] extends FunctorTests[F] {
     implicit def ArbFBC: Arbitrary[F[B => C]] = ArbF.synthesize[B => C]
 
     new RuleSet {
-      def name = "apply"
-      def bases = Nil
-      def parents = Seq(functor[A, B, C])
-      def props = Seq(
+      def name: String = "apply"
+      def bases: Seq[(String, RuleSet)] = Nil
+      def parents: Seq[RuleSet] = Seq(functor[A, B, C])
+      def props: Seq[(String, Prop)] = Seq(
         "apply composition" -> forAll(laws.applyComposition[A, B, C] _)
       )
     }
@@ -30,5 +31,5 @@ trait ApplyTests[F[_]] extends FunctorTests[F] {
 
 object ApplyTests {
   def apply[F[_]: Apply]: ApplyTests[F] =
-    new ApplyTests[F] { def laws = ApplyLaws[F] }
+    new ApplyTests[F] { def laws: ApplyLaws[F] = ApplyLaws[F] }
 }

--- a/laws/src/main/scala/cats/laws/discipline/ApplyTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/ApplyTests.scala
@@ -18,14 +18,10 @@ trait ApplyTests[F[_]] extends FunctorTests[F] {
     implicit def ArbFAB: Arbitrary[F[A => B]] = ArbF.synthesize[A => B]
     implicit def ArbFBC: Arbitrary[F[B => C]] = ArbF.synthesize[B => C]
 
-    new RuleSet {
-      def name: String = "apply"
-      def bases: Seq[(String, RuleSet)] = Nil
-      def parents: Seq[RuleSet] = Seq(functor[A, B, C])
-      def props: Seq[(String, Prop)] = Seq(
-        "apply composition" -> forAll(laws.applyComposition[A, B, C] _)
-      )
-    }
+    new DefaultRuleSet(
+      name = "apply",
+      parent = Some(functor[A, B, C]),
+      "apply composition" -> forAll(laws.applyComposition[A, B, C] _))
   }
 }
 

--- a/laws/src/main/scala/cats/laws/discipline/ArrowTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/ArrowTests.scala
@@ -4,7 +4,8 @@ package discipline
 
 import cats.arrow.Arrow
 import org.scalacheck.Arbitrary
-import org.scalacheck.Prop._
+import org.scalacheck.Prop
+import Prop._
 
 trait ArrowTests[F[_, _]] extends CategoryTests[F] with SplitTests[F] with StrongTests[F] {
   def laws: ArrowLaws[F]
@@ -30,14 +31,14 @@ trait ArrowTests[F[_, _]] extends CategoryTests[F] with SplitTests[F] with Stron
     EqFACDBCD: Eq[F[((A, C), D),(B, (C, D))]]
   ): RuleSet =
     new RuleSet {
-      def name = "arrow"
-      def bases = Nil
-      def parents = Seq(
+      def name: String = "arrow"
+      def bases: Seq[(String, RuleSet)] = Nil
+      def parents: Seq[RuleSet] = Seq(
         category[A, B, C, D],
         split[A, B, C, D, E, G],
         strong[A, B, C, D, E, G]
       )
-      def props = Seq(
+      def props: Seq[(String, Prop)] = Seq(
         "arrow identity" -> laws.arrowIdentity[A],
         "arrow composition" -> forAll(laws.arrowComposition[A, B, C] _),
         "arrow extension" -> forAll(laws.arrowExtension[A, B, C] _),
@@ -51,5 +52,5 @@ trait ArrowTests[F[_, _]] extends CategoryTests[F] with SplitTests[F] with Stron
 
 object ArrowTests {
   def apply[F[_, _]: Arrow]: ArrowTests[F] =
-    new ArrowTests[F] { def laws = ArrowLaws[F] }
+    new ArrowTests[F] { def laws: ArrowLaws[F] = ArrowLaws[F] }
 }

--- a/laws/src/main/scala/cats/laws/discipline/CategoryTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/CategoryTests.scala
@@ -17,15 +17,11 @@ trait CategoryTests[F[_, _]] extends ComposeTests[F] {
     EqFAB: Eq[F[A, B]],
     EqFAD: Eq[F[A, D]]
   ): RuleSet =
-    new RuleSet {
-      def name: String = "category"
-      def bases: Seq[(String, RuleSet)] = Nil
-      def parents: Seq[RuleSet] = Seq(compose[A, B, C, D])
-      def props: Seq[(String, Prop)] = Seq(
-        "category left identity" -> forAll(laws.categoryLeftIdentity[A, B] _),
-        "category right identity" -> forAll(laws.categoryRightIdentity[A, B] _)
-      )
-    }
+    new DefaultRuleSet(
+      name = "category",
+      parent = Some(compose[A, B, C, D]),
+      "category left identity" -> forAll(laws.categoryLeftIdentity[A, B] _),
+      "category right identity" -> forAll(laws.categoryRightIdentity[A, B] _))
 }
 
 object CategoryTests {

--- a/laws/src/main/scala/cats/laws/discipline/CategoryTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/CategoryTests.scala
@@ -4,7 +4,8 @@ package discipline
 
 import cats.arrow.Category
 import org.scalacheck.Arbitrary
-import org.scalacheck.Prop._
+import org.scalacheck.Prop
+import Prop._
 
 trait CategoryTests[F[_, _]] extends ComposeTests[F] {
   def laws: CategoryLaws[F]
@@ -17,10 +18,10 @@ trait CategoryTests[F[_, _]] extends ComposeTests[F] {
     EqFAD: Eq[F[A, D]]
   ): RuleSet =
     new RuleSet {
-      def name = "category"
-      def bases = Nil
-      def parents = Seq(compose[A, B, C, D])
-      def props = Seq(
+      def name: String = "category"
+      def bases: Seq[(String, RuleSet)] = Nil
+      def parents: Seq[RuleSet] = Seq(compose[A, B, C, D])
+      def props: Seq[(String, Prop)] = Seq(
         "category left identity" -> forAll(laws.categoryLeftIdentity[A, B] _),
         "category right identity" -> forAll(laws.categoryRightIdentity[A, B] _)
       )
@@ -29,5 +30,5 @@ trait CategoryTests[F[_, _]] extends ComposeTests[F] {
 
 object CategoryTests {
   def apply[F[_, _]: Category]: CategoryTests[F] =
-    new CategoryTests[F] { def laws = CategoryLaws[F] }
+    new CategoryTests[F] { def laws: CategoryLaws[F] = CategoryLaws[F] }
 }

--- a/laws/src/main/scala/cats/laws/discipline/CoflatMapTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/CoflatMapTests.scala
@@ -3,7 +3,8 @@ package laws
 package discipline
 
 import org.scalacheck.Arbitrary
-import org.scalacheck.Prop._
+import org.scalacheck.Prop
+import Prop._
 import org.typelevel.discipline.Laws
 
 trait CoflatMapTests[F[_]] extends Laws {
@@ -17,10 +18,10 @@ trait CoflatMapTests[F[_]] extends Laws {
     implicit def ArbFA: Arbitrary[F[A]] = ArbF.synthesize[A]
 
     new RuleSet {
-      def name = "coflatMap"
-      def bases = Nil
-      def parents = Nil
-      def props = Seq(
+      def name: String = "coflatMap"
+      def bases: Seq[(String, RuleSet)] = Nil
+      def parents: Seq[RuleSet] = Nil
+      def props: Seq[(String, Prop)] = Seq(
         "coflatMap associativity" -> forAll(laws.coflatMapAssociativity[A, B, C] _)
       )
     }
@@ -29,5 +30,5 @@ trait CoflatMapTests[F[_]] extends Laws {
 
 object CoflatMapTests {
   def apply[F[_]: CoflatMap]: CoflatMapTests[F] =
-    new CoflatMapTests[F] { def laws = CoflatMapLaws[F] }
+    new CoflatMapTests[F] { def laws: CoflatMapLaws[F] = CoflatMapLaws[F] }
 }

--- a/laws/src/main/scala/cats/laws/discipline/CoflatMapTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/CoflatMapTests.scala
@@ -17,14 +17,10 @@ trait CoflatMapTests[F[_]] extends Laws {
   ): RuleSet = {
     implicit def ArbFA: Arbitrary[F[A]] = ArbF.synthesize[A]
 
-    new RuleSet {
-      def name: String = "coflatMap"
-      def bases: Seq[(String, RuleSet)] = Nil
-      def parents: Seq[RuleSet] = Nil
-      def props: Seq[(String, Prop)] = Seq(
-        "coflatMap associativity" -> forAll(laws.coflatMapAssociativity[A, B, C] _)
-      )
-    }
+    new DefaultRuleSet(
+      name = "coflatMap",
+      parent = None,
+      "coflatMap associativity" -> forAll(laws.coflatMapAssociativity[A, B, C] _))
   }
 }
 

--- a/laws/src/main/scala/cats/laws/discipline/ComonadTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/ComonadTests.scala
@@ -3,7 +3,8 @@ package laws
 package discipline
 
 import org.scalacheck.Arbitrary
-import org.scalacheck.Prop._
+import org.scalacheck.Prop
+import Prop._
 
 trait ComonadTests[F[_]] extends CoflatMapTests[F] {
   def laws: ComonadLaws[F]
@@ -17,10 +18,10 @@ trait ComonadTests[F[_]] extends CoflatMapTests[F] {
     implicit def ArbFA: Arbitrary[F[A]] = ArbF.synthesize[A]
 
     new RuleSet {
-      def name = "comonad"
-      def bases = Nil
-      def parents = Seq(coflatMap[A, B, C])
-      def props = Seq(
+      def name: String = "comonad"
+      def bases: Seq[(String, RuleSet)] = Nil
+      def parents: Seq[RuleSet] = Seq(coflatMap[A, B, C])
+      def props: Seq[(String, Prop)] = Seq(
         "comonad left identity" -> forAll(laws.comonadLeftIdentity[A] _),
         "comonad right identity" -> forAll(laws.comonadRightIdentity[A, B] _)
       )
@@ -30,5 +31,5 @@ trait ComonadTests[F[_]] extends CoflatMapTests[F] {
 
 object ComonadTests {
   def apply[F[_]: Comonad]: ComonadTests[F] =
-    new ComonadTests[F] { def laws = ComonadLaws[F] }
+    new ComonadTests[F] { def laws: ComonadLaws[F] = ComonadLaws[F] }
 }

--- a/laws/src/main/scala/cats/laws/discipline/ComonadTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/ComonadTests.scala
@@ -17,15 +17,11 @@ trait ComonadTests[F[_]] extends CoflatMapTests[F] {
   ): RuleSet = {
     implicit def ArbFA: Arbitrary[F[A]] = ArbF.synthesize[A]
 
-    new RuleSet {
-      def name: String = "comonad"
-      def bases: Seq[(String, RuleSet)] = Nil
-      def parents: Seq[RuleSet] = Seq(coflatMap[A, B, C])
-      def props: Seq[(String, Prop)] = Seq(
-        "comonad left identity" -> forAll(laws.comonadLeftIdentity[A] _),
-        "comonad right identity" -> forAll(laws.comonadRightIdentity[A, B] _)
-      )
-    }
+    new DefaultRuleSet(
+      name = "comonad",
+      parent = Some(coflatMap[A, B, C]),
+      "comonad left identity" -> forAll(laws.comonadLeftIdentity[A] _),
+      "comonad right identity" -> forAll(laws.comonadRightIdentity[A, B] _))
   }
 }
 

--- a/laws/src/main/scala/cats/laws/discipline/ComposeTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/ComposeTests.scala
@@ -4,7 +4,8 @@ package discipline
 
 import cats.arrow.Compose
 import org.scalacheck.Arbitrary
-import org.scalacheck.Prop._
+import org.scalacheck.Prop
+import Prop._
 import org.typelevel.discipline.Laws
 
 trait ComposeTests[F[_, _]] extends Laws {
@@ -17,10 +18,10 @@ trait ComposeTests[F[_, _]] extends Laws {
     EqFAD: Eq[F[A, D]]
   ): RuleSet =
     new RuleSet {
-      def name = "compose"
-      def bases = Nil
-      def parents = Nil
-      def props = Seq(
+      def name: String = "compose"
+      def bases: Seq[(String, RuleSet)] = Nil
+      def parents: Seq[RuleSet] = Nil
+      def props: Seq[(String, Prop)] = Seq(
         "compose associativity" -> forAll(laws.composeAssociativity[A, B, C, D] _)
       )
     }
@@ -28,5 +29,5 @@ trait ComposeTests[F[_, _]] extends Laws {
 
 object ComposeTests {
   def apply[F[_, _]: Compose]: ComposeTests[F] =
-    new ComposeTests[F] { def laws = ComposeLaws[F] }
+    new ComposeTests[F] { def laws: ComposeLaws[F] = ComposeLaws[F] }
 }

--- a/laws/src/main/scala/cats/laws/discipline/ComposeTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/ComposeTests.scala
@@ -17,14 +17,10 @@ trait ComposeTests[F[_, _]] extends Laws {
     ArbFCD: Arbitrary[F[C, D]],
     EqFAD: Eq[F[A, D]]
   ): RuleSet =
-    new RuleSet {
-      def name: String = "compose"
-      def bases: Seq[(String, RuleSet)] = Nil
-      def parents: Seq[RuleSet] = Nil
-      def props: Seq[(String, Prop)] = Seq(
-        "compose associativity" -> forAll(laws.composeAssociativity[A, B, C, D] _)
-      )
-    }
+    new DefaultRuleSet(
+      name = "compose",
+      parent = None,
+      "compose associativity" -> forAll(laws.composeAssociativity[A, B, C, D] _))
 }
 
 object ComposeTests {

--- a/laws/src/main/scala/cats/laws/discipline/FlatMapTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/FlatMapTests.scala
@@ -20,15 +20,11 @@ trait FlatMapTests[F[_]] extends ApplyTests[F] {
     implicit def ArbFC: Arbitrary[F[C]] = ArbF.synthesize[C]
     implicit def ArbFAB: Arbitrary[F[A => B]] = ArbF.synthesize[A => B]
 
-    new RuleSet {
-      def name: String = "flatMap"
-      def bases: Seq[(String, RuleSet)] = Nil
-      def parents: Seq[RuleSet] = Seq(apply[A, B, C])
-      def props: Seq[(String, Prop)] = Seq(
-        "flatMap associativity" -> forAll(laws.flatMapAssociativity[A, B, C] _),
-        "flatMap consistent apply" -> forAll(laws.flatMapConsistentApply[A, B] _)
-      )
-    }
+    new DefaultRuleSet(
+      name = "flatMap",
+      parent = Some(apply[A, B, C]),
+      "flatMap associativity" -> forAll(laws.flatMapAssociativity[A, B, C] _),
+      "flatMap consistent apply" -> forAll(laws.flatMapConsistentApply[A, B] _))
   }
 }
 

--- a/laws/src/main/scala/cats/laws/discipline/FlatMapTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/FlatMapTests.scala
@@ -3,7 +3,8 @@ package laws
 package discipline
 
 import org.scalacheck.Arbitrary
-import org.scalacheck.Prop._
+import org.scalacheck.Prop
+import Prop._
 
 trait FlatMapTests[F[_]] extends ApplyTests[F] {
   def laws: FlatMapLaws[F]
@@ -20,10 +21,10 @@ trait FlatMapTests[F[_]] extends ApplyTests[F] {
     implicit def ArbFAB: Arbitrary[F[A => B]] = ArbF.synthesize[A => B]
 
     new RuleSet {
-      def name = "flatMap"
-      def bases = Nil
-      def parents = Seq(apply[A, B, C])
-      def props = Seq(
+      def name: String = "flatMap"
+      def bases: Seq[(String, RuleSet)] = Nil
+      def parents: Seq[RuleSet] = Seq(apply[A, B, C])
+      def props: Seq[(String, Prop)] = Seq(
         "flatMap associativity" -> forAll(laws.flatMapAssociativity[A, B, C] _),
         "flatMap consistent apply" -> forAll(laws.flatMapConsistentApply[A, B] _)
       )
@@ -33,5 +34,5 @@ trait FlatMapTests[F[_]] extends ApplyTests[F] {
 
 object FlatMapTests {
   def apply[F[_]: FlatMap]: FlatMapTests[F] =
-    new FlatMapTests[F] { def laws = FlatMapLaws[F] }
+    new FlatMapTests[F] { def laws: FlatMapLaws[F] = FlatMapLaws[F] }
 }

--- a/laws/src/main/scala/cats/laws/discipline/FunctorTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/FunctorTests.scala
@@ -16,15 +16,11 @@ trait FunctorTests[F[_]] extends InvariantTests[F] {
   ): RuleSet = {
     implicit def ArbFA: Arbitrary[F[A]] = ArbF.synthesize[A]
 
-    new RuleSet {
-      def name: String = "functor"
-      def bases: Seq[(String, RuleSet)] = Nil
-      def parents: Seq[RuleSet] = Seq(invariant[A, B, C])
-      def props: Seq[(String, Prop)] = Seq(
-        "covariant identity" -> forAll(laws.covariantIdentity[A] _),
-        "covariant composition" -> forAll(laws.covariantComposition[A, B, C] _)
-      )
-    }
+    new DefaultRuleSet(
+      name = "functor",
+      parent = Some(invariant[A, B, C]),
+      "covariant identity" -> forAll(laws.covariantIdentity[A] _),
+      "covariant composition" -> forAll(laws.covariantComposition[A, B, C] _))
   }
 }
 

--- a/laws/src/main/scala/cats/laws/discipline/FunctorTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/FunctorTests.scala
@@ -3,7 +3,8 @@ package laws
 package discipline
 
 import org.scalacheck.Arbitrary
-import org.scalacheck.Prop._
+import org.scalacheck.Prop
+import Prop._
 
 trait FunctorTests[F[_]] extends InvariantTests[F] {
   def laws: FunctorLaws[F]
@@ -16,10 +17,10 @@ trait FunctorTests[F[_]] extends InvariantTests[F] {
     implicit def ArbFA: Arbitrary[F[A]] = ArbF.synthesize[A]
 
     new RuleSet {
-      def name = "functor"
-      def bases = Nil
-      def parents = Seq(invariant[A, B, C])
-      def props = Seq(
+      def name: String = "functor"
+      def bases: Seq[(String, RuleSet)] = Nil
+      def parents: Seq[RuleSet] = Seq(invariant[A, B, C])
+      def props: Seq[(String, Prop)] = Seq(
         "covariant identity" -> forAll(laws.covariantIdentity[A] _),
         "covariant composition" -> forAll(laws.covariantComposition[A, B, C] _)
       )
@@ -29,5 +30,5 @@ trait FunctorTests[F[_]] extends InvariantTests[F] {
 
 object FunctorTests {
   def apply[F[_]: Functor]: FunctorTests[F] =
-    new FunctorTests[F] { def laws = FunctorLaws[F] }
+    new FunctorTests[F] { def laws: FunctorLaws[F] = FunctorLaws[F] }
 }

--- a/laws/src/main/scala/cats/laws/discipline/InvariantTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/InvariantTests.scala
@@ -17,15 +17,11 @@ trait InvariantTests[F[_]] extends Laws {
     EqFC: Eq[F[C]]
   ): RuleSet = {
 
-    new RuleSet {
-      def name: String = "invariant"
-      def bases: Seq[(String, RuleSet)] = Nil
-      def parents: Seq[RuleSet] = Nil
-      def props: Seq[(String, Prop)] = Seq(
-        "invariant identity" -> forAll(laws.invariantIdentity[A] _),
-        "invariant composition" -> forAll(laws.invariantComposition[A, B, C] _)
-      )
-    }
+    new DefaultRuleSet(
+      name = "invariant",
+      parent = None,
+      "invariant identity" -> forAll(laws.invariantIdentity[A] _),
+      "invariant composition" -> forAll(laws.invariantComposition[A, B, C] _))
   }
 }
 

--- a/laws/src/main/scala/cats/laws/discipline/InvariantTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/InvariantTests.scala
@@ -4,7 +4,8 @@ package discipline
 
 import cats.functor.Invariant
 import org.scalacheck.Arbitrary
-import org.scalacheck.Prop._
+import org.scalacheck.Prop
+import Prop._
 import org.typelevel.discipline.Laws
 
 trait InvariantTests[F[_]] extends Laws {
@@ -17,10 +18,10 @@ trait InvariantTests[F[_]] extends Laws {
   ): RuleSet = {
 
     new RuleSet {
-      def name = "invariant"
-      def bases = Nil
-      def parents = Nil
-      def props = Seq(
+      def name: String = "invariant"
+      def bases: Seq[(String, RuleSet)] = Nil
+      def parents: Seq[RuleSet] = Nil
+      def props: Seq[(String, Prop)] = Seq(
         "invariant identity" -> forAll(laws.invariantIdentity[A] _),
         "invariant composition" -> forAll(laws.invariantComposition[A, B, C] _)
       )
@@ -30,5 +31,5 @@ trait InvariantTests[F[_]] extends Laws {
 
 object InvariantTests {
   def apply[F[_]: Invariant]: InvariantTests[F] =
-    new InvariantTests[F] { def laws = InvariantLaws[F] }
+    new InvariantTests[F] { def laws: InvariantLaws[F] = InvariantLaws[F] }
 }

--- a/laws/src/main/scala/cats/laws/discipline/MonadCombineTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/MonadCombineTests.scala
@@ -3,7 +3,8 @@ package laws
 package discipline
 
 import org.scalacheck.Arbitrary
-import org.scalacheck.Prop._
+import org.scalacheck.Prop
+import Prop._
 
 trait MonadCombineTests[F[_]] extends MonadFilterTests[F] with AlternativeTests[F] {
   def laws: MonadCombineLaws[F]
@@ -19,10 +20,10 @@ trait MonadCombineTests[F[_]] extends MonadFilterTests[F] with AlternativeTests[
     implicit def ArbFB: Arbitrary[F[B]] = ArbF.synthesize[B]
 
     new RuleSet {
-      def name = "monadCombine"
-      def bases = Nil
-      def parents = Seq(monadFilter[A, B, C], alternative[A,B,C])
-      def props = Seq(
+      def name: String = "monadCombine"
+      def bases: Seq[(String, RuleSet)] = Nil
+      def parents: Seq[RuleSet] = Seq(monadFilter[A, B, C], alternative[A,B,C])
+      def props: Seq[(String, Prop)] = Seq(
         "monadCombine left distributivity" -> forAll(laws.monadCombineLeftDistributivity[A, B] _)
       )
     }
@@ -31,5 +32,5 @@ trait MonadCombineTests[F[_]] extends MonadFilterTests[F] with AlternativeTests[
 
 object MonadCombineTests {
   def apply[F[_]: MonadCombine]: MonadCombineTests[F] =
-    new MonadCombineTests[F] { def laws = MonadCombineLaws[F] }
+    new MonadCombineTests[F] { def laws: MonadCombineLaws[F] = MonadCombineLaws[F] }
 }

--- a/laws/src/main/scala/cats/laws/discipline/MonadFilterTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/MonadFilterTests.scala
@@ -18,15 +18,11 @@ trait MonadFilterTests[F[_]] extends MonadTests[F] {
     implicit def ArbFA: Arbitrary[F[A]] = ArbF.synthesize[A]
     implicit def ArbFB: Arbitrary[F[B]] = ArbF.synthesize[B]
 
-    new RuleSet {
-      def name: String = "monadFilter"
-      def bases: Seq[(String, RuleSet)] = Nil
-      def parents: Seq[RuleSet] = Seq(monad[A, B, C])
-      def props: Seq[(String, Prop)] = Seq(
-        "monadFilter left empty" -> forAll(laws.monadFilterLeftEmpty[A, B] _),
-        "monadFilter right empty" -> forAll(laws.monadFilterRightEmpty[A, B] _)
-      )
-    }
+    new DefaultRuleSet(
+      name = "monadFilter",
+      parent = Some(monad[A, B, C]),
+      "monadFilter left empty" -> forAll(laws.monadFilterLeftEmpty[A, B] _),
+      "monadFilter right empty" -> forAll(laws.monadFilterRightEmpty[A, B] _))
   }
 }
 

--- a/laws/src/main/scala/cats/laws/discipline/MonadFilterTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/MonadFilterTests.scala
@@ -3,7 +3,8 @@ package laws
 package discipline
 
 import org.scalacheck.Arbitrary
-import org.scalacheck.Prop._
+import org.scalacheck.Prop
+import Prop._
 
 trait MonadFilterTests[F[_]] extends MonadTests[F] {
   def laws: MonadFilterLaws[F]
@@ -18,10 +19,10 @@ trait MonadFilterTests[F[_]] extends MonadTests[F] {
     implicit def ArbFB: Arbitrary[F[B]] = ArbF.synthesize[B]
 
     new RuleSet {
-      def name = "monadFilter"
-      def bases = Nil
-      def parents = Seq(monad[A, B, C])
-      def props = Seq(
+      def name: String = "monadFilter"
+      def bases: Seq[(String, RuleSet)] = Nil
+      def parents: Seq[RuleSet] = Seq(monad[A, B, C])
+      def props: Seq[(String, Prop)] = Seq(
         "monadFilter left empty" -> forAll(laws.monadFilterLeftEmpty[A, B] _),
         "monadFilter right empty" -> forAll(laws.monadFilterRightEmpty[A, B] _)
       )
@@ -31,5 +32,5 @@ trait MonadFilterTests[F[_]] extends MonadTests[F] {
 
 object MonadFilterTests {
   def apply[F[_]: MonadFilter]: MonadFilterTests[F] =
-    new MonadFilterTests[F] { def laws = MonadFilterLaws[F] }
+    new MonadFilterTests[F] { def laws: MonadFilterLaws[F] = MonadFilterLaws[F] }
 }

--- a/laws/src/main/scala/cats/laws/discipline/MonadTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/MonadTests.scala
@@ -3,7 +3,8 @@ package laws
 package discipline
 
 import org.scalacheck.Arbitrary
-import org.scalacheck.Prop._
+import org.scalacheck.Prop
+import Prop._
 
 trait MonadTests[F[_]] extends ApplicativeTests[F] with FlatMapTests[F] {
   def laws: MonadLaws[F]
@@ -18,10 +19,10 @@ trait MonadTests[F[_]] extends ApplicativeTests[F] with FlatMapTests[F] {
     implicit def ArbFB: Arbitrary[F[B]] = ArbF.synthesize[B]
 
     new RuleSet {
-      def name = "monad"
-      def bases = Nil
-      def parents = Seq(applicative[A, B, C], flatMap[A, B, C])
-      def props = Seq(
+      def name: String = "monad"
+      def bases: Seq[(String, RuleSet)] = Nil
+      def parents: Seq[RuleSet] = Seq(applicative[A, B, C], flatMap[A, B, C])
+      def props: Seq[(String, Prop)] = Seq(
         "monad left identity" -> forAll(laws.monadLeftIdentity[A, B] _),
         "monad right identity" -> forAll(laws.monadRightIdentity[A] _)
       )
@@ -31,5 +32,5 @@ trait MonadTests[F[_]] extends ApplicativeTests[F] with FlatMapTests[F] {
 
 object MonadTests {
   def apply[F[_]: Monad]: MonadTests[F] =
-    new MonadTests[F] { def laws = MonadLaws[F] }
+    new MonadTests[F] { def laws: MonadLaws[F] = MonadLaws[F] }
 }

--- a/laws/src/main/scala/cats/laws/discipline/MonoidKTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/MonoidKTests.scala
@@ -28,5 +28,5 @@ trait MonoidKTests[F[_]] extends SemigroupKTests[F] {
 
 object MonoidKTests {
   def apply[F[_] : MonoidK]: MonoidKTests[F] =
-    new MonoidKTests[F] { def laws = MonoidKLaws[F] }
+    new MonoidKTests[F] { def laws: MonoidKLaws[F] = MonoidKLaws[F] }
 }

--- a/laws/src/main/scala/cats/laws/discipline/ProfunctorTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/ProfunctorTests.scala
@@ -17,15 +17,11 @@ trait ProfunctorTests[F[_, _]] extends Laws {
     EqFAB: Eq[F[A, B]],
     EqFAG: Eq[F[A, G]]
   ): RuleSet =
-    new RuleSet {
-      def name: String = "profunctor"
-      def bases: Seq[(String, RuleSet)] = Nil
-      def parents: Seq[RuleSet] = Nil
-      def props: Seq[(String, Prop)] = Seq(
-        "profunctor identity" -> forAll(laws.profunctorIdentity[A, B] _),
-        "profunctor composition" -> forAll(laws.profunctorComposition[A, B, C, D, E, G] _)
-      )
-    }
+    new DefaultRuleSet(
+      name = "profunctor",
+      parent = None,
+      "profunctor identity" -> forAll(laws.profunctorIdentity[A, B] _),
+      "profunctor composition" -> forAll(laws.profunctorComposition[A, B, C, D, E, G] _))
 }
 
 object ProfunctorTests {

--- a/laws/src/main/scala/cats/laws/discipline/ProfunctorTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/ProfunctorTests.scala
@@ -4,7 +4,8 @@ package discipline
 
 import cats.functor.Profunctor
 import org.scalacheck.Arbitrary
-import org.scalacheck.Prop._
+import org.scalacheck.Prop
+import Prop._
 import org.typelevel.discipline.Laws
 
 trait ProfunctorTests[F[_, _]] extends Laws {
@@ -17,10 +18,10 @@ trait ProfunctorTests[F[_, _]] extends Laws {
     EqFAG: Eq[F[A, G]]
   ): RuleSet =
     new RuleSet {
-      def name = "profunctor"
-      def bases = Nil
-      def parents = Nil
-      def props = Seq(
+      def name: String = "profunctor"
+      def bases: Seq[(String, RuleSet)] = Nil
+      def parents: Seq[RuleSet] = Nil
+      def props: Seq[(String, Prop)] = Seq(
         "profunctor identity" -> forAll(laws.profunctorIdentity[A, B] _),
         "profunctor composition" -> forAll(laws.profunctorComposition[A, B, C, D, E, G] _)
       )
@@ -29,5 +30,5 @@ trait ProfunctorTests[F[_, _]] extends Laws {
 
 object ProfunctorTests {
   def apply[F[_, _]: Profunctor]: ProfunctorTests[F] =
-    new ProfunctorTests[F] { def laws = ProfunctorLaws[F] }
+    new ProfunctorTests[F] { def laws: ProfunctorLaws[F] = ProfunctorLaws[F] }
 }

--- a/laws/src/main/scala/cats/laws/discipline/SemigroupKTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/SemigroupKTests.scala
@@ -28,5 +28,5 @@ trait SemigroupKTests[F[_]] extends Laws {
 
 object SemigroupKTests {
   def apply[F[_]: SemigroupK]: SemigroupKTests[F] =
-    new SemigroupKTests[F] { def laws = SemigroupKLaws[F] }
+    new SemigroupKTests[F] { def laws: SemigroupKLaws[F] = SemigroupKLaws[F] }
 }

--- a/laws/src/main/scala/cats/laws/discipline/SerializableTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/SerializableTests.scala
@@ -3,14 +3,16 @@ package laws
 package discipline
 
 import org.typelevel.discipline.Laws
+import org.scalacheck.Prop
+import Prop._
 
 object SerializableTests extends Laws {
   def serializable[A](a: A): RuleSet =
     new RuleSet {
-      def name = "serializable"
-      def bases = Nil
-      def parents = Nil
-      def props = Seq(
+      def name: String = "serializable"
+      def bases: Seq[(String, RuleSet)] = Nil
+      def parents: Seq[RuleSet] = Nil
+      def props: Seq[(String, Prop)] = Seq(
         "can serialize and deserialize" -> SerializableLaws.serializable(a)
       )
     }

--- a/laws/src/main/scala/cats/laws/discipline/SerializableTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/SerializableTests.scala
@@ -8,12 +8,8 @@ import Prop._
 
 object SerializableTests extends Laws {
   def serializable[A](a: A): RuleSet =
-    new RuleSet {
-      def name: String = "serializable"
-      def bases: Seq[(String, RuleSet)] = Nil
-      def parents: Seq[RuleSet] = Nil
-      def props: Seq[(String, Prop)] = Seq(
-        "can serialize and deserialize" -> SerializableLaws.serializable(a)
-      )
-    }
+    new DefaultRuleSet(
+      name = "serializable",
+      parent = None,
+      "can serialize and deserialize" -> SerializableLaws.serializable(a))
 }

--- a/laws/src/main/scala/cats/laws/discipline/SplitTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/SplitTests.scala
@@ -19,14 +19,10 @@ trait SplitTests[F[_, _]] extends ComposeTests[F] {
     EqFAD: Eq[F[A, D]],
     EqFADCG: Eq[F[(A, D), (C, G)]]
   ): RuleSet =
-    new RuleSet {
-      def name: String = "split"
-      def bases: Seq[(String, RuleSet)] = Nil
-      def parents: Seq[RuleSet] = Seq(compose[A, B, C, D])
-      def props: Seq[(String, Prop)] = Seq(
-        "split interchange" -> forAll(laws.splitInterchange[A, B, C, D, E, G] _)
-      )
-    }
+    new DefaultRuleSet(
+      name =  "split",
+      parent = Some(compose[A, B, C, D]),
+      "split interchange" -> forAll(laws.splitInterchange[A, B, C, D, E, G] _))
 }
 
 object SplitTests {

--- a/laws/src/main/scala/cats/laws/discipline/SplitTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/SplitTests.scala
@@ -4,7 +4,8 @@ package discipline
 
 import cats.arrow.Split
 import org.scalacheck.Arbitrary
-import org.scalacheck.Prop._
+import org.scalacheck.Prop
+import Prop._
 
 trait SplitTests[F[_, _]] extends ComposeTests[F] {
   def laws: SplitLaws[F]
@@ -19,10 +20,10 @@ trait SplitTests[F[_, _]] extends ComposeTests[F] {
     EqFADCG: Eq[F[(A, D), (C, G)]]
   ): RuleSet =
     new RuleSet {
-      def name = "split"
-      def bases = Nil
-      def parents = Seq(compose[A, B, C, D])
-      def props = Seq(
+      def name: String = "split"
+      def bases: Seq[(String, RuleSet)] = Nil
+      def parents: Seq[RuleSet] = Seq(compose[A, B, C, D])
+      def props: Seq[(String, Prop)] = Seq(
         "split interchange" -> forAll(laws.splitInterchange[A, B, C, D, E, G] _)
       )
     }
@@ -30,5 +31,5 @@ trait SplitTests[F[_, _]] extends ComposeTests[F] {
 
 object SplitTests {
   def apply[F[_, _]: Split]: SplitTests[F] =
-    new SplitTests[F] { def laws = SplitLaws[F] }
+    new SplitTests[F] { def laws: SplitLaws[F] = SplitLaws[F] }
 }

--- a/laws/src/main/scala/cats/laws/discipline/StrongTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/StrongTests.scala
@@ -4,7 +4,8 @@ package discipline
 
 import cats.functor.Strong
 import org.scalacheck.Arbitrary
-import org.scalacheck.Prop._
+import org.scalacheck.Prop
+import Prop._
 
 trait StrongTests[F[_, _]] extends ProfunctorTests[F] {
   def laws: StrongLaws[F]
@@ -19,10 +20,10 @@ trait StrongTests[F[_, _]] extends ProfunctorTests[F] {
     EqFEAED: Eq[F[(E, A), (E, D)]]
   ): RuleSet =
     new RuleSet {
-      def name = "strong"
-      def bases = Nil
-      def parents = Seq(profunctor[A, B, C, D, E, G])
-      def props = Seq(
+      def name: String = "strong"
+      def bases: Seq[(String, RuleSet)]  = Nil
+      def parents: Seq[RuleSet] = Seq(profunctor[A, B, C, D, E, G])
+      def props: Seq[(String, Prop)] = Seq(
         "strong first distributivity" -> forAll(laws.strongFirstDistributivity[A, B, C, D, E] _),
         "strong second distributivity" -> forAll(laws.strongSecondDistributivity[A, B, C, D, E] _)
       )
@@ -31,5 +32,5 @@ trait StrongTests[F[_, _]] extends ProfunctorTests[F] {
 
 object StrongTests {
   def apply[F[_, _]: Strong]: StrongTests[F] =
-    new StrongTests[F] { def laws = StrongLaws[F] }
+    new StrongTests[F] { def laws: StrongLaws[F] = StrongLaws[F] }
 }

--- a/laws/src/main/scala/cats/laws/discipline/StrongTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/StrongTests.scala
@@ -19,15 +19,11 @@ trait StrongTests[F[_, _]] extends ProfunctorTests[F] {
     EqFAEDE: Eq[F[(A, E), (D, E)]],
     EqFEAED: Eq[F[(E, A), (E, D)]]
   ): RuleSet =
-    new RuleSet {
-      def name: String = "strong"
-      def bases: Seq[(String, RuleSet)]  = Nil
-      def parents: Seq[RuleSet] = Seq(profunctor[A, B, C, D, E, G])
-      def props: Seq[(String, Prop)] = Seq(
-        "strong first distributivity" -> forAll(laws.strongFirstDistributivity[A, B, C, D, E] _),
-        "strong second distributivity" -> forAll(laws.strongSecondDistributivity[A, B, C, D, E] _)
-      )
-    }
+    new DefaultRuleSet(
+      name = "strong",
+      parent = Some(profunctor[A, B, C, D, E, G]),
+      "strong first distributivity" -> forAll(laws.strongFirstDistributivity[A, B, C, D, E] _),
+      "strong second distributivity" -> forAll(laws.strongSecondDistributivity[A, B, C, D, E] _))
 }
 
 object StrongTests {

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -59,4 +59,9 @@
  </check>
  <check level="error" class="org.scalastyle.file.NewLineAtEofChecker" enabled="true"></check>
  <check level="error" class="org.scalastyle.file.NoNewLineAtEofChecker" enabled="false"></check>
+ <check level="error" class="org.scalastyle.scalariform.PublicMethodsHaveTypeChecker" enabled="true">
+  <parameters>
+   <parameter name="ignoreOverride">false</parameter>
+  </parameters>
+ </check>
 </scalastyle>

--- a/tests/src/test/scala/cats/tests/AlgebraInvariantTests.scala
+++ b/tests/src/test/scala/cats/tests/AlgebraInvariantTests.scala
@@ -12,13 +12,13 @@ class AlgebraInvariantTests extends CatsSuite {
   val intMultiplication: Monoid[Int] = new Monoid[Int] {
     val empty = 1
 
-    def combine(x: Int, y: Int) = x * y
+    def combine(x: Int, y: Int): Int = x * y
   }
 
   val maxInt: Monoid[Int] = new Monoid[Int] {
     val empty = Int.MinValue
 
-    def combine(x: Int, y: Int) = if (x > y) x else y
+    def combine(x: Int, y: Int): Int = if (x > y) x else y
   }
 
   val genMonoidInt: Gen[Monoid[Int]] =

--- a/tests/src/test/scala/cats/tests/FoldableTests.scala
+++ b/tests/src/test/scala/cats/tests/FoldableTests.scala
@@ -5,7 +5,7 @@ class FoldableTests extends CatsSuite {
   import Fold.{Continue, Return, Pass}
 
   // disable scalatest ===
-  override def convertToEqualizer[T](left: T) = ???
+  override def convertToEqualizer[T](left: T): Equalizer[T] = ???
 
   // exists method written in terms of foldLazy
   def exists[F[_]: Foldable, A: Eq](as: F[A], goal: A): Lazy[Boolean] =

--- a/tests/src/test/scala/cats/tests/LazyTests.scala
+++ b/tests/src/test/scala/cats/tests/LazyTests.scala
@@ -8,7 +8,7 @@ import scala.math.min
 class LazyTests extends CatsSuite {
 
   // disable scalatest ===
-  override def convertToEqualizer[T](left: T) = ???
+  override def convertToEqualizer[T](left: T): Equalizer[T] = ???
 
   /**
    * Class for spooky side-effects and action-at-a-distance.

--- a/tests/src/test/scala/cats/tests/RegressionTests.scala
+++ b/tests/src/test/scala/cats/tests/RegressionTests.scala
@@ -8,16 +8,16 @@ class RegressionTests extends CatsSuite {
   // toy state class
   // not stack safe, very minimal, not for actual use
   case class State[S, A](run: S => (A, S)) { self =>
-    def map[B](f: A => B) =
-      State[S, B]({ s => val (a, s2) = self.run(s); (f(a), s2) })
-    def flatMap[B](f: A => State[S, B]) =
-      State[S, B]({ s => val (a, s2) = self.run(s); f(a).run(s2) })
+    def map[B](f: A => B): State[S, B] =
+      State({ s => val (a, s2) = self.run(s); (f(a), s2) })
+    def flatMap[B](f: A => State[S, B]): State[S, B] =
+      State({ s => val (a, s2) = self.run(s); f(a).run(s2) })
   }
 
   object State {
-    implicit def instance[S] = new Monad[State[S, ?]] {
-      def pure[A](a: A) = State[S, A](s => (a, s))
-      def flatMap[A, B](sa: State[S, A])(f: A => State[S, B]) = sa.flatMap(f)
+    implicit def instance[S]: Monad[State[S, ?]] = new Monad[State[S, ?]] {
+      def pure[A](a: A): State[S, A] = State(s => (a, s))
+      def flatMap[A, B](sa: State[S, A])(f: A => State[S, B]): State[S, B] = sa.flatMap(f)
     }
   }
 


### PR DESCRIPTION
@non [mentioned](https://github.com/non/cats/issues/291#issuecomment-99097551) that he would like to see this requirement. I don't know that I think we need it _everywhere_, but I do like that it catches cases where we accidentally forget to add a return type, as happened [here](https://github.com/non/cats/pull/302#discussion_r29667659) and some other places.

This pull requests adds a Scalasytle rule that enforces this constraint. It also updates the existing code to pass the Scalastyle rule.

Note: Scalastyle is producing false-positives for local defs.