### PR TITLE
Provide a default implementation of split in Arrow

### DIFF
--- a/core/src/main/scala/cats/arrow/Arrow.scala
+++ b/core/src/main/scala/cats/arrow/Arrow.scala
@@ -14,6 +14,9 @@ trait Arrow[F[_, _]] extends Split[F] with Strong[F] with Category[F] { self =>
     def swap[X, Y] = lift[(X, Y), (Y, X)] { case (x, y) => (y, x) }
     compose(swap, compose(first[A, B, C](fa), swap))
   }
+
+  def split[A, B, C, D](f: F[A, B], g: F[C, D]): F[(A, C), (B, D)] =
+    andThen(first(f), second(g))
 }
 
 object Arrow {

--- a/core/src/main/scala/cats/data/Cokleisli.scala
+++ b/core/src/main/scala/cats/data/Cokleisli.scala
@@ -90,6 +90,9 @@ private trait CokleisliArrow[F[_]] extends Arrow[Cokleisli[F, ?, ?]] with Coklei
 
   override def dimap[A, B, C, D](fab: Cokleisli[F, A, B])(f: C => A)(g: B => D): Cokleisli[F, C, D] =
     super[CokleisliProfunctor].dimap(fab)(f)(g)
+
+  override def split[A, B, C, D](f: Cokleisli[F, A, B], g: Cokleisli[F, C, D]): Cokleisli[F, (A, C), (B, D)] =
+    super[CokleisliSplit].split(f, g)
 }
 
 private trait CokleisliSplit[F[_]] extends Split[Cokleisli[F, ?, ?]] {

--- a/core/src/main/scala/cats/data/Kleisli.scala
+++ b/core/src/main/scala/cats/data/Kleisli.scala
@@ -142,6 +142,9 @@ private trait KleisliArrow[F[_]] extends Arrow[Kleisli[F, ?, ?]] with KleisliSpl
 
   override def second[A, B, C](fa: Kleisli[F, A, B]): Kleisli[F, (C, A), (C, B)] =
     super[KleisliStrong].second(fa)
+
+  override def split[A, B, C, D](f: Kleisli[F, A, B], g: Kleisli[F, C, D]): Kleisli[F, (A, C), (B, D)] =
+    super[KleisliSplit].split(f, g)
 }
 
 private trait KleisliSplit[F[_]] extends Split[Kleisli[F, ?, ?]] {

--- a/std/src/main/scala/cats/std/function.scala
+++ b/std/src/main/scala/cats/std/function.scala
@@ -53,7 +53,7 @@ trait Function1Instances {
 
       def id[A]: A => A = a => a
 
-      def split[A, B, C, D](f: A => B, g: C => D): ((A, C)) => (B, D) = {
+      override def split[A, B, C, D](f: A => B, g: C => D): ((A, C)) => (B, D) = {
         case (a, c) => (f(a), g(c))
       }
 


### PR DESCRIPTION
We can provide a default implementation of `split` in `Arrow` using `first` and `second` from `Strong`.