### PR TITLE
Do not use explicit parameters for the Alternative laws

### DIFF
--- a/laws/src/main/scala/cats/laws/discipline/AlternativeTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/AlternativeTests.scala
@@ -2,17 +2,16 @@ package cats
 package laws
 package discipline
 
-import cats.laws.AlternativeLaws
 import org.scalacheck.Arbitrary
 import org.scalacheck.Prop
 import Prop._
 
 trait AlternativeTests[F[_]] extends ApplicativeTests[F] with MonoidKTests[F]  {
-  def laws:AlternativeLaws[F]
+  def laws: AlternativeLaws[F]
 
   def alternative[A: Arbitrary, B: Arbitrary, C: Arbitrary](implicit
     ArbF: ArbitraryK[F],
-    arbFAB: Arbitrary[F[A => B]],
+    ArbFAB: Arbitrary[F[A => B]],
     EqFA: Eq[F[A]],
     EqFB: Eq[F[B]],
     EqFC: Eq[F[C]]
@@ -24,12 +23,9 @@ trait AlternativeTests[F[_]] extends ApplicativeTests[F] with MonoidKTests[F]  {
       val bases: Seq[(String, RuleSet)] = Nil
       val parents: Seq[RuleSet] = Seq(monoidK[A], applicative[A,B,C])
       val props: Seq[(String, Prop)] = Seq(
-        "left distributivity" -> forAll((fa1: F[A], fa2: F[A], fab: A => B) =>
-          laws.alternativeLeftDistributivity[A,B](fa1, fa2, fab)),
-        "right distributivity" -> forAll((fa: F[A], fab1: F[A => B], fab2: F[A => B]) =>
-          laws.alternativeRightDistributivity[A,B](fa, fab1, fab2)),
-        "right absorption" -> forAll((fab: F[A => B]) =>
-          laws.alternativeRightAbsorption[A,B](fab))
+        "left distributivity" -> forAll(laws.alternativeLeftDistributivity[A, B] _),
+        "right distributivity" -> forAll(laws.alternativeRightDistributivity[A, B] _),
+        "right absorption" -> forAll(laws.alternativeRightAbsorption[A, B] _)
       )
     }
 }


### PR DESCRIPTION
This reverts a small change of #303 that wasn't necessary, see also https://github.com/non/cats/pull/303#discussion_r29773243.