### PR TITLE
Rename apply

### DIFF
--- a/core/src/main/scala/cats/Applicative.scala
+++ b/core/src/main/scala/cats/Applicative.scala
@@ -20,7 +20,7 @@ import simulacrum._
    */
   def pure[A](x: A): F[A]
 
-  override def map[A, B](fa: F[A])(f: A => B): F[B] = apply(fa)(pure(f))
+  override def map[A, B](fa: F[A])(f: A => B): F[B] = ap(fa)(pure(f))
 
   /**
    * Two sequentially dependent Applicatives can be composed.

--- a/core/src/main/scala/cats/Apply.scala
+++ b/core/src/main/scala/cats/Apply.scala
@@ -17,7 +17,7 @@ trait Apply[F[_]] extends Functor[F] with ApplyArityFunctions[F] { self =>
   def ap[A, B](fa: F[A])(f: F[A => B]): F[B]
 
   /**
-   * apply2 is a binary version of ap, defined in terms of ap.
+   * ap2 is a binary version of ap, defined in terms of ap.
    */
   def ap2[A, B, Z](fa: F[A], fb: F[B])(f: F[(A, B) => Z]): F[Z] =
     ap(fb)(ap(fa)(map(f)(f => (a: A) => (b: B) => f(a, b))))

--- a/core/src/main/scala/cats/Apply.scala
+++ b/core/src/main/scala/cats/Apply.scala
@@ -14,13 +14,13 @@ trait Apply[F[_]] extends Functor[F] with ApplyArityFunctions[F] { self =>
    * Given a value and a function in the Apply context, applies the
    * function to the value.
    */
-  def apply[A, B](fa: F[A])(f: F[A => B]): F[B]
+  def ap[A, B](fa: F[A])(f: F[A => B]): F[B]
 
   /**
-   * apply2 is a binary version of apply, defined in terms of apply.
+   * apply2 is a binary version of ap, defined in terms of ap.
    */
-  def apply2[A, B, Z](fa: F[A], fb: F[B])(f: F[(A, B) => Z]): F[Z] =
-    apply(fb)(apply(fa)(map(f)(f => (a: A) => (b: B) => f(a, b))))
+  def ap2[A, B, Z](fa: F[A], fb: F[B])(f: F[(A, B) => Z]): F[Z] =
+    ap(fb)(ap(fa)(map(f)(f => (a: A) => (b: B) => f(a, b))))
 
   /**
    * Applies the pure (binary) function f to the effectful values fa and fb.
@@ -28,7 +28,7 @@ trait Apply[F[_]] extends Functor[F] with ApplyArityFunctions[F] { self =>
    * map2 can be seen as a binary version of [[cats.Functor]]#map.
    */
   def map2[A, B, Z](fa: F[A], fb: F[B])(f: (A, B) => Z): F[Z] =
-    apply(fb)(map(fa)(a => (b: B) => f(a, b)))
+    ap(fb)(map(fa)(a => (b: B) => f(a, b)))
 
   /**
    * Two sequentially dependent Applys can be composed.
@@ -52,6 +52,6 @@ trait CompositeApply[F[_], G[_]]
   def F: Apply[F]
   def G: Apply[G]
 
-  def apply[A, B](fa: F[G[A]])(f: F[G[A => B]]): F[G[B]] =
-    F.apply(fa)(F.map(f)(gab => G.apply(_)(gab)))
+  def ap[A, B](fa: F[G[A]])(f: F[G[A => B]]): F[G[B]] =
+    F.ap(fa)(F.map(f)(gab => G.ap(_)(gab)))
 }

--- a/core/src/main/scala/cats/FlatMap.scala
+++ b/core/src/main/scala/cats/FlatMap.scala
@@ -26,7 +26,7 @@ import simulacrum._
   def flatten[A](ffa: F[F[A]]): F[A] =
     flatMap(ffa)(fa => fa)
 
-  override def apply[A, B](fa: F[A])(ff: F[A => B]): F[B] =
+  override def ap[A, B](fa: F[A])(ff: F[A => B]): F[B] =
     flatMap(ff)(f => map(fa)(f))
 
   /**

--- a/core/src/main/scala/cats/data/Const.scala
+++ b/core/src/main/scala/cats/data/Const.scala
@@ -76,7 +76,7 @@ sealed abstract class ConstInstances0 extends ConstInstances1 {
     def pure[A](x: A): Const[C, A] =
       Const.empty
 
-    def apply[A, B](fa: Const[C, A])(f: Const[C, A => B]): Const[C, B] =
+    def ap[A, B](fa: Const[C, A])(f: Const[C, A => B]): Const[C, B] =
       fa.retag[B] combine f.retag[B]
   }
 }
@@ -88,7 +88,7 @@ sealed abstract class ConstInstances1 {
   }
 
   implicit def constApply[C: Semigroup]: Apply[Const[C, ?]] = new Apply[Const[C, ?]] {
-    def apply[A, B](fa: Const[C, A])(f: Const[C, A => B]): Const[C, B] =
+    def ap[A, B](fa: Const[C, A])(f: Const[C, A => B]): Const[C, B] =
       fa.retag[B] combine f.retag[B]
 
     def map[A, B](fa: Const[C, A])(f: A => B): Const[C, B] =

--- a/core/src/main/scala/cats/data/Kleisli.scala
+++ b/core/src/main/scala/cats/data/Kleisli.scala
@@ -10,7 +10,7 @@ import cats.functor.Strong
 final case class Kleisli[F[_], A, B](run: A => F[B]) { self =>
 
   def apply[C](f: Kleisli[F, A, B => C])(implicit F: Apply[F]): Kleisli[F, A, C] =
-    Kleisli(a => F.apply(run(a))(f.run(a)))
+    Kleisli(a => F.ap(run(a))(f.run(a)))
 
   def dimap[C, D](f: C => A)(g: B => D)(implicit F: Functor[F]): Kleisli[F, C, D] =
     Kleisli(c => F.map(run(f(c)))(g))
@@ -109,15 +109,15 @@ sealed abstract class KleisliInstances1 extends KleisliInstances2 {
     def pure[B](x: B): Kleisli[F, A, B] =
       Kleisli.pure[F, A, B](x)
 
-    def apply[B, C](fa: Kleisli[F, A, B])(f: Kleisli[F, A, B => C]): Kleisli[F, A, C] =
-      fa.apply(f)
+    def ap[B, C](fa: Kleisli[F, A, B])(f: Kleisli[F, A, B => C]): Kleisli[F, A, C] =
+      fa(f)
   }
 }
 
 sealed abstract class KleisliInstances2 extends KleisliInstances3 {
   implicit def kleisliApply[F[_]: Apply, A]: Apply[Kleisli[F, A, ?]] = new Apply[Kleisli[F, A, ?]] {
-    def apply[B, C](fa: Kleisli[F, A, B])(f: Kleisli[F, A, B => C]): Kleisli[F, A, C] =
-      fa.apply(f)
+    def ap[B, C](fa: Kleisli[F, A, B])(f: Kleisli[F, A, B => C]): Kleisli[F, A, C] =
+      fa(f)
 
     def map[B, C](fa: Kleisli[F, A, B])(f: B => C): Kleisli[F, A, C] =
       fa.map(f)

--- a/core/src/main/scala/cats/data/Validated.scala
+++ b/core/src/main/scala/cats/data/Validated.scala
@@ -107,7 +107,7 @@ sealed abstract class Validated[+E, +A] extends Product with Serializable {
    * From Apply:
    * if both the function and this value are Valid, apply the function
    */
-  def apply[EE >: E, B](f: Validated[EE, A => B])(implicit EE: Semigroup[EE]): Validated[EE,B] =
+  def ap[EE >: E, B](f: Validated[EE, A => B])(implicit EE: Semigroup[EE]): Validated[EE,B] =
     (this, f) match {
       case (Valid(a), Valid(f)) => Valid(f(a))
       case (Invalid(e1), Invalid(e2)) => Invalid(EE.combine(e1,e2))
@@ -177,7 +177,7 @@ sealed abstract class ValidatedInstances extends ValidatedInstances1 {
     def pure[A](a: A): Validated[E,A] = Validated.valid(a)
     override def map[A, B](fa: Validated[E,A])(f: A => B): Validated[E, B] = fa.map(f)
 
-    override def apply[A,B](fa: Validated[E,A])(f: Validated[E,A=>B]) =
+    override def ap[A,B](fa: Validated[E,A])(f: Validated[E,A=>B]) =
       (fa,f) match {
         case (Valid(a),Valid(f)) => Valid(f(a))
         case (e @ Invalid(_), Valid(_)) => e

--- a/core/src/main/scala/cats/data/XorT.scala
+++ b/core/src/main/scala/cats/data/XorT.scala
@@ -37,7 +37,7 @@ case class XorT[F[_], A, B](value: F[A Xor B]) {
   def bimap[C, D](fa: A => C, fb: B => D)(implicit F: Functor[F]): XorT[F, C, D] = XorT(F.map(value)(_.bimap(fa, fb)))
 
   def applyAlt[D](ff: XorT[F, A, B => D])(implicit F: Apply[F]): XorT[F, A, D] =
-    XorT[F, A, D](F.map2(this.value, ff.value)((xb, xbd) => Apply[A Xor ?].apply(xb)(xbd)))
+    XorT[F, A, D](F.map2(this.value, ff.value)((xb, xbd) => Apply[A Xor ?].ap(xb)(xbd)))
 
   def flatMap[AA >: A, D](f: B => XorT[F, AA, D])(implicit F: Monad[F]): XorT[F, AA, D] =
     XorT(F.flatMap(value) {

--- a/core/src/main/scala/cats/package.scala
+++ b/core/src/main/scala/cats/package.scala
@@ -33,7 +33,7 @@ package object cats {
       def flatMap[A, B](a: A)(f: A => B): B = f(a)
       def coflatMap[A, B](a: A)(f: A => B): B = f(a)
       override def map[A, B](fa: A)(f: A => B): B = f(fa)
-      override def apply[A, B](fa: A)(ff: A => B): B = ff(fa)
+      override def ap[A, B](fa: A)(ff: A => B): B = ff(fa)
       override def flatten[A](ffa: A): A = ffa
       override def map2[A, B, Z](fa: A, fb: B)(f: (A, B) => Z): Z = f(fa, fb)
       override def lift[A, B](f: A => B): A => B = f

--- a/core/src/main/scala/cats/syntax/apply.scala
+++ b/core/src/main/scala/cats/syntax/apply.scala
@@ -10,7 +10,6 @@ trait ApplySyntax1 {
 }
 
 trait ApplySyntax extends ApplySyntax1 {
-  // TODO: use simulacrum instances eventually
   implicit def applySyntax[F[_], A](fa: F[A])(implicit F: Apply[F]): ApplyOps[F, A] =
     new ApplyOps[F,A] {
       val self = fa

--- a/docs/src/main/tut/apply.md
+++ b/docs/src/main/tut/apply.md
@@ -7,12 +7,12 @@ scaladoc: "#cats.Apply"
 ---
 # Apply
 
-Apply extends the Functor typeclass (which features the familiar
-"map" function) with a new function "apply".  The apply function
-is similar to map in that we are transforming a value in a context,
-e.g. F[A] where F is the context (e.g. Option, List, Future) and A
-is the type of the value.  But the function A => B is now in the
-context itself, e.g. F[A => B] such as Option[A => B] or List[A => B].
+Apply extends the Functor typeclass (which features the familiar "map"
+function) with a new function "ap".  The ap function is similar to map
+in that we are transforming a value in a context, e.g. F[A] where F is
+the context (e.g. Option, List, Future) and A is the type of the
+value.  But the function A => B is now in the context itself,
+e.g. F[A => B] such as Option[A => B] or List[A => B].
 
 ```tut
 import cats._
@@ -21,14 +21,14 @@ val double: Int => Int = _ * 2
 val addTwo: Int => Int = _ + 2
 
 implicit val optionApply: Apply[Option] = new Apply[Option] {
-  def apply[A, B](fa: Option[A])(f: Option[A => B]): Option[B] =
+  def ap[A, B](fa: Option[A])(f: Option[A => B]): Option[B] =
     fa.flatMap (a => f.map (ff => ff(a)))
 
   def map[A,B](fa: Option[A])(f: A => B) = fa map f
 }
 
 implicit val listApply: Apply[List] = new Apply[List] {
-  def apply[A, B](fa: List[A])(f: List[A => B]): List[B] =
+  def ap[A, B](fa: List[A])(f: List[A => B]): List[B] =
     fa.flatMap (a => f.map (ff => ff(a)))
 
   def map[A,B](fa: List[A])(f: A => B) = fa map f
@@ -51,23 +51,23 @@ Apply[Option].map(None)(double)
 But also the new apply method, which applies functions from the functor
 
 ```tut
-Apply[Option].apply(Some(1))(Some(intToString))
-Apply[Option].apply(Some(1))(Some(double))
-Apply[Option].apply(None)(Some(double))
-Apply[Option].apply(Some(1))(None)
-Apply[Option].apply(None)(None)
+Apply[Option].ap(Some(1))(Some(intToString))
+Apply[Option].ap(Some(1))(Some(double))
+Apply[Option].ap(None)(Some(double))
+Apply[Option].ap(Some(1))(None)
+Apply[Option].ap(None)(None)
 ```
 
-### apply3, etc
+### ap3, etc
 
-Apply's apply function made it possible to build useful functions that
+Apply's ap function made it possible to build useful functions that
 "lift" a function that takes multiple arguments into a context.
 
 For example:
 
 ```tut
 val add2 = (a: Int, b: Int) => a + b
-Apply[Option].apply2(Some(1), Some(2))(Some(add2))
+Apply[Option].ap2(Some(1), Some(2))(Some(add2))
 ```
 
 Interestingly, if any of the arguments of this example are None, the
@@ -75,13 +75,13 @@ final result is None.  The effects of the context we are operating on
 are carried through the entire computation.
 
 ```tut
-Apply[Option].apply2(Some(1), None)(Some(add2))
-Apply[Option].apply2(Some(1), Some(2))(None)
+Apply[Option].ap2(Some(1), None)(Some(add2))
+Apply[Option].ap2(Some(1), Some(2))(None)
 ```
 
 ## apply builder syntax
 
-The `|@|` operator offers an alternative syntax for the higher-arity `Apply` functions (`applyN`, `mapN`).
+The `|@|` operator offers an alternative syntax for the higher-arity `Apply` functions (`apN`, `mapN`).
 First, import `cats.syntax.all._` or `cats.syntax.apply._`. Here we see that following two functions, `f1` and `f2`, are equivalent:
 ```tut
 import cats.syntax.apply._
@@ -96,7 +96,7 @@ f1(Some(1), Some(2), Some(3))
 f2(Some(1), Some(2), Some(3))
 ```
 
-All instances created by `|@|` have `map`, `apply`, and `tupled` methods of the appropriate arity.
+All instances created by `|@|` have `map`, `ap`, and `tupled` methods of the appropriate arity.
 
 ## composition
 
@@ -105,5 +105,5 @@ Like Functors, Apply instances also compose:
 ```tut
 val listOpt = Apply[List] compose Apply[Option]
 val plusOne = (x:Int) => x + 1
-listOpt.apply(List(Some(1), None, Some(3)))(List(Some(plusOne)))
+listOpt.ap(List(Some(1), None, Some(3)))(List(Some(plusOne)))
 ```

--- a/free/src/main/scala/cats/free/FreeApplicative.scala
+++ b/free/src/main/scala/cats/free/FreeApplicative.scala
@@ -33,7 +33,7 @@ sealed abstract class FreeApplicative[F[_], A] { self =>
   final def run[G[_]](f: F ~> G)(implicit G: Applicative[G]): G[A] =
     this match {
       case Pure(a) => G.pure(a)
-      case x: Ap[F, A] => G.apply(f(x.pivot))(x.fn.run(f))
+      case x: Ap[F, A] => G.ap(f(x.pivot))(x.fn.run(f))
     }
 }
 
@@ -64,7 +64,7 @@ object FreeApplicative {
 
   implicit final def freeApplicative[S[_]]: Applicative[FA[S, ?]] = {
     new Applicative[FA[S, ?]] {
-      def apply[A, B](fa: FA[S, A])(f: FA[S, A => B]): FA[S, B] = fa.ap(f)
+      def ap[A, B](fa: FA[S, A])(f: FA[S, A => B]): FA[S, B] = fa.ap(f)
       def pure[A](a: A): FA[S, A] = Pure(a)
     }
   }

--- a/laws/src/main/scala/cats/laws/AlternativeLaws.scala
+++ b/laws/src/main/scala/cats/laws/AlternativeLaws.scala
@@ -8,13 +8,13 @@ trait AlternativeLaws[F[_]] extends ApplicativeLaws[F] with MonoidKLaws[F] {
   implicit def algebra[A] = F.algebra[A]
 
   def alternativeRightAbsorption[A, B](ff: F[A => B]): IsEq[F[B]] =
-    (F.empty[A] apply ff) <-> F.empty[B]
+    (F.empty[A] ap ff) <-> F.empty[B]
 
   def alternativeLeftDistributivity[A, B](fa: F[A], fa2: F[A], f: A => B): IsEq[F[B]] =
     ((fa |+| fa2) map f) <-> ((fa map f) |+| (fa2 map f))
 
   def alternativeRightDistributivity[A, B](fa: F[A], ff: F[A => B], fg: F[A => B]): IsEq[F[B]] =
-    (fa apply (ff |+| fg)) <-> ((fa apply ff) |+| (fa apply fg))
+    (fa ap (ff |+| fg)) <-> ((fa ap ff) |+| (fa ap fg))
 
 }
 

--- a/laws/src/main/scala/cats/laws/ApplicativeLaws.scala
+++ b/laws/src/main/scala/cats/laws/ApplicativeLaws.scala
@@ -11,16 +11,16 @@ trait ApplicativeLaws[F[_]] extends ApplyLaws[F] {
   implicit override def F: Applicative[F]
 
   def applicativeIdentity[A](fa: F[A]): IsEq[F[A]] =
-    fa.apply(F.pure((a: A) => a)) <-> fa
+    fa.ap(F.pure((a: A) => a)) <-> fa
 
   def applicativeHomomorphism[A, B](a: A, f: A => B): IsEq[F[B]] =
-    F.pure(a).apply(F.pure(f)) <-> F.pure(f(a))
+    F.pure(a).ap(F.pure(f)) <-> F.pure(f(a))
 
   def applicativeInterchange[A, B](a: A, ff: F[A => B]): IsEq[F[B]] =
-    F.pure(a).apply(ff) <-> ff.apply(F.pure(f => f(a)))
+    F.pure(a).ap(ff) <-> ff.ap(F.pure(f => f(a)))
 
   def applicativeMap[A, B](fa: F[A], f: A => B): IsEq[F[B]] =
-    fa.map(f) <-> fa.apply(F.pure(f))
+    fa.map(f) <-> fa.ap(F.pure(f))
 
   /**
    * This law is [[applyComposition]] stated in terms of `pure`. It is a
@@ -29,7 +29,7 @@ trait ApplicativeLaws[F[_]] extends ApplyLaws[F] {
    */
   def applicativeComposition[A, B, C](fa: F[A], fab: F[A => B], fbc: F[B => C]): IsEq[F[C]] = {
     val compose: (B => C) => (A => B) => (A => C) = _.compose
-    fa.apply(fab.apply(fbc.apply(F.pure(compose)))) <-> fa.apply(fab).apply(fbc)
+    fa.ap(fab.ap(fbc.ap(F.pure(compose)))) <-> fa.ap(fab).ap(fbc)
   }
 }
 

--- a/laws/src/main/scala/cats/laws/ApplyLaws.scala
+++ b/laws/src/main/scala/cats/laws/ApplyLaws.scala
@@ -12,7 +12,7 @@ trait ApplyLaws[F[_]] extends FunctorLaws[F] {
 
   def applyComposition[A, B, C](fa: F[A], fab: F[A => B], fbc: F[B => C]): IsEq[F[C]] = {
     val compose: (B => C) => (A => B) => (A => C) = _.compose
-    fa.apply(fab).apply(fbc) <-> fa.apply(fab.apply(fbc.map(compose)))
+    fa.ap(fab).ap(fbc) <-> fa.ap(fab.ap(fbc.map(compose)))
   }
 }
 

--- a/laws/src/main/scala/cats/laws/FlatMapLaws.scala
+++ b/laws/src/main/scala/cats/laws/FlatMapLaws.scala
@@ -16,7 +16,7 @@ trait FlatMapLaws[F[_]] extends ApplyLaws[F] {
     fa.flatMap(f).flatMap(g) <-> fa.flatMap(a => f(a).flatMap(g))
 
   def flatMapConsistentApply[A, B](fa: F[A], fab: F[A => B]): IsEq[F[B]] =
-    fa.apply(fab) <-> fab.flatMap(f => fa.map(f))
+    fa.ap(fab) <-> fab.flatMap(f => fa.map(f))
 
   /**
    * The composition of [[cats.data.Kleisli]] arrows is associative. This is

--- a/project/Boilerplate.scala
+++ b/project/Boilerplate.scala
@@ -116,7 +116,7 @@ object Boilerplate {
         |
         -  private[syntax] class ApplyBuilder$arity[${`A..N`}](${params}) {
         -    $next
-        -    def apply[Z](f: F[(${`A..N`}) => Z])(implicit F: Apply[F]): F[Z] = F.apply$n(${`a..n`})(f)
+        -    def ap[Z](f: F[(${`A..N`}) => Z])(implicit F: Apply[F]): F[Z] = F.ap$n(${`a..n`})(f)
         -    def map[Z](f: (${`A..N`}) => Z)(implicit F: Apply[F]): F[Z] = F.map$n(${`a..n`})(f)
         -    $tupled
         - }
@@ -144,11 +144,11 @@ object Boilerplate {
       val fArgsB = (a until arity) map { "f" + _ } mkString ","
       val argsA = (0 until a) map { "a" + _ } mkString ","
       val argsB = (a until arity) map { "a" + _ } mkString ","
-      def applyN(n: Int) = if (n == 1) { "apply" } else { s"apply$n" }
+      def apN(n: Int) = if (n == 1) { "ap" } else { s"ap$n" }
       def allArgs = (0 until arity) map { "a" + _ } mkString ","
 
       val map = if (arity == 3) {
-        "- apply(f2)(map2(f0, f1)((a, b) => c => f(a, b, c)))"
+        " ap(f2)(map2(f0, f1)((a, b) => c => f(a, b, c)))"
       }  else {
         block"""
           -    map2(tuple$a($fArgsA), tuple$b($fArgsB)) {
@@ -158,7 +158,7 @@ object Boilerplate {
       }
       val apply =
         block"""
-          -    ${applyN(b)}($fArgsB)(${applyN(a)}($fArgsA)(map(f)(f =>
+          -    ${apN(b)}($fArgsB)(${apN(a)}($fArgsA)(map(f)(f =>
           -      ($argsA) => ($argsB) => f($allArgs)
           -    )))
           """
@@ -168,11 +168,9 @@ object Boilerplate {
         |trait ApplyArityFunctions[F[_]] { self: Apply[F] =>
         |  def tuple2[A, B](fa: F[A], fb: F[B]): F[(A, B)] = map2(fa, fb)((_, _))
         |
-        -  def apply$arity[${`A..N`}, Z]($fparams)(f: F[(${`A..N`}) => Z]):F[Z] =
-              $apply
-        -  def map$arity[${`A..N`}, Z]($fparams)(f: (${`A..N`}) => Z):F[Z] =
-               $map
-        -  def tuple$arity[${`A..N`}]($fparams):F[(${`A..N`})] =
+        -  def ap$arity[${`A..N`}, Z]($fparams)(f: F[(${`A..N`}) => Z]):F[Z] = $apply
+        -  def map$arity[${`A..N`}, Z]($fparams)(f: (${`A..N`}) => Z):F[Z] = $map
+        -  def tuple$arity[${`A..N`}]($fparams):F[(${`A..N`})] = 
         -    map$arity($fargsS)((${`_.._`}))
         |}
       """

--- a/std/src/main/scala/cats/std/map.scala
+++ b/std/src/main/scala/cats/std/map.scala
@@ -29,10 +29,10 @@ trait MapInstances extends algebra.std.MapInstances {
       override def map2[A, B, Z](fa: Map[K, A], fb: Map[K, B])(f: (A, B) => Z): Map[K, Z] =
         fa.flatMap { case (k, a) => fb.get(k).map(b => (k, f(a, b))) }
 
-      override def apply[A, B](fa: Map[K, A])(ff: Map[K, A => B]): Map[K, B] =
+      override def ap[A, B](fa: Map[K, A])(ff: Map[K, A => B]): Map[K, B] =
         fa.flatMap { case (k, a) => ff.get(k).map(f => (k, f(a))) }
 
-      override def apply2[A, B, Z](fa: Map[K, A], fb: Map[K, B])(f: Map[K, (A, B) => Z]): Map[K, Z] =
+      override def ap2[A, B, Z](fa: Map[K, A], fb: Map[K, B])(f: Map[K, (A, B) => Z]): Map[K, Z] =
         f.flatMap { case (k, f) =>
           for { a <- fa.get(k); b <- fb.get(k) } yield (k, f(a, b))
         }

--- a/tests/src/test/scala/cats/tests/RegressionTests.scala
+++ b/tests/src/test/scala/cats/tests/RegressionTests.scala
@@ -50,8 +50,8 @@ class RegressionTests extends CatsSuite {
     assert(buf.toList == names)
   }
 
-  test("#167: confirm apply2 order") {
-    val twelve = Apply[State[String, ?]].apply2(
+  test("#167: confirm ap2 order") {
+    val twelve = Apply[State[String, ?]].ap2(
       State[String, Unit](s => ((), s + "1")),
       State[String, Unit](s => ((), s + "2"))
     )(State.instance[String].pure((_: Unit, _: Unit) => ())).run("")._2


### PR DESCRIPTION
rename the "apply" method on the Apply typeclass to "ap". apply is such a special name in the scala world that this method, which is rarely useful to users, should probably not use this name.