### PR TITLE
Add six new Comonad laws.

### DIFF
--- a/core/src/main/scala/cats/Lazy.scala
+++ b/core/src/main/scala/cats/Lazy.scala
@@ -102,7 +102,10 @@ object Lazy {
    * Alias for `apply`, to mirror the `byName` method.
    */
   def byNeed[A](body: => A): Lazy[A] =
-    new ByNeed[A]{
+    new ByNeed[A] {
       override lazy val value = body
     }
+
+  implicit def lazyEq[A: Eq]: Eq[Lazy[A]] =
+    Eq.by(_.value)
 }

--- a/laws/src/main/scala/cats/laws/ComonadLaws.scala
+++ b/laws/src/main/scala/cats/laws/ComonadLaws.scala
@@ -2,14 +2,31 @@ package cats
 package laws
 
 import cats.data.Cokleisli
-import cats.syntax.coflatMap._
-import cats.syntax.comonad._
+import cats.implicits._
 
 /**
  * Laws that must be obeyed by any [[Comonad]].
  */
 trait ComonadLaws[F[_]] extends CoflatMapLaws[F] {
   implicit override def F: Comonad[F]
+
+  def extractCoflattenIdentity[A](fa: F[A]): IsEq[F[A]] =
+    fa.coflatten.extract <-> fa
+
+  def mapCoflattenIdentity[A](fa: F[A]): IsEq[F[A]] =
+    fa.coflatten.map(_.extract) <-> fa
+
+  def coflattenThroughMap[A](fa: F[A]): IsEq[F[F[F[A]]]] =
+    fa.coflatten.coflatten <-> fa.coflatten.map(_.coflatten)
+
+  def coflattenCoherence[A, B](fa: F[A], f: F[A] => B): IsEq[F[B]] =
+    fa.coflatMap(f) <-> fa.coflatten.map(f)
+
+  def coflatMapIdentity[A, B](fa: F[A]): IsEq[F[F[A]]] =
+    fa.coflatten <-> fa.coflatMap(identity)
+
+  def mapCoflatMapCoherence[A, B](fa: F[A], f: A => B): IsEq[F[B]] =
+    fa.map(f) <-> fa.coflatMap(fa0 => f(fa0.extract))
 
   def comonadLeftIdentity[A](fa: F[A]): IsEq[F[A]] =
     fa.coflatMap(_.extract) <-> fa

--- a/laws/src/main/scala/cats/laws/discipline/ArbitraryK.scala
+++ b/laws/src/main/scala/cats/laws/discipline/ArbitraryK.scala
@@ -13,6 +13,9 @@ trait ArbitraryK[F[_]] {
 }
 
 object ArbitraryK {
+
+  def apply[F[_]](implicit arbk: ArbitraryK[F]): ArbitraryK[F] = arbk
+
   implicit val option: ArbitraryK[Option] =
     new ArbitraryK[Option] { def synthesize[A: Arbitrary]: Arbitrary[Option[A]] = implicitly }
 

--- a/laws/src/main/scala/cats/laws/discipline/ComonadTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/ComonadTests.scala
@@ -7,25 +7,43 @@ import org.scalacheck.Prop
 import Prop._
 
 trait ComonadTests[F[_]] extends CoflatMapTests[F] {
+
+  implicit def arbitraryK: ArbitraryK[F]
+  implicit def eqK: EqK[F]
+
   def laws: ComonadLaws[F]
 
-  def comonad[A: Arbitrary, B: Arbitrary, C: Arbitrary](implicit
-    ArbF: ArbitraryK[F],
-    EqB: Eq[B],
-    EqFA: Eq[F[A]],
-    EqFC: Eq[F[C]]
-  ): RuleSet = {
-    implicit def ArbFA: Arbitrary[F[A]] = ArbF.synthesize[A]
+  def comonad[A: Arbitrary: Eq, B: Arbitrary: Eq, C: Arbitrary: Eq]: RuleSet = {
+    implicit def ArbFA: Arbitrary[F[A]] = ArbitraryK[F].synthesize[A]
+
+    implicit val eqfa: Eq[F[A]] = EqK[F].synthesize[A]
+    implicit val eqffa: Eq[F[F[A]]] = EqK[F].synthesize[F[A]]
+    implicit val eqfffa: Eq[F[F[F[A]]]] = EqK[F].synthesize[F[F[A]]]
+    implicit val eqfb: Eq[F[B]] = EqK[F].synthesize[B]
+    implicit val eqfc: Eq[F[C]] = EqK[F].synthesize[C]
 
     new DefaultRuleSet(
       name = "comonad",
       parent = Some(coflatMap[A, B, C]),
+
+      "extractCoflattenIdentity" -> forAll(laws.extractCoflattenIdentity[A] _),
+      "mapCoflattenIdentity" -> forAll(laws.mapCoflattenIdentity[A] _),
+      "coflattenThroughMap" -> forAll(laws.coflattenThroughMap[A] _),
+
+      "coflattenCoherence" -> forAll(laws.coflattenCoherence[A, B] _),
+      "coflatMapIdentity" -> forAll(laws.coflatMapIdentity[A, B] _),
+      "mapCoflatMapCoherence" -> forAll(laws.mapCoflatMapCoherence[A, B] _),
+
       "comonad left identity" -> forAll(laws.comonadLeftIdentity[A] _),
       "comonad right identity" -> forAll(laws.comonadRightIdentity[A, B] _))
   }
 }
 
 object ComonadTests {
-  def apply[F[_]: Comonad]: ComonadTests[F] =
-    new ComonadTests[F] { def laws: ComonadLaws[F] = ComonadLaws[F] }
+  def apply[F[_]: ArbitraryK: Comonad: EqK]: ComonadTests[F] =
+    new ComonadTests[F] {
+      def arbitraryK: ArbitraryK[F] = ArbitraryK[F]
+      def eqK: EqK[F] = EqK[F]
+      def laws: ComonadLaws[F] = ComonadLaws[F]
+    }
 }

--- a/laws/src/main/scala/cats/laws/discipline/EqK.scala
+++ b/laws/src/main/scala/cats/laws/discipline/EqK.scala
@@ -1,0 +1,86 @@
+package cats
+package laws
+package discipline
+
+import cats.data.{Cokleisli, Kleisli, Validated, Xor, XorT, Ior, Const}
+import cats.laws.discipline.arbitrary._
+import org.scalacheck.Arbitrary
+
+import cats.implicits._
+
+import scala.concurrent.Future
+
+trait EqK[F[_]] {
+  def synthesize[A: Eq]: Eq[F[A]]
+}
+
+object EqK {
+
+  def apply[F[_]](implicit eqk: EqK[F]): EqK[F] = eqk
+
+  implicit val option: EqK[Option] =
+    new EqK[Option] { def synthesize[A: Eq]: Eq[Option[A]] = implicitly }
+
+  implicit def eitherA[A: Eq]: EqK[Either[A, ?]] =
+    new EqK[Either[A, ?]] { def synthesize[B: Eq]: Eq[Either[A, B]] = implicitly }
+
+  implicit def eitherB[B: Eq]: EqK[Either[?, B]] =
+    new EqK[Either[?, B]] { def synthesize[A: Eq]: Eq[Either[A, B]] = implicitly }
+
+  implicit val function0: EqK[Function0] =
+    new EqK[Function0] { def synthesize[A: Eq]: Eq[() => A] = implicitly }
+
+  implicit val list: EqK[List] =
+    new EqK[List] { def synthesize[A: Eq]: Eq[List[A]] = implicitly }
+
+  implicit val lazy_ : EqK[Lazy] =
+    new EqK[Lazy] { def synthesize[A: Eq]: Eq[Lazy[A]] = implicitly }
+
+  implicit def mapA[B: Eq]: EqK[Map[?, B]] =
+    new EqK[Map[?, B]] { def synthesize[A: Eq]: Eq[Map[A, B]] = implicitly }
+
+  implicit def mapB[A]: EqK[Map[A, ?]] =
+    new EqK[Map[A, ?]] { def synthesize[B: Eq]: Eq[Map[A, B]] = implicitly[Eq[Map[A, B]]] }
+
+  implicit def constA[A: Eq]: EqK[Const[A, ?]] =
+    new EqK[Const[A, ?]] { def synthesize[B: Eq]: Eq[Const[A, B]] = implicitly }
+
+  implicit def xorA[A: Eq]: EqK[A Xor ?] =
+    new EqK[A Xor ?] { def synthesize[B: Eq]: Eq[A Xor B] = implicitly }
+
+  implicit def xorB[B: Eq]: EqK[? Xor B] =
+    new EqK[? Xor B] { def synthesize[A: Eq]: Eq[A Xor B] = implicitly }
+
+  implicit def xorTA[F[_]: EqK, A: Eq]: EqK[XorT[F, A, ?]] =
+    new EqK[XorT[F, A, ?]] {
+      def synthesize[B: Eq]: Eq[XorT[F, A, B]] =
+        XorT.xorTEq(EqK[F].synthesize[A Xor B])
+    }
+
+  implicit def xorTB[F[_]: EqK, B: Eq]: EqK[XorT[F, ?, B]] =
+    new EqK[XorT[F, ?, B]] {
+      def synthesize[A: Eq]: Eq[XorT[F, A, B]] =
+        XorT.xorTEq(EqK[F].synthesize[A Xor B])
+    }
+
+  implicit def validA[A: Eq]: EqK[Validated[A, ?]] =
+    new EqK[Validated[A, ?]] { def synthesize[B: Eq]: Eq[Validated[A, B]] = implicitly }
+
+  implicit def validB[B: Eq]: EqK[Validated[?, B]] =
+    new EqK[Validated[?, B]] { def synthesize[A: Eq]: Eq[Validated[A, B]] = implicitly }
+
+  implicit def iorA[A: Eq]: EqK[A Ior ?] =
+    new EqK[A Ior ?] { def synthesize[B: Eq]: Eq[A Ior B] = implicitly }
+
+  implicit def iorB[B: Eq]: EqK[? Ior B] =
+    new EqK[? Ior B] { def synthesize[A: Eq]: Eq[A Ior B] = implicitly }
+
+  implicit val set: EqK[Set] =
+    new EqK[Set] { def synthesize[A: Eq]: Eq[Set[A]] = implicitly }
+
+  implicit val stream: EqK[Stream] =
+    new EqK[Stream] { def synthesize[A: Eq]: Eq[Stream[A]] = implicitly }
+
+  implicit val vector: EqK[Vector] =
+    new EqK[Vector] { def synthesize[A: Eq]: Eq[Vector[A]] = implicitly }
+}

--- a/std/src/main/scala/cats/std/map.scala
+++ b/std/src/main/scala/cats/std/map.scala
@@ -1,7 +1,23 @@
 package cats
 package std
 
+import cats.syntax.eq._
+
 trait MapInstances extends algebra.std.MapInstances {
+
+  implicit def MapEq[A, B: Eq]: Eq[Map[A, B]] =
+    new Eq[Map[A, B]] {
+      def eqv(lhs: Map[A, B], rhs: Map[A, B]): Boolean = {
+        def checkKeys: Boolean =
+          lhs.forall { case (k, v1) =>
+            rhs.get(k) match {
+              case Some(v2) => v1 === v2
+              case None => false
+            }
+          }
+        (lhs eq rhs) || (lhs.size == rhs.size && checkKeys)
+      }
+    }
 
   implicit def MapShow[A, B](implicit showA: Show[A], showB: Show[B]): Show[Map[A, B]] =
     Show.show[Map[A, B]] { m =>

--- a/tests/src/test/scala/cats/tests/FutureTests.scala
+++ b/tests/src/test/scala/cats/tests/FutureTests.scala
@@ -8,6 +8,11 @@ import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class FutureTests extends CatsSuite {
+  implicit val eqkf: EqK[Future] =
+    new EqK[Future] {
+      def synthesize[A: Eq]: Eq[Future[A]] = futureEq(1.second)
+    }
+
   implicit val eqv: Eq[Future[Int]] = futureEq(1.second)
   implicit val comonad: Comonad[Future] = futureComonad(1.second)
 


### PR DESCRIPTION
This commit adds some new laws, as well as adding an EqK[F[_]]
which makes it a bit easier to write tests. Like ArbitraryK,
EqK is defined in the laws module, rather than core.

It also adds some Eq and EqK instances that were previously
absent (the EqK instances are also in laws not core or std).