### PR TITLE
Remove duplicated tutSettings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -78,7 +78,6 @@ lazy val docs = project
   .settings(unidocSettings)
   .settings(site.settings)
   .settings(ghpages.settings)
-  .settings(tutSettings)
   .settings(docSettings)
   .settings(tutSettings)
   .dependsOn(core, std, free)


### PR DESCRIPTION
`tutSettings` is added twice to the docs setting. Adding it once should be enough, right?