### PR TITLE
Move State companion to the package object

### DIFF
--- a/free/src/main/scala/cats/free/Trampoline.scala
+++ b/free/src/main/scala/cats/free/Trampoline.scala
@@ -1,7 +1,9 @@
 package cats
 package free
 
-object Trampoline {
+// To workaround SI-7139 `object Trampoline` needs to be defined inside the package object
+// together with the type alias.
+abstract class TrampolineFunctions {
   def done[A](a: A): Trampoline[A] =
     Free.Pure[Function0,A](a)
 

--- a/free/src/main/scala/cats/free/package.scala
+++ b/free/src/main/scala/cats/free/package.scala
@@ -4,6 +4,7 @@ package object free {
 
   /** Alias for the free monad over the `Function0` functor. */
   type Trampoline[A] = Free[Function0, A]
+  object Trampoline extends TrampolineFunctions
 
   /**
    * Free monad of the free functor (Coyoneda) of S.

--- a/state/src/main/scala/cats/state/State.scala
+++ b/state/src/main/scala/cats/state/State.scala
@@ -112,7 +112,8 @@ sealed abstract class StateTInstances0 {
     StateT.stateTMonad[Trampoline, S]
 }
 
-object State {
+// To workaround SI-7139, define `object State` inside the package object.
+abstract class StateCompanion {
   def apply[S, A](f: S => (S, A)): State[S, A] =
     StateT.applyF(Trampoline.done((s: S) => Trampoline.done(f(s))))
 

--- a/state/src/main/scala/cats/state/State.scala
+++ b/state/src/main/scala/cats/state/State.scala
@@ -112,8 +112,9 @@ sealed abstract class StateTInstances0 {
     StateT.stateTMonad[Trampoline, S]
 }
 
-// To workaround SI-7139, define `object State` inside the package object.
-abstract class StateCompanion {
+// To workaround SI-7139 `object State` needs to be defined inside the package object
+// together with the type alias.
+abstract class StateFunctions {
   def apply[S, A](f: S => (S, A)): State[S, A] =
     StateT.applyF(Trampoline.done((s: S) => Trampoline.done(f(s))))
 

--- a/state/src/main/scala/cats/state/package.scala
+++ b/state/src/main/scala/cats/state/package.scala
@@ -4,5 +4,5 @@ import free.Trampoline
 
 package object state {
   type State[S, A] = StateT[Trampoline, S, A]
-  object State extends StateCompanion
+  object State extends StateFunctions
 }

--- a/state/src/main/scala/cats/state/package.scala
+++ b/state/src/main/scala/cats/state/package.scala
@@ -4,4 +4,5 @@ import free.Trampoline
 
 package object state {
   type State[S, A] = StateT[Trampoline, S, A]
+  object State extends StateCompanion
 }


### PR DESCRIPTION
As it stands, `State` causes strange behaviors like State.apply working
the first time, but failing the second time to find apply. See https://gist.github.com/eed3si9n/9804d496bfeb457282c2
@retronym pointed me to [SI-7139](https://issues.scala-lang.org/browse/SI-7139), which says that the REPL gets
confused about the type when there's a type alias and an object named
the same.

This adds the workaround posted on SI-7139, which is to move the name `State` into package object.