### PR TITLE
224 - Test Traverse and Foldable

### DIFF
--- a/laws/src/main/scala/cats/laws/FoldableLaws.scala
+++ b/laws/src/main/scala/cats/laws/FoldableLaws.scala
@@ -2,9 +2,28 @@ package cats
 package laws
 
 trait FoldableLaws[F[_]] {
+  implicit def F: Foldable[F]
+
+  def leftFoldConsistentWithFoldMap[A, B](
+    fa: F[A],
+    f: A => B
+  )(implicit
+    M: Monoid[B]
+  ): IsEq[B] = {
+    F.foldMap(fa)(f) <-> F.foldLeft(fa, M.empty){ (b, a) => M.combine(b, f(a)) }
+  }
+
+  def rightFoldConsistentWithFoldMap[A, B](
+    fa: F[A],
+    f: A => B
+  )(implicit
+    M: Monoid[B]
+  ): IsEq[B] = {
+    F.foldMap(fa)(f) <-> F.foldRight(fa, Lazy(M.empty)){ a => Fold.Continue(M.combine(_, f(a)))}.value
+  }
 }
 
 object FoldableLaws {
   def apply[F[_]](implicit ev: Foldable[F]): FoldableLaws[F] =
-    new FoldableLaws[F] {}
+    new FoldableLaws[F] { def F: Foldable[F] = ev }
 }

--- a/laws/src/main/scala/cats/laws/FoldableLaws.scala
+++ b/laws/src/main/scala/cats/laws/FoldableLaws.scala
@@ -1,0 +1,10 @@
+package cats
+package laws
+
+trait FoldableLaws[F[_]] {
+}
+
+object FoldableLaws {
+  def apply[F[_]](implicit ev: Foldable[F]): FoldableLaws[F] =
+    new FoldableLaws[F] {}
+}

--- a/laws/src/main/scala/cats/laws/TraverseLaws.scala
+++ b/laws/src/main/scala/cats/laws/TraverseLaws.scala
@@ -1,0 +1,34 @@
+package cats
+package laws
+
+import cats.Id
+import cats.syntax.functor._
+import cats.syntax.traverse._
+
+trait TraverseLaws[F[_]] extends FunctorLaws[F] with FoldableLaws[F] {
+  implicit override def F: Traverse[F]
+
+  def traverseIdentity[A, B](fa: F[A], f: A => B): IsEq[F[B]] = {
+    fa.traverse[Id, B](f) <-> F.map(fa)(f)
+  }
+
+  def traverseComposition[A, B, C, M[_], N[_]](
+    fa: F[A],
+    f: A => M[B],
+    g: B => N[C]
+  )(implicit
+    N: Applicative[N],
+    M: Applicative[M]
+  ): IsEq[M[N[F[C]]]] = {
+    implicit val MN = M.compose(N)
+    type MN[Z] = M[N[Z]]
+    val lhs: MN[F[C]] = M.map(fa.traverse(f))(fb => fb.traverse(g))
+    val rhs: MN[F[C]] = fa.traverse[MN, C](a => M.map(f(a))(g))
+    lhs <-> rhs
+  }
+}
+
+object TraverseLaws {
+  def apply[F[_]](implicit ev: Traverse[F]): TraverseLaws[F] =
+    new TraverseLaws[F] { def F: Traverse[F] = ev }
+}

--- a/laws/src/main/scala/cats/laws/TraverseLaws.scala
+++ b/laws/src/main/scala/cats/laws/TraverseLaws.scala
@@ -38,8 +38,8 @@ trait TraverseLaws[F[_]] extends FunctorLaws[F] with FoldableLaws[F] {
   ): IsEq[(M[F[B]], N[F[B]])] = {
     type MN[Z] = (M[Z], N[Z])
     implicit val MN = new Applicative[MN] {
-      override def pure[X](x: X): (M[X], N[X]) = (M.pure(x), N.pure(x))
-      override def ap[X, Y](fa: (M[X], N[X]))(f: (M[X => Y], N[X => Y])): (M[Y], N[Y]) = {
+      override def pure[X](x: X): (MN[X]) = (M.pure(x), N.pure(x))
+      override def ap[X, Y](fa: MN[X])(f: MN[X => Y]): MN[Y] = {
         val (fam, fan) = fa
         val (fm, fn) = f
         (M.ap(fam)(fm), N.ap(fan)(fn))

--- a/laws/src/main/scala/cats/laws/TraverseLaws.scala
+++ b/laws/src/main/scala/cats/laws/TraverseLaws.scala
@@ -38,7 +38,7 @@ trait TraverseLaws[F[_]] extends FunctorLaws[F] with FoldableLaws[F] {
   ): IsEq[(M[F[B]], N[F[B]])] = {
     type MN[Z] = (M[Z], N[Z])
     implicit val MN = new Applicative[MN] {
-      override def pure[X](x: X): (MN[X]) = (M.pure(x), N.pure(x))
+      override def pure[X](x: X): MN[X] = (M.pure(x), N.pure(x))
       override def ap[X, Y](fa: MN[X])(f: MN[X => Y]): MN[Y] = {
         val (fam, fan) = fa
         val (fm, fn) = f

--- a/laws/src/main/scala/cats/laws/discipline/FoldableTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/FoldableTests.scala
@@ -1,0 +1,22 @@
+package cats
+package laws
+package discipline
+
+import org.scalacheck.Arbitrary
+import org.scalacheck.Prop._
+import org.typelevel.discipline.Laws
+
+trait FoldableTests[F[_]] extends Laws {
+  def foldable[A: Arbitrary]: RuleSet = {
+
+    new DefaultRuleSet(
+      name = "foldable",
+      parent = None)
+  }
+}
+
+
+object FoldableTests {
+  def apply[F[_]: Foldable]: FoldableTests[F] =
+    new FoldableTests[F] { def laws: FoldableLaws[F] = FoldableLaws[F] }
+}

--- a/laws/src/main/scala/cats/laws/discipline/FoldableTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/FoldableTests.scala
@@ -7,11 +7,21 @@ import org.scalacheck.Prop._
 import org.typelevel.discipline.Laws
 
 trait FoldableTests[F[_]] extends Laws {
-  def foldable[A: Arbitrary]: RuleSet = {
+  def laws: FoldableLaws[F]
+
+  def foldable[A: Arbitrary, B: Arbitrary](implicit
+    ArbF: ArbitraryK[F],
+    B: Monoid[B],
+    EqB: Eq[B]
+  ): RuleSet = {
+    implicit def ArbFA: Arbitrary[F[A]] = ArbF.synthesize[A]
 
     new DefaultRuleSet(
       name = "foldable",
-      parent = None)
+      parent = None,
+      "foldLeft consistent with foldMap" -> forAll(laws.leftFoldConsistentWithFoldMap[A, B] _),
+      "foldRight consistent with foldMap" -> forAll(laws.rightFoldConsistentWithFoldMap[A, B] _)
+    )
   }
 }
 

--- a/laws/src/main/scala/cats/laws/discipline/TraverseTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/TraverseTests.scala
@@ -9,24 +9,34 @@ import Prop._
 trait TraverseTests[F[_]] extends FunctorTests[F] with FoldableTests[F] {
   def laws: TraverseLaws[F]
 
-  def traverse[A: Arbitrary, B: Arbitrary, C: Arbitrary, M[_]: Applicative, N[_]: Applicative](implicit
+  def traverse[A: Arbitrary, B: Arbitrary, C: Arbitrary, M: Arbitrary, X[_]: Applicative, Y[_]: Applicative](implicit
     ArbF: ArbitraryK[F],
-    ArbM: ArbitraryK[M],
-    ArbN: ArbitraryK[N],
+    ArbX: ArbitraryK[X],
+    ArbY: ArbitraryK[Y],
+    M: Monoid[M],
     EqFA: Eq[F[A]],
     EqFC: Eq[F[C]],
-    EqMNFC: Eq[M[N[F[C]]]]
+    EqM: Eq[M],
+    EqXYFC: Eq[X[Y[F[C]]]],
+    EqXFB: Eq[X[F[B]]],
+    EqYFB: Eq[Y[F[B]]]
   ): RuleSet = {
     implicit def ArbFA: Arbitrary[F[A]] = ArbF.synthesize[A]
-    implicit def ArbMB: Arbitrary[M[B]] = ArbM.synthesize[B]
-    implicit def ArbNC: Arbitrary[N[C]] = ArbN.synthesize[C]
+    implicit def ArbMB: Arbitrary[X[B]] = ArbX.synthesize[B]
+    implicit def ArbNB: Arbitrary[Y[B]] = ArbY.synthesize[B]
+    implicit def ArbNC: Arbitrary[Y[C]] = ArbY.synthesize[C]
+    implicit def EqXFBYFB : Eq[(X[F[B]], Y[F[B]])] = new Eq[(X[F[B]], Y[F[B]])] {
+      override def eqv(x: (X[F[B]], Y[F[B]]), y: (X[F[B]], Y[F[B]])): Boolean =
+        EqXFB.eqv(x._1, y._1) && EqYFB.eqv(x._2, y._2)
+    }
     new RuleSet {
       def name: String = "traverse"
       def bases: Seq[(String, RuleSet)] = Nil
-      def parents: Seq[RuleSet] = Seq(functor[A, B, C], foldable[A])
+      def parents: Seq[RuleSet] = Seq(functor[A, B, C], foldable[A, M])
       def props: Seq[(String, Prop)] = Seq(
         "traverse identity" -> forAll(laws.traverseIdentity[A, C] _),
-        "traverse composition" -> forAll(laws.traverseComposition[A, B, C, M, N] _)
+        "traverse sequential composition" -> forAll(laws.traverseSequentialComposition[A, B, C, X, Y] _),
+        "traverse parallel composition" -> forAll(laws.traverseParallelComposition[A, B, X, Y] _)
       )
     }
   }

--- a/laws/src/main/scala/cats/laws/discipline/TraverseTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/TraverseTests.scala
@@ -1,0 +1,38 @@
+package cats
+package laws
+package discipline
+
+import org.scalacheck.{Prop, Arbitrary}
+import Prop._
+
+
+trait TraverseTests[F[_]] extends FunctorTests[F] with FoldableTests[F] {
+  def laws: TraverseLaws[F]
+
+  def traverse[A: Arbitrary, B: Arbitrary, C: Arbitrary, M[_]: Applicative, N[_]: Applicative](implicit
+    ArbF: ArbitraryK[F],
+    ArbM: ArbitraryK[M],
+    ArbN: ArbitraryK[N],
+    EqFA: Eq[F[A]],
+    EqFC: Eq[F[C]],
+    EqMNFC: Eq[M[N[F[C]]]]
+  ): RuleSet = {
+    implicit def ArbFA: Arbitrary[F[A]] = ArbF.synthesize[A]
+    implicit def ArbMB: Arbitrary[M[B]] = ArbM.synthesize[B]
+    implicit def ArbNC: Arbitrary[N[C]] = ArbN.synthesize[C]
+    new RuleSet {
+      def name: String = "traverse"
+      def bases: Seq[(String, RuleSet)] = Nil
+      def parents: Seq[RuleSet] = Seq(functor[A, B, C], foldable[A])
+      def props: Seq[(String, Prop)] = Seq(
+        "traverse identity" -> forAll(laws.traverseIdentity[A, C] _),
+        "traverse composition" -> forAll(laws.traverseComposition[A, B, C, M, N] _)
+      )
+    }
+  }
+}
+
+object TraverseTests {
+  def apply[F[_]: Traverse]: TraverseTests[F] =
+    new TraverseTests[F] { def laws: TraverseLaws[F] = TraverseLaws[F] }
+}

--- a/std/src/main/scala/cats/std/list.scala
+++ b/std/src/main/scala/cats/std/list.scala
@@ -42,8 +42,8 @@ trait ListInstances {
         Fold.partialIterate(fa)(f)
 
       def traverse[G[_], A, B](fa: List[A])(f: A => G[B])(implicit G: Applicative[G]): G[List[B]] = {
-        val gba = G.pure(ListBuffer.empty[B])
-        val gbb = fa.foldLeft(gba)((buf, a) => G.map2(buf, f(a))(_ += _))
+        val gba = G.pure(Vector.empty[B])
+        val gbb = fa.foldLeft(gba)((buf, a) => G.map2(buf, f(a))(_ :+ _))
         G.map(gbb)(_.toList)
       }
     }

--- a/std/src/main/scala/cats/std/vector.scala
+++ b/std/src/main/scala/cats/std/vector.scala
@@ -30,9 +30,8 @@ trait VectorInstances {
 
       def traverse[G[_]: Applicative, A, B](fa: Vector[A])(f: A => G[B]): G[Vector[B]] = {
         val G = Applicative[G]
-        val gba = G.pure(new VectorBuilder[B])
-        val gbb = fa.foldLeft(gba)((buf, a) => G.map2(buf, f(a))(_ += _))
-        G.map(gbb)(_.result)
+        val gba = G.pure(Vector.empty[B])
+        fa.foldLeft(gba)((buf, a) => G.map2(buf, f(a))(_ :+ _))
       }
     }
 

--- a/tests/src/test/scala/cats/tests/ConstTests.scala
+++ b/tests/src/test/scala/cats/tests/ConstTests.scala
@@ -2,9 +2,12 @@ package cats
 package tests
 
 import cats.data.Const
-import cats.laws.discipline.{ApplicativeTests, SerializableTests}
+import cats.laws.discipline.{TraverseTests, ApplicativeTests, SerializableTests}
 
 class ConstTests extends CatsSuite {
   checkAll("Const[String, Int]", ApplicativeTests[Const[String, ?]].applicative[Int, Int, Int])
   checkAll("Applicative[Const[String, ?]]", SerializableTests.serializable(Applicative[Const[String, ?]]))
+
+  checkAll("Const[String, Int] with Option", TraverseTests[Const[String, ?]].traverse[Int, Int, Int, Int, Option, Option])
+  checkAll("Traverse[Const[String, ?]]", SerializableTests.serializable(Traverse[Const[String, ?]]))
 }

--- a/tests/src/test/scala/cats/tests/EitherTests.scala
+++ b/tests/src/test/scala/cats/tests/EitherTests.scala
@@ -1,9 +1,13 @@
 package cats
 package tests
 
-import cats.laws.discipline.{MonadTests, SerializableTests}
+import cats.laws.discipline.{TraverseTests, MonadTests, SerializableTests}
 
 class EitherTests extends CatsSuite {
   checkAll("Either[Int, Int]", MonadTests[Either[Int, ?]].flatMap[Int, Int, Int])
   checkAll("Monad[Either[Int, ?]]", SerializableTests.serializable(Monad[Either[Int, ?]]))
+
+
+  checkAll("Either[Int, Int] with Option", TraverseTests[Either[Int, ?]].traverse[Int, Int, Int, Int, Option, Option])
+  checkAll("Traverse[Either[Int, ?]", SerializableTests.serializable(Traverse[Either[Int, ?]]))
 }

--- a/tests/src/test/scala/cats/tests/FoldableTests.scala
+++ b/tests/src/test/scala/cats/tests/FoldableTests.scala
@@ -1,7 +1,7 @@
 package cats
 package tests
 
-class FoldableTests extends CatsSuite {
+class FoldableTestsAdditional extends CatsSuite {
   import Fold.{Continue, Return, Pass}
 
   // disable scalatest ===

--- a/tests/src/test/scala/cats/tests/IorTests.scala
+++ b/tests/src/test/scala/cats/tests/IorTests.scala
@@ -2,9 +2,12 @@ package cats
 package tests
 
 import cats.data.Ior
-import cats.laws.discipline.{MonadTests, SerializableTests}
+import cats.laws.discipline.{TraverseTests, MonadTests, SerializableTests}
 
 class IorTests extends CatsSuite {
   checkAll("Ior[String, Int]", MonadTests[String Ior ?].monad[Int, Int, Int])
   checkAll("Monad[String Ior ?]]", SerializableTests.serializable(Monad[String Ior ?]))
+
+  checkAll("Ior[String, Int] with Option", TraverseTests[String Ior ?].traverse[Int, Int, Int, Int, Option, Option])
+  checkAll("Traverse[String Ior ?]", SerializableTests.serializable(Traverse[String Ior ?]))
 }

--- a/tests/src/test/scala/cats/tests/ListTests.scala
+++ b/tests/src/test/scala/cats/tests/ListTests.scala
@@ -10,6 +10,6 @@ class ListTests extends CatsSuite {
   checkAll("List[Int]", MonadCombineTests[List].monadCombine[Int, Int, Int])
   checkAll("MonadCombine[List]", SerializableTests.serializable(MonadCombine[List]))
 
-  checkAll("List[Int] with Option", TraverseTests[List].traverse[Int, Int, Int, Option, Option])
+  checkAll("List[Int] with Option", TraverseTests[List].traverse[Int, Int, Int, Int, Option, Option])
   checkAll("Traverse[List]", SerializableTests.serializable(Traverse[List]))
 }

--- a/tests/src/test/scala/cats/tests/ListTests.scala
+++ b/tests/src/test/scala/cats/tests/ListTests.scala
@@ -1,7 +1,7 @@
 package cats
 package tests
 
-import cats.laws.discipline.{CoflatMapTests, MonadCombineTests, SerializableTests}
+import cats.laws.discipline.{TraverseTests, CoflatMapTests, MonadCombineTests, SerializableTests}
 
 class ListTests extends CatsSuite {
   checkAll("List[Int]", CoflatMapTests[List].coflatMap[Int, Int, Int])
@@ -9,4 +9,7 @@ class ListTests extends CatsSuite {
 
   checkAll("List[Int]", MonadCombineTests[List].monadCombine[Int, Int, Int])
   checkAll("MonadCombine[List]", SerializableTests.serializable(MonadCombine[List]))
+
+  checkAll("List[Int] with Option", TraverseTests[List].traverse[Int, Int, Int, Option, Option])
+  checkAll("Traverse[List]", SerializableTests.serializable(Traverse[List]))
 }

--- a/tests/src/test/scala/cats/tests/MapTests.scala
+++ b/tests/src/test/scala/cats/tests/MapTests.scala
@@ -1,9 +1,12 @@
 package cats
 package tests
 
-import cats.laws.discipline.{FlatMapTests, SerializableTests}
+import cats.laws.discipline.{TraverseTests, FlatMapTests, SerializableTests}
 
 class MapTests extends CatsSuite {
   checkAll("Map[Int, Int]", FlatMapTests[Map[Int, ?]].flatMap[Int, Int, Int])
   checkAll("FlatMap[Map[Int, ?]]", SerializableTests.serializable(FlatMap[Map[Int, ?]]))
+
+  checkAll("Map[Int, Int] with Option", TraverseTests[Map[Int, ?]].traverse[Int, Int, Int, Int, Option, Option])
+  checkAll("Traverse[Map[Int, ?]]", SerializableTests.serializable(Traverse[Map[Int, ?]]))
 }

--- a/tests/src/test/scala/cats/tests/OptionTests.scala
+++ b/tests/src/test/scala/cats/tests/OptionTests.scala
@@ -10,6 +10,6 @@ class OptionTests extends CatsSuite {
   checkAll("Option[Int]", MonadCombineTests[Option].monadCombine[Int, Int, Int])
   checkAll("MonadCombine[Option]", SerializableTests.serializable(MonadCombine[Option]))
 
-  checkAll("Option[Int] with Option", TraverseTests[Option].traverse[Int, Int, Int, Option, Option])
+  checkAll("Option[Int] with Option", TraverseTests[Option].traverse[Int, Int, Int, Int, Option, Option])
   checkAll("Traverse[Option]", SerializableTests.serializable(Traverse[Option]))
 }

--- a/tests/src/test/scala/cats/tests/OptionTests.scala
+++ b/tests/src/test/scala/cats/tests/OptionTests.scala
@@ -1,7 +1,7 @@
 package cats
 package tests
 
-import cats.laws.discipline.{CoflatMapTests, MonadCombineTests, SerializableTests}
+import cats.laws.discipline.{TraverseTests, CoflatMapTests, MonadCombineTests, SerializableTests}
 
 class OptionTests extends CatsSuite {
   checkAll("Option[Int]", CoflatMapTests[Option].coflatMap[Int, Int, Int])
@@ -9,4 +9,7 @@ class OptionTests extends CatsSuite {
 
   checkAll("Option[Int]", MonadCombineTests[Option].monadCombine[Int, Int, Int])
   checkAll("MonadCombine[Option]", SerializableTests.serializable(MonadCombine[Option]))
+
+  checkAll("Option[Int] with Option", TraverseTests[Option].traverse[Int, Int, Int, Option, Option])
+  checkAll("Traverse[Option]", SerializableTests.serializable(Traverse[Option]))
 }

--- a/tests/src/test/scala/cats/tests/SetTests.scala
+++ b/tests/src/test/scala/cats/tests/SetTests.scala
@@ -1,9 +1,12 @@
 package cats
 package tests
 
-import cats.laws.discipline.{MonoidKTests, SerializableTests}
+import cats.laws.discipline.{FoldableTests, MonoidKTests, SerializableTests}
 
 class SetTests extends CatsSuite {
   checkAll("Set[Int]", MonoidKTests[Set].monoidK[Int])
   checkAll("MonoidK[Set]", SerializableTests.serializable(MonoidK[Set]))
+
+  checkAll("Set[Int]", FoldableTests[Set].foldable[Int, Int])
+  checkAll("Foldable[Set]", SerializableTests.serializable(Foldable[Set]))
 }

--- a/tests/src/test/scala/cats/tests/StreamTests.scala
+++ b/tests/src/test/scala/cats/tests/StreamTests.scala
@@ -1,7 +1,7 @@
 package cats
 package tests
 
-import cats.laws.discipline.{CoflatMapTests, MonadCombineTests, SerializableTests}
+import cats.laws.discipline.{TraverseTests, CoflatMapTests, MonadCombineTests, SerializableTests}
 
 class StreamTests extends CatsSuite {
   checkAll("Stream[Int]", CoflatMapTests[Stream].coflatMap[Int, Int, Int])
@@ -9,4 +9,7 @@ class StreamTests extends CatsSuite {
 
   checkAll("Stream[Int]", MonadCombineTests[Stream].monadCombine[Int, Int, Int])
   checkAll("MonadCombine[Stream]", SerializableTests.serializable(MonadCombine[Stream]))
+
+  checkAll("Stream[Int] with Option", TraverseTests[Stream].traverse[Int, Int, Int, Option, Option])
+  checkAll("Traverse[Stream]", SerializableTests.serializable(Traverse[Stream]))
 }

--- a/tests/src/test/scala/cats/tests/StreamTests.scala
+++ b/tests/src/test/scala/cats/tests/StreamTests.scala
@@ -10,6 +10,6 @@ class StreamTests extends CatsSuite {
   checkAll("Stream[Int]", MonadCombineTests[Stream].monadCombine[Int, Int, Int])
   checkAll("MonadCombine[Stream]", SerializableTests.serializable(MonadCombine[Stream]))
 
-  checkAll("Stream[Int] with Option", TraverseTests[Stream].traverse[Int, Int, Int, Option, Option])
+  checkAll("Stream[Int] with Option", TraverseTests[Stream].traverse[Int, Int, Int, Int, Option, Option])
   checkAll("Traverse[Stream]", SerializableTests.serializable(Traverse[Stream]))
 }

--- a/tests/src/test/scala/cats/tests/ValidatedTests.scala
+++ b/tests/src/test/scala/cats/tests/ValidatedTests.scala
@@ -3,12 +3,14 @@ package tests
 
 import cats.data.Validated
 import cats.std.string._
-import cats.laws.discipline.{ApplicativeTests, SerializableTests}
+import cats.laws.discipline.{TraverseTests, ApplicativeTests, SerializableTests}
 import cats.laws.discipline.arbitrary._
 import org.scalacheck.Arbitrary
 
 class ValidatedTests extends CatsSuite {
-
   checkAll("Validated[String, Int]", ApplicativeTests[Validated[String,?]].applicative[Int, Int, Int])
   checkAll("Applicative[Validated[String,?]]", SerializableTests.serializable(Applicative[Validated[String,?]]))
+
+  checkAll("Validated[String, Int] with Option", TraverseTests[Validated[String,?]].traverse[Int, Int, Int, Int, Option, Option])
+  checkAll("Traverse[Validated[String,?]]", SerializableTests.serializable(Traverse[Validated[String,?]]))
 }

--- a/tests/src/test/scala/cats/tests/VectorTests.scala
+++ b/tests/src/test/scala/cats/tests/VectorTests.scala
@@ -7,6 +7,6 @@ class VectorTests extends CatsSuite {
   checkAll("Vector[Int]", MonadCombineTests[Vector].monadCombine[Int, Int, Int])
   checkAll("MonadCombine[Vector]", SerializableTests.serializable(MonadCombine[Vector]))
 
-  checkAll("Vector[Int] with Option", TraverseTests[Vector].traverse[Int, Int, Int, Option, Option])
+  checkAll("Vector[Int] with Option", TraverseTests[Vector].traverse[Int, Int, Int, Int, Option, Option])
   checkAll("Traverse[Vector]", SerializableTests.serializable(Traverse[Vector]))
 }

--- a/tests/src/test/scala/cats/tests/VectorTests.scala
+++ b/tests/src/test/scala/cats/tests/VectorTests.scala
@@ -1,9 +1,12 @@
 package cats
 package tests
 
-import cats.laws.discipline.{MonadCombineTests, SerializableTests}
+import cats.laws.discipline.{TraverseTests, MonadCombineTests, SerializableTests}
 
 class VectorTests extends CatsSuite {
   checkAll("Vector[Int]", MonadCombineTests[Vector].monadCombine[Int, Int, Int])
   checkAll("MonadCombine[Vector]", SerializableTests.serializable(MonadCombine[Vector]))
+
+  checkAll("Vector[Int] with Option", TraverseTests[Vector].traverse[Int, Int, Int, Option, Option])
+  checkAll("Traverse[Vector]", SerializableTests.serializable(Traverse[Vector]))
 }

--- a/tests/src/test/scala/cats/tests/XorTests.scala
+++ b/tests/src/test/scala/cats/tests/XorTests.scala
@@ -2,9 +2,13 @@ package cats
 package tests
 
 import cats.data.Xor
-import cats.laws.discipline.{MonadTests, SerializableTests}
+import cats.laws.discipline.{TraverseTests, MonadTests, SerializableTests}
 
 class XorTests extends CatsSuite {
   checkAll("Xor[String, Int]", MonadTests[String Xor ?].monad[Int, Int, Int])
   checkAll("Monad[String Xor ?]", SerializableTests.serializable(Monad[String Xor ?]))
+
+  checkAll("Xor[String, Int] with Option", TraverseTests[Xor[String,?]].traverse[Int, Int, Int, Int, Option, Option])
+  checkAll("Traverse[Xor[String,?]]", SerializableTests.serializable(Traverse[Xor[String,?]]))
+
 }


### PR DESCRIPTION
Laws for Foldable:
- foldMap must be consistent with foldLeft
- foldMap must be consistent with foldRight

Laws for Traverse:
- identity
- sequential composition
- parallel composition

Added TraverseTests to std instances for:
- List
- Option
- Stream
- Vector

Added FoldableTests to std instances for:
- Set

Also fixed bugs in the Traverse instances for List and Vector.
They were using mutable state (ListBuffer/VectorBuilder) in traverse which caused them to fail tests of the parallel composition law.