### PR TITLE
Tests for Validated.

### DIFF
--- a/core/src/main/scala/cats/data/Validated.scala
+++ b/core/src/main/scala/cats/data/Validated.scala
@@ -110,7 +110,7 @@ sealed abstract class Validated[+E, +A] extends Product with Serializable {
   def ap[EE >: E, B](f: Validated[EE, A => B])(implicit EE: Semigroup[EE]): Validated[EE,B] =
     (this, f) match {
       case (Valid(a), Valid(f)) => Valid(f(a))
-      case (Invalid(e1), Invalid(e2)) => Invalid(EE.combine(e1,e2))
+      case (Invalid(e1), Invalid(e2)) => Invalid(EE.combine(e2,e1))
       case (e @ Invalid(_), _) => e
       case (_, e @ Invalid(_)) => e
     }
@@ -185,12 +185,7 @@ sealed abstract class ValidatedInstances extends ValidatedInstances1 {
         fa.map(f)
 
       override def ap[A,B](fa: Validated[E,A])(f: Validated[E,A=>B]): Validated[E, B] =
-        (fa,f) match {
-          case (Valid(a),Valid(f)) => Valid(f(a))
-          case (e @ Invalid(_), Valid(_)) => e
-          case (Valid(_), e @ Invalid(_)) => e
-          case (Invalid(e1), Invalid(e2)) => Invalid(E.combine(e1, e2))
-        }
+        fa.ap(f)(E)
     }
 }
 

--- a/tests/src/test/scala/cats/tests/ValidatedTests.scala
+++ b/tests/src/test/scala/cats/tests/ValidatedTests.scala
@@ -2,13 +2,42 @@ package cats
 package tests
 
 import cats.data.Validated
+import cats.data.Validated.{Valid, Invalid}
 import cats.std.string._
 import cats.laws.discipline.{ApplicativeTests, SerializableTests}
 import cats.laws.discipline.arbitrary._
 import org.scalacheck.Arbitrary
+import org.scalacheck.Prop._
 
 class ValidatedTests extends CatsSuite {
-
   checkAll("Validated[String, Int]", ApplicativeTests[Validated[String,?]].applicative[Int, Int, Int])
   checkAll("Applicative[Validated[String,?]]", SerializableTests.serializable(Applicative[Validated[String,?]]))
+
+  test("ap2 combines failures in order") {
+    val plus = (_: Int) + (_: Int)
+    assert(Validated.validatedInstances[String].ap2(Invalid("1"), Invalid("2"))(Valid(plus)) == Invalid("12"))
+  }
+
+  test("fromTryCatch catches matching exceptions") {
+    assert(Validated.fromTryCatch[NumberFormatException]{ "foo".toInt }.isInstanceOf[Invalid[NumberFormatException]])
+  }
+
+  test("fromTryCatch lets non-matching exceptions escape") {
+    val _ = intercept[NumberFormatException] {
+      Validated.fromTryCatch[IndexOutOfBoundsException]{ "foo".toInt }
+    }
+  }
+
+  test("filter makes non-matching entries invalid") {
+    for {
+      x <- Valid(1).filter[String](_ % 2 == 0)
+    } fail("1 is not even")
+  }
+
+  test("filter leaves matching entries valid") {
+    assert(
+      (for {
+        _ <- Valid(2).filter[String](_ % 2 == 0)
+      } yield ()).isValid)
+  }
 }

--- a/tests/src/test/scala/cats/tests/ValidatedTests.scala
+++ b/tests/src/test/scala/cats/tests/ValidatedTests.scala
@@ -15,7 +15,7 @@ class ValidatedTests extends CatsSuite {
 
   test("ap2 combines failures in order") {
     val plus = (_: Int) + (_: Int)
-    assert(Validated.validatedInstances[String].ap2(Invalid("1"), Invalid("2"))(Valid(plus)) == Invalid("12"))
+    assert(Applicative[Validated[String, ?]].ap2(Invalid("1"), Invalid("2"))(Valid(plus)) == Invalid("12"))
   }
 
   test("fromTryCatch catches matching exceptions") {
@@ -29,9 +29,10 @@ class ValidatedTests extends CatsSuite {
   }
 
   test("filter makes non-matching entries invalid") {
-    for {
-      x <- Valid(1).filter[String](_ % 2 == 0)
-    } fail("1 is not even")
+    assert(
+      (for {
+        x <- Valid(1).filter[String](_ % 2 == 0)
+      } yield ()).isInvalid)
   }
 
   test("filter leaves matching entries valid") {


### PR DESCRIPTION
Ensure failures are combined in order. This required a bugfix.
Also test filter and fromTryCatch since these aren't covered by a typeclass instance and are complex enough to need comments.
Traverse laws are added in the separate PR for #224.