### PR TITLE
Fix Kleisli's lift method

### DIFF
--- a/core/src/main/scala/cats/data/Kleisli.scala
+++ b/core/src/main/scala/cats/data/Kleisli.scala
@@ -45,8 +45,8 @@ final case class Kleisli[F[_], A, B](run: A => F[B]) { self =>
   def traverse[G[_]](f: G[A])(implicit F: Applicative[F], G: Traverse[G]): F[G[B]] =
     G.traverse(f)(run)
 
-  def lift[G[_]](implicit F: Applicative[F]): Kleisli[λ[α => F[F[α]]], A, B] =
-    Kleisli[λ[α => F[F[α]]], A, B](a => Applicative[F].pure(run(a)))
+  def lift[G[_]](implicit G: Applicative[G]): Kleisli[λ[α => G[F[α]]], A, B] =
+    Kleisli[λ[α => G[F[α]]], A, B](a => Applicative[G].pure(run(a)))
 
   def lower(implicit F: Monad[F]): Kleisli[F, A, F[B]] =
     Kleisli(a => F.pure(run(a)))

--- a/tests/src/test/scala/cats/tests/KleisliTests.scala
+++ b/tests/src/test/scala/cats/tests/KleisliTests.scala
@@ -3,6 +3,7 @@ package tests
 
 import cats.arrow.Arrow
 import cats.data.Kleisli
+import Kleisli.kleisli
 import cats.functor.Strong
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
@@ -21,4 +22,10 @@ class KleisliTests extends CatsSuite {
 
   checkAll("Kleisli[Option, Int, Int]", ArrowTests[Kleisli[Option, ?, ?]].arrow[Int, Int, Int, Int, Int, Int])
   checkAll("Arrow[Kleisli[Option, ?, ?]]", SerializableTests.serializable(Arrow[Kleisli[Option, ?, ?]]))
+
+  test("lift") {
+    val f = kleisli { (x: Int) => (Some(x + 1): Option[Int]) }
+    val l = f.lift[List]
+    assert((List(1, 2, 3) >>= l.run) == List(Some(2), Some(3), Some(4)))
+  }
 }


### PR DESCRIPTION
I thought it was suspicious that `G[_]` doesn't have any bounds, then I realized the whole thing is implemented wrong. Added a simple test as well.