### PR TITLE
Use consistent naming in unapply syntax

### DIFF
--- a/core/src/main/scala/cats/syntax/apply.scala
+++ b/core/src/main/scala/cats/syntax/apply.scala
@@ -2,9 +2,9 @@ package cats
 package syntax
 
 trait ApplySyntax1 {
-  implicit def applySyntaxU[A](a: A)(implicit U: Unapply[Apply, A]): ApplyOps[U.M, U.A] =
+  implicit def applySyntaxU[FA](fa: FA)(implicit U: Unapply[Apply, FA]): ApplyOps[U.M, U.A] =
     new ApplyOps[U.M, U.A] {
-      val self = U.subst(a)
+      val self = U.subst(fa)
       val typeClassInstance = U.TC
     }
 }

--- a/core/src/main/scala/cats/syntax/semigroupk.scala
+++ b/core/src/main/scala/cats/syntax/semigroupk.scala
@@ -3,9 +3,9 @@ package syntax
 
 trait SemigroupKSyntax1 {
   // TODO: use simulacrum instances eventually
-  implicit def semigroupSyntaxU[FA](a: FA)(implicit U: Unapply[SemigroupK,FA]): SemigroupK.Ops[U.M, U.A] =
+  implicit def semigroupSyntaxU[FA](fa: FA)(implicit U: Unapply[SemigroupK,FA]): SemigroupK.Ops[U.M, U.A] =
     new SemigroupK.Ops[U.M, U.A] {
-      val self = U.subst(a)
+      val self = U.subst(fa)
       val typeClassInstance = U.TC
     }
 }


### PR DESCRIPTION
All but two places were using `fa: FA` for `Unapply` syntax methods.