### PR TITLE
Prioritize Unapply instances

### DIFF
--- a/core/src/main/scala/cats/Unapply.scala
+++ b/core/src/main/scala/cats/Unapply.scala
@@ -28,7 +28,7 @@ trait Unapply[TC[_[_]], MA] {
   def subst: MA => M[A]
 }
 
-object Unapply {
+object Unapply extends Unapply2Instances {
   // a convenience method for summoning Unapply instances
   def apply[TC[_[_]], MA](implicit ev: Unapply[TC,MA]): Unapply[TC, MA] = implicitly
 
@@ -47,6 +47,9 @@ object Unapply {
       override def TC: TC[F] = tc
       override def subst: F[AA] => M[A] = identity
   }
+}
+
+sealed abstract class Unapply2Instances extends Unapply3Instances {
 
   // the type we will instantiate when we find a typeclass instance
   // for a type in the shape F[_,_] when we fix the left type
@@ -100,6 +103,9 @@ object Unapply {
     type M[X] = F[AA,X]
     type A = B
   }
+}
+
+sealed abstract class Unapply3Instances {
 
   // the type we will instantiate when we find a typeclass instance
   // for a type in the shape of a Monad Transformer with 3 type params

--- a/state/src/test/scala/cats/state/StateTests.scala
+++ b/state/src/test/scala/cats/state/StateTests.scala
@@ -16,9 +16,13 @@ class StateTests extends CatsSuite {
 
   test("traversing state is stack-safe"){
     val ns = (0 to 100000).toList
-    // syntax doesn't work here. Should look into why
-    val x = Traverse[List].traverse[State[Int, ?], Int, Int](ns)(_ => add1)
+    val x = ns.traverseU(_ => add1)
     assert(x.runS(0).run == 100001)
+  }
+
+  test("Apply syntax is usable on State") {
+    val x = add1 *> add1
+    assert(x.runS(0).run == 2)
   }
 
   checkAll("StateT[Option, Int, Int]", MonadTests[StateT[Option, Int, ?]].monad[Int, Int, Int])

--- a/tests/src/test/scala/cats/tests/UnapplyTests.scala
+++ b/tests/src/test/scala/cats/tests/UnapplyTests.scala
@@ -13,7 +13,6 @@ class UnapplyTests extends CatsSuite {
     assert(x == Some(List(1,2,3)))
   }
 
-
   test("Unapply works for F[_,_] with the left fixed") {
     val x = Traverse[List].traverseU(List(1,2,3))(Xor.right(_))
     assert(x == Xor.right(List(1,2,3)))


### PR DESCRIPTION
This resolves an issue with ambiguous implicits that resulted in
Apply syntax not working on State. I imagine it probably also
helps syntax in a bunch of other cases.

The added unit test did not compile before this change.