### PR TITLE
Fixed typo in the output of Const.show

### DIFF
--- a/core/src/main/scala/cats/data/Const.scala
+++ b/core/src/main/scala/cats/data/Const.scala
@@ -28,7 +28,7 @@ final case class Const[A, B](getConst: A) {
     A.compare(getConst, that.getConst)
 
   def show(implicit A: Show[A]): String =
-    s"Const(${A.show(getConst)}})"
+    s"Const(${A.show(getConst)})"
 }
 
 object Const extends ConstInstances {


### PR DESCRIPTION
Const.show was outputting an extra } after the Const value as part of
the string generated. Updated code to render as Const(value) instead of
Const(value}), which is consistent with the other show methods.

This PR is kind of a test bed for me, I’m really just learning github and trying to get a feel for cats, which is where I came across the inconsistency in the text generated.

I’ve not added a test as part of this, but happy to add one. The only reason I have not added a test to verify the output is as expected is because it didn’t seem to fit with the other tests in ConstTest.scala which all seemed to be related to law checking, so I wasn’t sure whether you had alternative approach for these kinds of tests or not.

More than happy to create some tests around this (and the same for other classes), if it is useful.