### PR TITLE
Support building for 2.10 as well as 2.11.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: scala
 git:
   depth: 9999
 scala:
+- 2.10.5
 - 2.11.6
 script:
 - if [[ "$TRAVIS_PULL_REQUEST" == "false" &&

--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ lazy val scoverageSettings = Seq(
 lazy val buildSettings = Seq(
   organization := "org.spire-math",
   scalaVersion := "2.11.6",
-  crossScalaVersions := Seq("2.11.6")
+  crossScalaVersions := Seq("2.10.5", "2.11.6")
 )
 
 lazy val commonSettings = Seq(

--- a/std/src/main/scala/cats/std/stream.scala
+++ b/std/src/main/scala/cats/std/stream.scala
@@ -11,7 +11,7 @@ trait StreamInstances {
 
       def combine[A](x: Stream[A], y: Stream[A]): Stream[A] = x #::: y
 
-      def pure[A](x: A): Stream[A] = x #:: Stream.Empty
+      def pure[A](x: A): Stream[A] = Stream(x)
 
       override def map[A, B](fa: Stream[A])(f: A => B): Stream[B] =
         fa.map(f)

--- a/tests/src/test/scala/cats/tests/FoldableTests.scala
+++ b/tests/src/test/scala/cats/tests/FoldableTests.scala
@@ -52,7 +52,7 @@ class FoldableTestsAdditional extends CatsSuite {
     // handled lazily. it only needs to be evaluated if we reach the
     // "end" of the fold.
     val trap = Lazy(bomb[Boolean])
-    val result = F.foldRight(1 #:: 2 #:: Stream.Empty, trap) { n =>
+    val result = F.foldRight(1 #:: 2 #:: Stream.empty, trap) { n =>
       if (n == 2) Return(true) else Pass
     }
     assert(result.value)


### PR DESCRIPTION
Previously some of our dependencies were only available for
Scala 2.11. Since that is no longer the case, let's add
2.10.5 to the versions we build for.