### PR TITLE
Fallback to monospace font for code samples.

### DIFF
--- a/docs/src/site/css/styles.css
+++ b/docs/src/site/css/styles.css
@@ -54,7 +54,7 @@ blockquote {
 }
 
 code, pre {
-  font-family:Monaco, Bitstream Vera Sans Mono, Lucida Console, Terminal;
+  font-family:Monaco, Bitstream Vera Sans Mono, Lucida Console, Terminal, monospace;
   color:#333;
   font-size:12px;
 }


### PR DESCRIPTION
If a user doesn't have any of the enumerated fonts, the code samples render in proportional width.  This restores the spirit of `<pre>` and `<code>` with a last resort.