### PR TITLE
Add extract method to State instances

### DIFF
--- a/state/src/main/scala/cats/state/State.scala
+++ b/state/src/main/scala/cats/state/State.scala
@@ -136,7 +136,7 @@ abstract class StateFunctions {
   def modify[S](f: S => S): State[S, Unit] = State(s => (f(s), ()))
 
   /**
-   * Extract a value from the input state, without modifying the state.
+   * Inspect a value from the input state, without modifying the state.
    */
   def inspect[S, T](f: S => T): State[S, T] = State(s => (s, f(s)))
 

--- a/state/src/main/scala/cats/state/State.scala
+++ b/state/src/main/scala/cats/state/State.scala
@@ -78,6 +78,12 @@ final class StateT[F[_], S, A](val runF: F[S => F[(S, A)]]) {
   def modify(f: S => S)(implicit F: Monad[F]): StateT[F, S, A] =
     transform((s, a) => (f(s), a))
 
+  /**
+   * Extract a value from the input state, without modifying the state.
+   */
+  def extract[B](f: S => B)(implicit F: Monad[F]): StateT[F, S, B] =
+    transform((s, _) => (s, f(s)))
+
 }
 
 object StateT extends StateTInstances {
@@ -115,6 +121,7 @@ sealed abstract class StateTInstances0 {
 // To workaround SI-7139 `object State` needs to be defined inside the package object
 // together with the type alias.
 abstract class StateFunctions {
+
   def apply[S, A](f: S => (S, A)): State[S, A] =
     StateT.applyF(Trampoline.done((s: S) => Trampoline.done(f(s))))
 

--- a/state/src/main/scala/cats/state/State.scala
+++ b/state/src/main/scala/cats/state/State.scala
@@ -81,7 +81,7 @@ final class StateT[F[_], S, A](val runF: F[S => F[(S, A)]]) {
   /**
    * Extract a value from the input state, without modifying the state.
    */
-  def extract[B](f: S => B)(implicit F: Monad[F]): StateT[F, S, B] =
+  def inspect[B](f: S => B)(implicit F: Monad[F]): StateT[F, S, B] =
     transform((s, _) => (s, f(s)))
 
 }
@@ -138,12 +138,12 @@ abstract class StateFunctions {
   /**
    * Extract a value from the input state, without modifying the state.
    */
-  def extract[S, T](f: S => T): State[S, T] = State(s => (s, f(s)))
+  def inspect[S, T](f: S => T): State[S, T] = State(s => (s, f(s)))
 
   /**
    * Return the input state without modifying it.
    */
-  def get[S]: State[S, S] = extract(identity)
+  def get[S]: State[S, S] = inspect(identity)
 
   /**
    * Set the state to `s` and return Unit.

--- a/state/src/main/scala/cats/state/State.scala
+++ b/state/src/main/scala/cats/state/State.scala
@@ -79,7 +79,7 @@ final class StateT[F[_], S, A](val runF: F[S => F[(S, A)]]) {
     transform((s, a) => (f(s), a))
 
   /**
-   * Extract a value from the input state, without modifying the state.
+   * Inspect a value from the input state, without modifying the state.
    */
   def inspect[B](f: S => B)(implicit F: Monad[F]): StateT[F, S, B] =
     transform((s, _) => (s, f(s)))

--- a/state/src/test/scala/cats/state/StateTests.scala
+++ b/state/src/test/scala/cats/state/StateTests.scala
@@ -33,10 +33,10 @@ class StateTests extends CatsSuite {
     assert(x.runS(0).run == 2)
   }
 
-  test("Singleton and instance extract are consistent")(check {
+  test("Singleton and instance inspect are consistent")(check {
     forAll { (s: String, i: Int) =>
-      State.extract[Int, String](_.toString).run(i).run ==
-        State.pure[Int, Unit](()).extract(_.toString).run(i).run
+      State.inspect[Int, String](_.toString).run(i).run ==
+        State.pure[Int, Unit](()).inspect(_.toString).run(i).run
     }
   })
 

--- a/state/src/test/scala/cats/state/StateTests.scala
+++ b/state/src/test/scala/cats/state/StateTests.scala
@@ -33,6 +33,13 @@ class StateTests extends CatsSuite {
     assert(x.runS(0).run == 2)
   }
 
+  test("Singleton and instance extract are consistent")(check {
+    forAll { (s: String, i: Int) =>
+      State.extract[Int, String](_.toString).run(i).run ==
+        State.pure[Int, Unit](()).extract(_.toString).run(i).run
+    }
+  })
+
   checkAll("StateT[Option, Int, Int]", MonadTests[StateT[Option, Int, ?]].monad[Int, Int, Int])
   checkAll("Monad[StateT[Option, Int, ?]]", SerializableTests.serializable(Monad[StateT[Option, Int, ?]]))
 }


### PR DESCRIPTION
Similar to the extract method on the State companion object.

The name "extract" seems meaningful to me, but I realized that it
is a bit unfortunate that it's also the name of the method on
Comonad. Since State is implemented in terms of Trampoline, I thought
it might be kind of handy to have a runExtract method on StateT
that requires a Comonad and runs the State and extracts the value
in one go. This would make the name collision particularly unfortunate.

Anybody have any thoughts/ideas? One that comes to mind for me is
renaming the current State.extract to zoom.