### PR TITLE
Added AlgebraK, abstracting over SemigroupK and MonoidK.

### DIFF
--- a/core/src/main/scala/cats/AlgebraK.scala
+++ b/core/src/main/scala/cats/AlgebraK.scala
@@ -1,0 +1,14 @@
+package cats
+
+/**
+ * AlgebraK abstracts over type classes representing algebras at
+ * the kind level.
+ *
+ * Type classes extending AlgebraK, such as SemigroupK and
+ * MonoidKi, are useful when their type parameter F[_] has a
+ * structure that can be combined for any particular type.
+ */
+trait AlgebraK[+A[_], F[_]] {
+  def apply[T]: A[F[T]]
+}
+

--- a/core/src/main/scala/cats/Foldable.scala
+++ b/core/src/main/scala/cats/Foldable.scala
@@ -135,7 +135,7 @@ import simulacrum.typeclass
    * }}}
    */
   def foldK[G[_], A](fga: F[G[A]])(implicit G: MonoidK[G]): G[A] =
-    fold(fga)(G.algebra)
+    fold(fga)(G[A])
 
 
   /**

--- a/core/src/main/scala/cats/MonoidK.scala
+++ b/core/src/main/scala/cats/MonoidK.scala
@@ -22,7 +22,7 @@ import simulacrum.typeclass
  *    combination operation and empty value just depend on the
  *    structure of F, but not on the structure of A.
  */
-@typeclass trait MonoidK[F[_]] extends SemigroupK[F] { self =>
+@typeclass trait MonoidK[F[_]] extends SemigroupK[F] with AlgebraK[Monoid, F] { self =>
 
   /**
    * Given a type A, create an "empty" F[A] value.
@@ -32,7 +32,7 @@ import simulacrum.typeclass
   /**
    * Given a type A, create a concrete Monoid[F[A]].
    */
-  override def algebra[A]: Monoid[F[A]] =
+  override def apply[A]: Monoid[F[A]] =
     new Monoid[F[A]] {
       def empty: F[A] = self.empty
       def combine(x: F[A], y: F[A]): F[A] = self.combine(x, y)

--- a/core/src/main/scala/cats/Reducible.scala
+++ b/core/src/main/scala/cats/Reducible.scala
@@ -46,7 +46,7 @@ import Fold.{Return, Pass, Continue}
    * This method is a generalization of `reduce`.
    */
   def reduceK[G[_], A](fga: F[G[A]])(implicit G: SemigroupK[G]): G[A] =
-    reduce(fga)(G.algebra)
+    reduce(fga)(G[A])
 
   /**
    * Apply `f` to each element of `fa` and combine them using the

--- a/core/src/main/scala/cats/SemigroupK.scala
+++ b/core/src/main/scala/cats/SemigroupK.scala
@@ -20,7 +20,7 @@ import simulacrum.{op, typeclass}
  *    The combination operation just depends on the structure of F,
  *    but not the structure of A.
  */
-@typeclass trait SemigroupK[F[_]] extends Serializable { self =>
+@typeclass trait SemigroupK[F[_]] extends AlgebraK[Semigroup, F] with Serializable { self =>
 
   /**
    * Combine two F[A] values.
@@ -39,7 +39,7 @@ import simulacrum.{op, typeclass}
   /**
    * Given a type A, create a concrete Semigroup[F[A]].
    */
-  def algebra[A]: Semigroup[F[A]] =
+  def apply[A]: Semigroup[F[A]] =
     new Semigroup[F[A]] {
       def combine(x: F[A], y: F[A]): F[A] = self.combine(x, y)
     }

--- a/laws/src/main/scala/cats/laws/AlternativeLaws.scala
+++ b/laws/src/main/scala/cats/laws/AlternativeLaws.scala
@@ -5,7 +5,7 @@ import cats.syntax.all._
 
 trait AlternativeLaws[F[_]] extends ApplicativeLaws[F] with MonoidKLaws[F] {
   implicit override def F: Alternative[F]
-  implicit def algebra[A]: Monoid[F[A]] = F.algebra[A]
+  implicit def algebra[A]: Monoid[F[A]] = F[A]
 
   def alternativeRightAbsorption[A, B](ff: F[A => B]): IsEq[F[B]] =
     (F.empty[A] ap ff) <-> F.empty[B]

--- a/tests/src/test/scala/cats/tests/ConstTests.scala
+++ b/tests/src/test/scala/cats/tests/ConstTests.scala
@@ -16,7 +16,7 @@ class ConstTests extends CatsSuite {
 
   // Get Apply[Const[C : Semigroup, ?]], not Applicative[Const[C : Monoid, ?]]
   {
-    implicit def nonEmptyListSemigroup[A]: Semigroup[NonEmptyList[A]] = SemigroupK[NonEmptyList].algebra
+    implicit def nonEmptyListSemigroup[A]: Semigroup[NonEmptyList[A]] = SemigroupK[NonEmptyList].apply[A]
     checkAll("Apply[Const[NonEmptyList[String], Int]]", ApplyTests[Const[NonEmptyList[String], ?]].apply[Int, Int, Int])
     checkAll("Apply[Const[NonEmptyList[String], ?]]", SerializableTests.serializable(Apply[Const[NonEmptyList[String], ?]]))
   }


### PR DESCRIPTION
This hasn't worked out as nicely as I would have hoped. To start with, it's doesn't generalize to `EqK`, `ArbitraryK` because unlike `SemigroupK` and `MonoidK` these are sensitive to the structure of their elements.

Also the switch to `apply` doesn't work out so smoothly, at least in the context of `ConstTests`. Here we're forced to write `SemigroupK[NonEmptyList].apply[A]` because silly syntactic restrictions prevent us from having two type argument lists adjacent to one another (ie. `SemigroupK[NonEmptyList][A]`.

Feel free to merge if you think this is still of value, but I think it's fairly marginal.