### PR TITLE
Revise Fold to be its own trampoline.

### DIFF
--- a/core/src/main/scala/cats/Fold.scala
+++ b/core/src/main/scala/cats/Fold.scala
@@ -76,27 +76,29 @@ package cats
  * not stack-safe.)
  */
 sealed abstract class Fold[A] extends Product with Serializable {
-  import Fold.{Return, Continue, Pass}
+  import Fold.{Return, Composed}
 
-  def imap[B](f: A => B)(g: B => A): Fold[B] =
+  def complete(la: Lazy[A]): A =
     this match {
-      case Return(a) => Return(f(a))
-      case Continue(h) => Continue(b => f(g(b)))
-      case _ => Pass
+      case Return(a) => a
+      case Composed(fs) => fs.foldLeft(la.value)((a, f) => f(a))
+    }
+
+  def andThen(that: => Fold[A]): Fold[A] =
+    this match {
+      case Return(a) =>
+        Return(a)
+      case Composed(fs) =>
+        that match {
+          case Return(a) => Return(complete(Lazy.eager(a)))
+          case Composed(gs) => Composed(fs ::: gs)
+        }
     }
 
   def compose(f: A => A): Fold[A] =
     this match {
       case Return(a) => Return(f(a))
-      case Continue(g) => Continue(f andThen g)
-      case _ => Continue(f)
-    }
-
-  def complete(la: Lazy[A]): A =
-    this match {
-      case Return(a) => a
-      case Continue(f) => f(la.value)
-      case _ => la.value
+      case Composed(gs) => Composed(gs ::: (f :: Nil))
     }
 }
 
@@ -118,7 +120,13 @@ object Fold {
    * When the end of the fold is reached, the final A value will
    * propagate back through these functions, producing a final result.
    */
-  final case class Continue[A](f: A => A) extends Fold[A]
+  final def Continue[A](f: A => A): Fold[A] =
+    Composed(f :: Nil)
+
+  /**
+   * 
+   */
+  final case class Composed[A](fs: List[A => A]) extends Fold[A]
 
   /**
    * Pass allows the fold to continue, without modifying the result.
@@ -126,24 +134,19 @@ object Fold {
    * Pass' behavior is identical to `Continue(identity[A])`, but it may be
    * more efficient.
    */
-  final def Pass[A]: Fold[A] = pass.asInstanceOf[Fold[A]]
-
-  final case object pass extends Fold[Nothing]
+  final def Pass[A]: Fold[A] = Composed(Nil)
 
   /**
    * partialIterate provides a partialFold for `Iterable[A]` values.
    */
   def partialIterate[A, B](as: Iterable[A])(f: A => Fold[B]): Fold[B] = {
-    def unroll(b: B, fs: List[B => B]): B =
-      fs.foldLeft(b)((b, f) => f(b))
     def loop(it: Iterator[A], fs: List[B => B]): Fold[B] =
       if (it.hasNext) {
         f(it.next) match {
-          case Return(b) => Return(unroll(b, fs))
-          case Continue(f) => loop(it, f :: fs)
-          case _ => loop(it, fs)
+          case Composed(gs) => loop(it, gs ::: fs)
+          case fold => Composed(fs) andThen fold
         }
-      } else Continue(b => unroll(b, fs))
+      } else Composed(fs)
     loop(as.iterator, Nil)
   }
 }

--- a/core/src/main/scala/cats/Fold.scala
+++ b/core/src/main/scala/cats/Fold.scala
@@ -94,12 +94,6 @@ sealed abstract class Fold[A] extends Product with Serializable {
           case Composed(gs) => Composed(fs ::: gs)
         }
     }
-
-  def compose(f: A => A): Fold[A] =
-    this match {
-      case Return(a) => Return(f(a))
-      case Composed(gs) => Composed(gs ::: (f :: Nil))
-    }
 }
 
 object Fold {
@@ -124,15 +118,20 @@ object Fold {
     Composed(f :: Nil)
 
   /**
-   * 
+   * Composed allows functions to be composed in a stack-safe way.
+   *
+   * The functions are applied first-to-last.
+   *
+   * That is `List(f1, f2, f3)` will be applied to `a` as
+   * `f3(f2(f1(a)))`.
    */
   final case class Composed[A](fs: List[A => A]) extends Fold[A]
 
   /**
    * Pass allows the fold to continue, without modifying the result.
    *
-   * Pass' behavior is identical to `Continue(identity[A])`, but it may be
-   * more efficient.
+   * Pass' behavior is identical to `Continue(identity[A])`, but it
+   * may be more efficient.
    */
   final def Pass[A]: Fold[A] = Composed(Nil)
 

--- a/core/src/main/scala/cats/Reducible.scala
+++ b/core/src/main/scala/cats/Reducible.scala
@@ -2,7 +2,7 @@ package cats
 
 import simulacrum._
 
-import Fold.{Return, Pass, Continue}
+import Fold.{Return, Pass, Continue, Composed}
 
 /**
  * Data structures that can be reduced to a summary value.
@@ -161,8 +161,7 @@ abstract class NonEmptyReducible[F[_], G[_]](implicit G: Foldable[G]) extends Re
     def right: Fold[B] = G.partialFold(ga)(f)
     f(a) match {
       case Return(b) => Return(b)
-      case Continue(g) => right compose g
-      case _ => right
+      case fold => fold andThen right
     }
   }
 

--- a/core/src/main/scala/cats/data/OneAnd.scala
+++ b/core/src/main/scala/cats/data/OneAnd.scala
@@ -104,18 +104,8 @@ trait OneAndInstances {
       override def foldRight[A, B](fa: OneAnd[A, F], b: Lazy[B])(f: A => Fold[B]): Lazy[B] =
         fa.foldRight(b)(f)
 
-      override def partialFold[A, B](fa: OneAnd[A,F])(f: A => Fold[B]): Fold[B] = {
-        import Fold._
-        f(fa.head) match {
-          case b @ Return(_) => b
-          case Continue(c) => foldable.partialFold(fa.tail)(f) match {
-            case Return(b) => Return(c(b))
-            case Continue(cc) => Continue { b => c(cc(b)) }
-            case _ => Continue(c)
-          }
-          case _ => foldable.partialFold(fa.tail)(f)
-        }
-      }
+      override def partialFold[A, B](fa: OneAnd[A,F])(f: A => Fold[B]): Fold[B] =
+        f(fa.head) andThen foldable.partialFold(fa.tail)(f)
     }
 
   implicit def oneAndMonad[F[_]](implicit monad: MonadCombine[F]): Monad[OneAnd[?, F]] =


### PR DESCRIPTION
This commit explores Miles' suggestion that allowing users
to use the andThen and compose methods to build Fold instances
in a stack-safe way makes the type more approachable.

This also simplifies the partialIterate method a bit.

(Don't merge this yet -- if we agree this is the right direction
then I need to update some documentation first.)