### PR TITLE
ReaderT and Reader type and value aliases, closes #382

### DIFF
--- a/core/src/main/scala/cats/data/Kleisli.scala
+++ b/core/src/main/scala/cats/data/Kleisli.scala
@@ -62,7 +62,7 @@ object Kleisli extends KleisliInstances with KleisliFunctions
 
 sealed trait KleisliFunctions {
   /** creates a [[Kleisli]] from a function */
-  def kleisli[F[_], A, B](f: A => F[B]): Kleisli[F, A, B] =
+  def function[F[_], A, B](f: A => F[B]): Kleisli[F, A, B] =
     Kleisli(f)
 
   def pure[F[_], A, B](x: B)(implicit F: Applicative[F]): Kleisli[F, A, B] =

--- a/core/src/main/scala/cats/data/package.scala
+++ b/core/src/main/scala/cats/data/package.scala
@@ -27,4 +27,12 @@ package object data {
         Fold.Continue { case OneAnd(h, t) => OneAnd(a, h :: t) }
       }
   }
+
+  type ReaderT[F[_], A, B] = Kleisli[F, A, B]
+  val ReaderT = Kleisli
+
+  type Reader[A, B] = ReaderT[Id, A, B]
+  object Reader {
+    def apply[A, B](f: A => B): Reader[A, B] = ReaderT.function[Id, A, B](f)
+  }
 }

--- a/tests/src/test/scala/cats/tests/KleisliTests.scala
+++ b/tests/src/test/scala/cats/tests/KleisliTests.scala
@@ -3,7 +3,6 @@ package tests
 
 import cats.arrow.{Split, Arrow}
 import cats.data.Kleisli
-import Kleisli.kleisli
 import cats.functor.Strong
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
@@ -65,7 +64,7 @@ class KleisliTests extends CatsSuite {
 
   check {
     forAll { (f: Int => Option[String], g: Int => Int, i: Int) =>
-      f(g(i)) == Kleisli.local[Option, String, Int](g)(Kleisli.kleisli(f)).run(i)
+      f(g(i)) == Kleisli.local[Option, String, Int](g)(Kleisli.function(f)).run(i)
     }
   }
 
@@ -76,7 +75,7 @@ class KleisliTests extends CatsSuite {
   }
 
   test("lift") {
-    val f = kleisli { (x: Int) => (Some(x + 1): Option[Int]) }
+    val f = Kleisli.function { (x: Int) => (Some(x + 1): Option[Int]) }
     val l = f.lift[List]
     assert((List(1, 2, 3) >>= l.run) == List(Some(2), Some(3), Some(4)))
   }


### PR DESCRIPTION
Changed Kleisli.kleisli to Kleisli.function for a more
generic name.. mostly to make ReaderT value alias usage
look a bit more natural.. ReaderT.function instead of
ReaderT.kleisli.