### PR TITLE
Released version on site

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,7 +149,7 @@ run `sbt docs/makeSite`
 
 3. Start jekyll with `jekyll serve`
 
-4. Navigate to http://localhost:4000/indoctrinate/ in your browser
+4. Navigate to http://localhost:4000/cats/ in your browser
 
 5. Make changes to your site, and run `sbt makeSite` to regenerate the site. The changes should be reflected as soon as you run `makeSite`.
 

--- a/docs/src/site/index.md
+++ b/docs/src/site/index.md
@@ -22,7 +22,7 @@ Cats has not yet published artifacts, so in order to use Cats you will have to g
 
 Then in your project, add to your build.sbt
 
-    libraryDependencies += "org.spire-math" %% "cats-core" % "0.1.0-SNAPSHOT"
+    libraryDependencies += "org.spire-math" %% "cats-core" % "0.1.2"
 
 <a name "motivations"></a>
 # Motivations


### PR DESCRIPTION
Currently the site docs point to an old snapshot, this updates the docs to point to the currently released version instead.