### PR TITLE
Optimize Later[A].

### DIFF
--- a/core/src/main/scala/cats/Eval.scala
+++ b/core/src/main/scala/cats/Eval.scala
@@ -118,7 +118,7 @@ case class Now[A](value: A) extends Eval[A]
  * garbage collection.
  */
 class Later[A](f: () => A) extends Eval[A] {
-  private[this] var thunk: Function0[A] = f
+  private[this] var thunk: () => A = f
 
   // The idea here is that `f` may have captured very large
   // structures, but produce a very small result. In this case, once


### PR DESCRIPTION
This commit allows instances of Later[A] to "forget" the
thunk they use to lazily-evaluate their computation. This
means that expensive objects used to compute Later[A]
instances will be garbage-collected once the value is
computed.

Previously, a Later[A] instance would have held onto the
captured thunk, which in turn would have held onto its
captured objects. If those objects were large, this could
manifest as a larger-than-necessary memory footprint.