### PR TITLE
Set scalatest 3.0.0 defaults to mirror 2.2.5

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -37,7 +37,7 @@ lazy val commonSettings = Seq(
   ),
   scmInfo := Some(ScmInfo(url("https://github.com/non/cats"),
     "scm:git:git@github.com:non/cats.git"))
-)
+) ++ warnUnusedImport
 
 lazy val commonJsSettings = Seq(
   scalaJSStage in Global := FastOptStage,
@@ -45,7 +45,8 @@ lazy val commonJsSettings = Seq(
 )
 
 lazy val commonJvmSettings = Seq(
-  parallelExecution in Test := false
+  parallelExecution in Test := false,
+  testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-oDF")
 )
 
 lazy val catsSettings = buildSettings ++ commonSettings ++ publishSettings ++ scoverageSettings

--- a/tests/js/src/test/scala/cats/tests/Platform.scala
+++ b/tests/js/src/test/scala/cats/tests/Platform.scala
@@ -1,7 +1,13 @@
 package cats
 package tests
 
+import org.scalactic.anyvals.{PosZDouble, PosInt}
+
 private[tests] object Platform {
+
+  // Override defaults to mimick scalatest 2.2.5 values
+  val minSuccessful = PosInt(10)
+  val maxDiscardedFactor = PosZDouble(50.0)
 
   trait UltraSlowCatsSuite extends CatsSuite {
     implicit override val generatorDrivenConfig: PropertyCheckConfiguration =

--- a/tests/jvm/src/test/scala/cats/tests/Platform.scala
+++ b/tests/jvm/src/test/scala/cats/tests/Platform.scala
@@ -1,6 +1,13 @@
 package cats
 package tests
 
+import org.scalactic.anyvals.{PosZDouble, PosInt}
+
 private[tests] object Platform {
+
+  // Override defaults to mimick scalatest 2.2.5 values
+  val minSuccessful = PosInt(100)
+  val maxDiscardedFactor = PosZDouble(5.0)
+
   trait UltraSlowCatsSuite extends CatsSuite {}
 }

--- a/tests/shared/src/test/scala/cats/tests/CatsSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/CatsSuite.scala
@@ -16,6 +16,10 @@ import scala.util.{Failure, Success, Try}
  * boilerplate in Cats tests.
  */
 trait CatsSuite extends FunSuite with Matchers with Discipline with AllInstances with AllSyntax with TestInstances {
+
+  implicit override val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfiguration(
+      minSuccessful = Platform.minSuccessful, maxDiscardedFactor = Platform.maxDiscardedFactor)
+
   // disable scalatest's ===
   override def convertToEqualizer[T](left: T): Equalizer[T] = ???
 }


### PR DESCRIPTION
These settings should fix the new intermittent test failures by reverting to scalatest 2.2.5 values. If successful, I shall raise issue to scalatest.