### PR TITLE
Make the spelling of "type class" consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ ensure correctness.
 
 Cats will be designed to use modern *best practices*:
 
- * [simulacrum](https://github.com/mpilquist/simulacrum) for minimizing typeclass boilerplate
+ * [simulacrum](https://github.com/mpilquist/simulacrum) for minimizing type class boilerplate
  * [machinist](https://github.com/typelevel/machinist) for optimizing implicit operators
  * [scalacheck](http://scalacheck.org) for property-based testing
  * [discipline](https://github.com/typelevel/discipline) for encoding and testing laws

--- a/core/src/main/scala/cats/FlatMap.scala
+++ b/core/src/main/scala/cats/FlatMap.scala
@@ -3,7 +3,7 @@ package cats
 import simulacrum.typeclass
 
 /**
- *  FlatMap typeclass gives us flatMap, which allows us to have a value
+ *  FlatMap type class gives us flatMap, which allows us to have a value
  *  in a context (F[A]) and then feed that into a function that takes
  *  a normal value and returns a value in a context (A => F[B]).
  *

--- a/core/src/main/scala/cats/Show.scala
+++ b/core/src/main/scala/cats/Show.scala
@@ -4,7 +4,7 @@ import simulacrum.typeclass
 import cats.functor.Contravariant
 
 /**
- * A typeclass to provide textual representation. It is meant to be a
+ * A type class to provide textual representation. It is meant to be a
  * better "toString". Whereas toString exists for any Object,
  * regardless of whether or not the creator of the class explicitly
  * made a toString method, a Show instance will only exist if someone

--- a/core/src/main/scala/cats/Unapply.scala
+++ b/core/src/main/scala/cats/Unapply.scala
@@ -1,9 +1,9 @@
 package cats
 
 /**
- * A typeclass that is used to help guide scala's type inference to
- * find typeclass instances for types which have shapes which differ
- * from what their typeclasses are looking for.
+ * A type class that is used to help guide Scala's type inference to
+ * find type class instances for types which have shapes which differ
+ * from what their type classes are looking for.
  *
  * For example, [[Functor]] is defined for types in the shape
  * F[_]. Scala has no problem finding instance of Functor which match
@@ -11,15 +11,15 @@ package cats
  * also a functor defined for some types which have the Shape F[_,_]
  * when one of the two 'holes' is fixed. For example. there is a
  * Functor for Map[A,?] for any A, and for Either[A,?] for any A,
- * however the scala compiler will not find them without some coercing.
+ * however the Scala compiler will not find them without some coercing.
  */
 trait Unapply[TC[_[_]], MA] {
-  // a type constructor which is properly kinded for the typeclass
+  // a type constructor which is properly kinded for the type class
   type M[_]
   // the type applied to the type constructor to make an MA
   type A
 
-  // the actual typeclass instance found
+  // the actual type class instance found
   def TC: TC[M]
 
   // a function which will coerce the MA value into one of type M[A]
@@ -32,7 +32,7 @@ object Unapply extends Unapply2Instances {
   // a convenience method for summoning Unapply instances
   def apply[TC[_[_]], MA](implicit ev: Unapply[TC,MA]): Unapply[TC, MA] = implicitly
 
-  // the type we will instantiate when we find a typeclass instance
+  // the type we will instantiate when we find a type class instance
   // which is already the expected shape: F[_]
   type Aux1[TC[_[_]], MA, F[_], AA] = Unapply[TC, MA] {
     type M[X] = F[X]
@@ -51,14 +51,14 @@ object Unapply extends Unapply2Instances {
 
 sealed abstract class Unapply2Instances extends Unapply3Instances {
 
-  // the type we will instantiate when we find a typeclass instance
+  // the type we will instantiate when we find a type class instance
   // for a type in the shape F[_,_] when we fix the left type
   type Aux2Left[TC[_[_]], FA, F[_,_], AA, B] = Unapply[TC, FA] {
     type M[X] = F[X,B]
     type A = AA
   }
 
-  // the type we will instantiate when we find a typeclass instance
+  // the type we will instantiate when we find a type class instance
   // for a type in the shape F[_,_] when we fix the right type
   type Aux2Right[TC[_[_]], MA, F[_,_], AA, B] = Unapply[TC, MA] {
     type M[X] = F[AA,X]
@@ -97,7 +97,7 @@ sealed abstract class Unapply2Instances extends Unapply3Instances {
      def subst: F[Nothing, B] => M[A] = identity
    }
 
-  // the type we will instantiate when we find a typeclass instance
+  // the type we will instantiate when we find a type class instance
   // for a type in the shape of a Monad Transformer with 2 type params
   type Aux2MT[TC[_[_]], MA, F[_[_],_], AA[_], B] = Unapply[TC, MA] {
     type M[X] = F[AA,X]
@@ -107,7 +107,7 @@ sealed abstract class Unapply2Instances extends Unapply3Instances {
 
 sealed abstract class Unapply3Instances {
 
-  // the type we will instantiate when we find a typeclass instance
+  // the type we will instantiate when we find a type class instance
   // for a type in the shape of a Monad Transformer with 3 type params
   // F[_[_],_,_] when we fix the middle type
   type Aux3MTLeft[TC[_[_]], MA, F[_[_],_,_], AA[_], B, C] = Unapply[TC, MA] {
@@ -115,7 +115,7 @@ sealed abstract class Unapply3Instances {
     type A = B
   }
 
-  // the type we will instantiate when we find a typeclass instance
+  // the type we will instantiate when we find a type class instance
   // for a type in the shape of a Monad Transformer with 3 type params
   // F[_[_],_,_] when we fix the right type
   type Aux3MTRight[TC[_[_]], MA, F[_[_],_,_], AA[_], B, C] = Unapply[TC, MA] {

--- a/core/src/main/scala/cats/functor/Bifunctor.scala
+++ b/core/src/main/scala/cats/functor/Bifunctor.scala
@@ -2,7 +2,7 @@ package cats
 package functor
 
 /**
- * A typeclass of types which give rise to two independent, covariant
+ * A type class of types which give rise to two independent, covariant
  * functors.
  */
 trait Bifunctor[F[_, _]] extends Serializable { self =>

--- a/core/src/main/scala/cats/std/anyval.scala
+++ b/core/src/main/scala/cats/std/anyval.scala
@@ -25,7 +25,7 @@ trait IntInstances extends algebra.std.IntInstances {
 
 }
 
-trait ByteInstances /* missing algebra typeclasses */ {
+trait ByteInstances /* missing algebra type classes */ {
 
   implicit val byteShow: Show[Byte] =
     Show.fromToString[Byte]
@@ -41,7 +41,7 @@ trait ByteInstances /* missing algebra typeclasses */ {
     }
 }
 
-trait CharInstances /* missing algebra typeclasses */ {
+trait CharInstances /* missing algebra type classes */ {
 
   implicit val charShow: Show[Char] =
     Show.fromToString[Char]
@@ -53,7 +53,7 @@ trait CharInstances /* missing algebra typeclasses */ {
     }
 }
 
-trait ShortInstances /* missing algebra typeclasses */ {
+trait ShortInstances /* missing algebra type classes */ {
 
   implicit val shortShow: Show[Short] =
     Show.fromToString[Short]
@@ -70,7 +70,7 @@ trait ShortInstances /* missing algebra typeclasses */ {
 
 }
 
-trait LongInstances /* missing algebra typeclasses */ {
+trait LongInstances /* missing algebra type classes */ {
 
   implicit val longShow: Show[Long] =
     Show.fromToString[Long]
@@ -86,7 +86,7 @@ trait LongInstances /* missing algebra typeclasses */ {
     }
 }
 
-trait FloatInstances /* missing algebra typeclasses */ {
+trait FloatInstances /* missing algebra type classes */ {
 
   implicit val floatShow: Show[Float] =
     Show.fromToString[Float]
@@ -103,7 +103,7 @@ trait FloatInstances /* missing algebra typeclasses */ {
 
 }
 
-trait DoubleInstances /* missing algebra typeclasses */ {
+trait DoubleInstances /* missing algebra type classes */ {
 
   implicit val doubleShow: Show[Double] =
     Show.fromToString[Double]
@@ -127,7 +127,7 @@ trait BooleanInstances extends algebra.std.BooleanInstances {
 
 }
 
-trait UnitInstances /* missing algebra typeclasses */ {
+trait UnitInstances /* missing algebra type classes */ {
 
   implicit val unitShow: Show[Unit] =
     Show.fromToString[Unit]

--- a/docs/src/main/tut/apply.md
+++ b/docs/src/main/tut/apply.md
@@ -7,7 +7,7 @@ scaladoc: "#cats.Apply"
 ---
 # Apply
 
-`Apply` extends the [`Functor`](functor.md) typeclass (which features the familiar `map`
+`Apply` extends the [`Functor`](functor.md) type class (which features the familiar `map`
 function) with a new function `ap`. The `ap` function is similar to `map`
 in that we are transforming a value in a context (a context being the `F` in `F[A]`;
 a context can be `Option`, `List` or `Future` for example).

--- a/docs/src/main/tut/functor.md
+++ b/docs/src/main/tut/functor.md
@@ -7,7 +7,7 @@ scaladoc: "#cats.Functor"
 ---
 # Functor
 
-A `Functor` is a ubiquitous typeclass involving types that have one
+A `Functor` is a ubiquitous type class involving types that have one
 "hole", i.e. types which have the shape `F[?]`, such as `Option`,
 `List` and `Future`. (This is in contrast to a type like `Int` which has
 no hole, or `Tuple2` which has two holes (`Tuple2[?,?]`)).

--- a/docs/src/main/tut/monad.md
+++ b/docs/src/main/tut/monad.md
@@ -7,7 +7,7 @@ scaladoc: "#cats.Monad"
 ---
 # Monad
 
-Monad extends the Applicative typeclass with a new function `flatten`. Flatten
+Monad extends the Applicative type class with a new function `flatten`. Flatten
 takes a value in a nested context (eg. `F[F[A]]` where F is the context) and
 "joins" the contexts together so that we have a single context (ie. F[A]).
 

--- a/docs/src/main/tut/semigroupk.md
+++ b/docs/src/main/tut/semigroupk.md
@@ -21,7 +21,7 @@ must be the same as
 
 for all possible values of a,b,c.
 
-Cats does not define a Semigroup typeclass itself, we use the
+Cats does not define a Semigroup type class itself, we use the
 [Semigroup
 trait](https://github.com/non/algebra/blob/master/core/src/main/scala/algebra/Semigroup.scala)
 which is defined in the [algebra
@@ -106,7 +106,7 @@ two <+> n
 
 You'll notice that instead of declaring `one` as `Some(1)`, I chose
 `Option(1)`, and I added an explicit type declaration for `n`. This is
-because there aren't typeclass instances for Some or None, but for
+because there aren't type class instances for Some or None, but for
 Option. If we try to use Some and None, we'll get errors:
 
 ```tut:nofail

--- a/docs/src/main/tut/typeclasses.md
+++ b/docs/src/main/tut/typeclasses.md
@@ -1,12 +1,12 @@
-# Typeclasses
+# Type classes
 
-The typeclass pattern is a ubiquitous pattern in Scala, its function
+The type class pattern is a ubiquitous pattern in Scala, its function
 is to provide a behavior for some type. You think of it as an
 "interface" in the Java sense. Here's an example.
 
 ```tut
 /**
- * A typeclass to provide textual representation
+ * A type class to provide textual representation
  */
 trait Show[A] {
   def show(f: A): String
@@ -38,7 +38,7 @@ implicit val stringShow = new Show[String] {
 log("a string")
 ```
 
-This example demonstrates a powerful property of the typeclass
+This example demonstrates a powerful property of the type class
 pattern. We have been able to provide an implementation of Show for
 String, without needing to change the definition of java.lang.String
 to extend a new Java-style interface; something we couldn't have done

--- a/docs/src/site/colophon.md
+++ b/docs/src/site/colophon.md
@@ -12,7 +12,7 @@ We would like to thank the maintainers of these supporting projects,
 and we'd encourage you to check out these projects and consider
 integrating them into your own projects.
 
- * [simulacrum](https://github.com/mpilquist/simulacrum) for minimizing typeclass boilerplate
+ * [simulacrum](https://github.com/mpilquist/simulacrum) for minimizing type class boilerplate
  * [machinist](https://github.com/typelevel/machinist) for optimizing implicit operators
  * [scalacheck](http://scalacheck.org) for property-based testing
  * [discipline](https://github.com/typelevel/discipline) for encoding and testing laws

--- a/docs/src/site/index.md
+++ b/docs/src/site/index.md
@@ -54,9 +54,9 @@ page](contributing.html) to find out ways to give us feedback.
 ### Modularity
 
 We are trying to make the library modular. It will have a tight
-core which will contain only the [typeclasses](typeclasses.html),
+core which will contain only the [type classes](typeclasses.html),
 the bare minimum of data structures that are needed to support
-them, and typeclass instances for those data structures and standard
+them, and type class instances for those data structures and standard
 library types.
 
 ### Documentation
@@ -86,10 +86,10 @@ these obvious, and will keep them well documented.
 
 In an attempt to be more modular, Cats is broken up into a number of sub-projects:
 
-* *core* - contains typeclass definitions (e.g. Functor, Applicative, Monad), essential datatypes, and
-  typeclass instances for those datatypes and standard library types
-* *laws* - laws for the typeclasses, used to validate typeclass instances
-* *tests* - tests that check typeclass instances with laws from *laws*
+* *core* - contains type class definitions (e.g. Functor, Applicative, Monad), essential datatypes, and
+  type class instances for those datatypes and standard library types
+* *laws* - laws for the type classes, used to validate type class instances
+* *tests* - tests that check type class instances with laws from *laws*
 * *docs* - The source for this website
 
 <a name="copyright"></a>


### PR DESCRIPTION
This changes all occurences of "typeclass" to "type class" in user
visible places. Filenames or technical strings like "typeclasses.md"
or the Jekyll "typeclasses" section are not changed.

closes: #441