### PR TITLE
Add TeX and LaTeX support

### DIFF
--- a/docs/src/site/_layouts/default.html
+++ b/docs/src/site/_layouts/default.html
@@ -3,6 +3,11 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="chrome=1">
+    <!--mathjax-->
+    <script src='https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML'></script>
+    <script type="text/x-mathjax-config">
+      MathJax.Hub.Config({tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]}});
+    </script>
     <title>{{ site.name }} - {{ page.title }}</title>
 
     <link rel="stylesheet" href="{{ site.baseurl }}css/styles.css">


### PR DESCRIPTION
Adds [MathJax TeX and LaTeX Support](http://docs.mathjax.org/en/latest/tex.html) for the documentation.

Example screenshot:

![tex](https://cloud.githubusercontent.com/assets/5887373/9294853/d9dedfc4-4459-11e5-89b9-9a51a6479c49.png)


