### PR TITLE
Improves miscellaneous items in documentation

### DIFF
--- a/docs/src/main/tut/applicative.md
+++ b/docs/src/main/tut/applicative.md
@@ -7,7 +7,7 @@ scaladoc: "#cats.Applicative"
 ---
 # Applicative
 
-`Applicative` extends [Apply](apply.html) by adding a single method,
+`Applicative` extends [`Apply`](apply.html) by adding a single method,
 `pure`:
 
 ```scala
@@ -40,7 +40,7 @@ into the other context:
 
 ## Applicative Functors & Monads
 
-`Applicative` is a generalization of [Monad](monad.html), allowing expression
+`Applicative` is a generalization of [`Monad`](monad.html), allowing expression
 of effectful computations in a pure functional way.
 
 `Applicative` is generally preferred to `Monad` when the structure of a

--- a/docs/src/main/tut/applicative.md
+++ b/docs/src/main/tut/applicative.md
@@ -7,8 +7,8 @@ scaladoc: "#cats.Applicative"
 ---
 # Applicative
 
-Applicative functors are a simple extension of the [Apply
-functor](apply.html) which adds a single method, `pure`:
+`Applicative` extends [Apply](apply.html) by adding a single method,
+`pure`:
 
 ```scala
     def pure[A](x: A): F[A]
@@ -40,9 +40,9 @@ into the other context:
 
 ## Applicative Functors & Monads
 
-Applicative functors are a generalization of monads thus allowing to express 
-effectful computations into a pure functional way.
+`Applicative` is a generalization of [Monad](monad.html), allowing expression
+of effectful computations in a pure functional way.
 
-Applicative functors are generally preferred to monads when the structure 
-of a computation is fixed a priori. That makes it possible to perform certain
+`Applicative` is generally preferred to `Monad` when the structure of a
+computation is fixed a priori. That makes it possible to perform certain
 kinds of static analysis on applicative values.

--- a/docs/src/main/tut/apply.md
+++ b/docs/src/main/tut/apply.md
@@ -7,7 +7,7 @@ scaladoc: "#cats.Apply"
 ---
 # Apply
 
-`Apply` extends the [`Functor`](functor.html) type class (which features the familiar `map`
+`Apply` extends the [Functor](functor.html) type class (which features the familiar `map`
 function) with a new function `ap`. The `ap` function is similar to `map`
 in that we are transforming a value in a context (a context being the `F` in `F[A]`;
 a context can be `Option`, `List` or `Future` for example).

--- a/docs/src/main/tut/apply.md
+++ b/docs/src/main/tut/apply.md
@@ -7,7 +7,7 @@ scaladoc: "#cats.Apply"
 ---
 # Apply
 
-`Apply` extends the [Functor](functor.html) type class (which features the familiar `map`
+`Apply` extends the [`Functor`](functor.html) type class (which features the familiar `map`
 function) with a new function `ap`. The `ap` function is similar to `map`
 in that we are transforming a value in a context (a context being the `F` in `F[A]`;
 a context can be `Option`, `List` or `Future` for example).

--- a/docs/src/main/tut/id.md
+++ b/docs/src/main/tut/id.md
@@ -29,7 +29,7 @@ val y: Int = x
 ```
 
 Using this type declaration, we can treat our Id type constructor as a
-[Monad](monad.html) and as a [Comonad](comonad.html). The `pure`
+[`Monad`](monad.html) and as a [`Comonad`](comonad.html). The `pure`
 method, which has type `A => Id[A]` just becomes the identity
 function.  The `map` method from `Functor` just becomes function
 application:

--- a/docs/src/main/tut/monad.md
+++ b/docs/src/main/tut/monad.md
@@ -7,9 +7,10 @@ scaladoc: "#cats.Monad"
 ---
 # Monad
 
-Monad extends the Applicative type class with a new function `flatten`. Flatten
-takes a value in a nested context (eg. `F[F[A]]` where F is the context) and
-"joins" the contexts together so that we have a single context (ie. F[A]).
+`Monad` extends the [Applicative](applicative.html) type class with a
+new function `flatten`. Flatten takes a value in a nested context (eg.
+`F[F[A]]` where F is the context) and "joins" the contexts together so
+that we have a single context (ie. F[A]).
 
 The name `flatten` should remind you of the functions of the same name on many
 classes in the standard library.
@@ -22,7 +23,7 @@ List(List(1),List(2,3)).flatten
 
 ### Monad instances
 
-If Applicative is already present and `flatten` is well-behaved, extending to
+If `Applicative` is already present and `flatten` is well-behaved, extending to
 Monad is trivial. The catch in cats' implementation is that we have to override
 `flatMap` as well.
 

--- a/docs/src/main/tut/monad.md
+++ b/docs/src/main/tut/monad.md
@@ -23,18 +23,22 @@ List(List(1),List(2,3)).flatten
 
 ### Monad instances
 
-If `Applicative` is already present and `flatten` is well-behaved, extending to
-Monad is trivial. The catch in cats' implementation is that we have to override
-`flatMap` as well.
+If `Applicative` is already present and `flatten` is well-behaved,
+extending the `Applicative` to a `Monad` is trivial. To provide evidence
+that a type belongs in the `Monad` typeclass, cats' implementation
+requires us to provide an implementation of `pure` (which can be reused
+from `Applicative`) and `flatMap`.
 
-`flatMap` is just map followed by flatten.
+We can use `flatten` to define `flatMap`: `flatMap` is just `map`
+followed by `flatten`. Conversely, `flatten` is just `flatMap` using
+the identity function `x => x` (i.e. `flatMap(_)(x => x)`).
 
 ```tut
 import cats._
 
 implicit def optionMonad(implicit app: Applicative[Option]) =
   new Monad[Option] {
-    override def flatten[A](ffa: Option[Option[A]]): Option[A] = ffa.flatten
+    // Define flatMap using Option's flatten method
     override def flatMap[A, B](fa: Option[A])(f: A => Option[B]): Option[B] =
       app.map(fa)(f).flatten
     // Reuse this definition from Applicative.
@@ -44,7 +48,7 @@ implicit def optionMonad(implicit app: Applicative[Option]) =
 
 ### flatMap
 
-`flatMap` is often considered to be the core function of Monad, and cats'
+`flatMap` is often considered to be the core function of `Monad`, and cats
 follows this tradition by providing implementations of `flatten` and `map`
 derived from `flatMap` and `pure`.
 
@@ -72,8 +76,8 @@ universe.reify(
 
 ### ifM
 
-Monad provides the ability to choose later operations in a sequence based on
-the results of earlier ones. This is embodied in `ifM`, which lifts an if
+`Monad` provides the ability to choose later operations in a sequence based on
+the results of earlier ones. This is embodied in `ifM`, which lifts an `if`
 statement into the monadic context.
 
 ```tut
@@ -81,10 +85,14 @@ Monad[List].ifM(List(true, false, true))(List(1, 2), List(3, 4))
 ```
 
 ### Composition
-Unlike Functors and Applicatives, Monads in general do not compose.
+Unlike [Functors](functor.html) and [Applicatives](applicative.html),
+not all `Monad`s compose. This means that even if `M[_]` and `N[_]` are
+both `Monad`s, `M[N[_]]` is not guaranteed to be a `Monad`.
 
 However, many common cases do. One way of expressing this is to provide
-instructions on how to compose any outer monad with a specific inner monad.
+instructions on how to compose any outer monad (`F` in the following
+example) with a specific inner monad (`Option` in the following
+example).
 
 ```tut
 case class OptionT[F[_], A](value: F[Option[A]])

--- a/docs/src/main/tut/monad.md
+++ b/docs/src/main/tut/monad.md
@@ -7,10 +7,10 @@ scaladoc: "#cats.Monad"
 ---
 # Monad
 
-`Monad` extends the [Applicative](applicative.html) type class with a
+`Monad` extends the [`Applicative`](applicative.html) type class with a
 new function `flatten`. Flatten takes a value in a nested context (eg.
 `F[F[A]]` where F is the context) and "joins" the contexts together so
-that we have a single context (ie. F[A]).
+that we have a single context (ie. `F[A]`).
 
 The name `flatten` should remind you of the functions of the same name on many
 classes in the standard library.
@@ -85,7 +85,7 @@ Monad[List].ifM(List(true, false, true))(List(1, 2), List(3, 4))
 ```
 
 ### Composition
-Unlike [Functors](functor.html) and [Applicatives](applicative.html),
+Unlike [`Functor`s](functor.html) and [`Applicative`s](applicative.html),
 not all `Monad`s compose. This means that even if `M[_]` and `N[_]` are
 both `Monad`s, `M[N[_]]` is not guaranteed to be a `Monad`.
 

--- a/docs/src/main/tut/semigroupk.md
+++ b/docs/src/main/tut/semigroupk.md
@@ -22,7 +22,7 @@ must be the same as
 for all possible values of `a`, `b`, `c`.
 
 Cats does not define a `Semigroup` type class itself. Instead, we use the
-[Semigroup
+[`Semigroup`
 trait](https://github.com/non/algebra/blob/master/core/src/main/scala/algebra/Semigroup.scala)
 which is defined in the [algebra
 project](https://github.com/non/algebra). The [`cats` package

--- a/docs/src/main/tut/semigroupk.md
+++ b/docs/src/main/tut/semigroupk.md
@@ -7,31 +7,30 @@ scaladoc: "#cats.SemigroupK"
 ---
 # SemigroupK
 
-Before introducing a SemigroupK, it makes sense to talk about what a
-Semigroup is. A semigroup for some given type A has a single operation
-(which we will call `combine`), which takes two values of type A, and
-returns a value of type A. This operation must be guaranteed to be
+Before introducing a `SemigroupK`, it makes sense to talk about what a
+`Semigroup` is. A semigroup for some given type `A` has a single operation
+(which we will call `combine`), which takes two values of type `A`, and
+returns a value of type `A`. This operation must be guaranteed to be
 associative. That is to say that:
 
     ((a combine b) combine c)
 
 must be the same as
-     
+
     (a combine (b combine c))
 
-for all possible values of a,b,c.
+for all possible values of `a`, `b`, `c`.
 
-Cats does not define a Semigroup type class itself, we use the
+Cats does not define a `Semigroup` type class itself. Instead, we use the
 [Semigroup
 trait](https://github.com/non/algebra/blob/master/core/src/main/scala/algebra/Semigroup.scala)
 which is defined in the [algebra
-project](https://github.com/non/algebra) on which we depend. The
-[`cats` package
+project](https://github.com/non/algebra). The [`cats` package
 object](https://github.com/non/cats/blob/master/core/src/main/scala/cats/package.scala)
-defines type aliases to the Semigroup from algebra, so that you can
+defines type aliases to the `Semigroup` from algebra, so that you can
 `import cats.semigroup`.
 
-There are instances of Semigroup defined for many types found in the
+There are instances of `Semigroup` defined for many types found in the
 scala common library:
 
 ```tut
@@ -45,45 +44,50 @@ Semigroup[Option[Int]].combine(Option(1), None)
 Semigroup[Int => Int].combine({(x: Int) => x + 1},{(x: Int) => x * 10}).apply(6)
 ```
 
-SemigroupK has a very similar structure to Semigroup, the difference
-is that it operates on type constructors of one argument. So, for
-example, whereas you can find a Semigroup for types which are fully
+`SemigroupK` has a very similar structure to `Semigroup`, the difference
+is that `SemigroupK` operates on type constructors of one argument. So, for
+example, whereas you can find a `Semigroup` for types which are fully
 specified like `Int` or `List[Int]` or `Option[Int]`, you will find
-SemigroupK for type constructors like `List` and `Option`. These types
+`SemigroupK` for type constructors like `List` and `Option`. These types
 are type constructors in that you can think of them as "functions" in
-the type space. You can think of the list type as a function which
-takes a concrete type, like `Int` and returns a concrete type:
+the type space. You can think of the `List` type as a function which
+takes a concrete type, like `Int`, and returns a concrete type:
 `List[Int]`. This pattern would also be referred to having `kind: * ->
-*`, whereas Int would have kind `*` and Map would have kind `*,* -> *`,
+*`, whereas `Int` would have kind `*` and `Map` would have kind `*,* -> *`,
 and, in fact, the `K` in `SemigroupK` stands for `Kind`.
 
-For list, the `SemigroupK` instance behaves the same, it is still just
-appending lists:
+For `List`, the `Semigroup` and `SemigroupK` instance's `combine`
+operation are both list concatenation:
 
 ```tut
 SemigroupK[List].combine(List(1,2,3), List(4,5,6)) == Semigroup[List[Int]].combine(List(1,2,3), List(4,5,6))
 ```
 
-However for `Option`, our `Semigroup` instance was predicated on
-knowing that the type the Option was (possibly) containing itself had
-a semigroup instance available, so that in the case that we were
-combining a `Some` with a `Some`, we would know how to combine the two
-values. With the SemigroupK instance, we are "universally quantified"
-on the type parameter to Option, so we cannot know anything about
-it. We cannot know, for instance, how to combine two of them, so in
-the case of Option, the `combine` method has no choice but to use the
+However for `Option`, `Semigroup` and `SemigroupK`'s `combine` operation
+differs. Since `Semigroup` operates on fully specified types, a
+`Semigroup[Option[A]]` knows the concrete type of `A` and will
+use `Semigroup[A].combine` to combine the inner `A`s. Consequently,
+`Semigroup[Option[A]].combine` requires an implicit
+`Semigroup[A]`.
+
+In contrast, since `SemigroupK[Option]` operates on `Option` where
+the inner type is not fully specified and can be anything (i.e. is
+"universally quantified"). Thus, we cannot know how to `combine`
+two of them. Therefore, in the case of `Option` the
+`SemigroupK[Option].combine` method has no choice but to use the
 `orElse` method of Option:
 
 ```tut
+Semigroup[Option[Int]].combine(Some(1), Some(2))
 SemigroupK[Option].combine(Some(1), Some(2))
 SemigroupK[Option].combine(Some(1), None)
 SemigroupK[Option].combine(None, Some(2))
 ```
 
-There is inline syntax available for both Semigroup and
-SemigroupK. Here we are following the convention from scalaz, that
+There is inline syntax available for both `Semigroup` and
+`SemigroupK`. Here we are following the convention from scalaz, that
 `|+|` is the operator from semigroup and that `<+>` is the operator
-from SemigroupK (called Plus in scalaz).
+from `SemigroupK` (called `Plus` in scalaz).
 
 ```tut
 import cats.syntax.all._
@@ -104,10 +108,10 @@ two |+| n
 two <+> n
 ```
 
-You'll notice that instead of declaring `one` as `Some(1)`, I chose
-`Option(1)`, and I added an explicit type declaration for `n`. This is
-because there aren't type class instances for Some or None, but for
-Option. If we try to use Some and None, we'll get errors:
+You'll notice that instead of declaring `one` as `Some(1)`, we chose
+`Option(1)`, and we added an explicit type declaration for `n`. This is
+because the `SemigroupK` type class instances is defined for `Option`,
+not `Some` or `None`. If we try to use `Some` or `None`, we'll get errors:
 
 ```tut:nofail
 Some(1) <+> None


### PR DESCRIPTION
Documentation improvements I made while going through cats' documentation for the first time. 

 * Adds many markup changes for inline code and references to other sections
 * Revises explanation text to be more accessible for newcomers (hopefully!)
 * Modifies explanation and code example comparing `Semigroup` vs `SemigroupK`