### PR TITLE
Remove section about adding cats-free to build.sbt

### DIFF
--- a/docs/src/main/tut/freemonad.md
+++ b/docs/src/main/tut/freemonad.md
@@ -91,12 +91,6 @@ a way to link a single operation with successive operations.
 As we will see, the `next` field is also necessary to allow us to
 provide a `Functor` instance for `KVStoreA[_]`.
 
-### Import Free in your `build.sbt`
-
-```scala
-libraryDependencies += "cats" %% "cats-free" % "0.1.2"
-```
-
 ### Free your ADT
 
 There are six basic steps to "freeing" the ADT:


### PR DESCRIPTION
The reasons are:
- The version number would be mostly out of date because it currently
  needs to be updated manually.
- We can assume that the reader has the "cats" module in their
  libraryDependencies and all examples work with just this.
- Other docs don't have this.

see also #450