### PR TITLE
Cache SBT assets on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,6 @@ env:
   global:
   - secure: Kf44XQFpq2QGe3rn98Dsf5Uz3WXzPDralS54co7sqT5oQGs1mYLYZRYz+I75ZSo5ffZ86H7M+AI9YFofqGwAjBixBbqf1tGkUh3oZp2fN3QfqzazGV3HzC+o41zALG5FL+UBaURev9ChQ5fYeTtFB7YAzejHz4y5E97awk934Rg=
   - secure: QbNAu0jCaKrwjJi7KZtYEBA/pYbTJ91Y1x/eLAJpsamswVOvwnThA/TLYuux+oiZQCiDUpBzP3oxksIrEEUAhl0lMtqRFY3MrcUr+si9NIjX8hmoFwkvZ5o1b7pmLF6Vz3rQeP/EWMLcljLzEwsrRXeK0Ei2E4vFpsg8yz1YXJg=
-sudo: false
 cache:
   directories:
   - $HOME/.sbt/0.13

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ env:
   - secure: QbNAu0jCaKrwjJi7KZtYEBA/pYbTJ91Y1x/eLAJpsamswVOvwnThA/TLYuux+oiZQCiDUpBzP3oxksIrEEUAhl0lMtqRFY3MrcUr+si9NIjX8hmoFwkvZ5o1b7pmLF6Vz3rQeP/EWMLcljLzEwsrRXeK0Ei2E4vFpsg8yz1YXJg=
 cache:
   directories:
-  - $HOME/.sbt/0.13
+  - $HOME/.sbt/0.13/dependency
   - $HOME/.sbt/boot/scala*
   - $HOME/.sbt/launchers
   - $HOME/.ivy2/cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,9 +32,9 @@ cache:
   - $HOME/.sbt/0.13
   - $HOME/.sbt/boot/scala*
   - $HOME/.sbt/launchers
-  - $HOME/.ivy2
+  - $HOME/.ivy2/cache
 before_cache:
-  - du -h -d 1 $HOME/.ivy2/
+  - du -h -d 1 $HOME/.ivy2/cache
   - du -h -d 2 $HOME/.sbt/
   - find $HOME/.sbt -name "*.lock" -type f -delete
   - find $HOME/.ivy2/cache -name "ivydata-*.properties" -type f -delete

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,3 +26,16 @@ env:
   global:
   - secure: Kf44XQFpq2QGe3rn98Dsf5Uz3WXzPDralS54co7sqT5oQGs1mYLYZRYz+I75ZSo5ffZ86H7M+AI9YFofqGwAjBixBbqf1tGkUh3oZp2fN3QfqzazGV3HzC+o41zALG5FL+UBaURev9ChQ5fYeTtFB7YAzejHz4y5E97awk934Rg=
   - secure: QbNAu0jCaKrwjJi7KZtYEBA/pYbTJ91Y1x/eLAJpsamswVOvwnThA/TLYuux+oiZQCiDUpBzP3oxksIrEEUAhl0lMtqRFY3MrcUr+si9NIjX8hmoFwkvZ5o1b7pmLF6Vz3rQeP/EWMLcljLzEwsrRXeK0Ei2E4vFpsg8yz1YXJg=
+sudo: false
+cache:
+  directories:
+  - $HOME/.sbt/0.13
+  - $HOME/.sbt/boot/scala*
+  - $HOME/.sbt/cache
+  - $HOME/.sbt/launchers
+  - $HOME/.ivy2
+before_cache:
+  - du -h -d 1 $HOME/.ivy2/
+  - du -h -d 2 $HOME/.sbt/
+  - find $HOME/.sbt -name "*.lock" -type f -delete
+  - find $HOME/.ivy2/cache -name "ivydata-*.properties" -type f -delete

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,6 @@ cache:
   directories:
   - $HOME/.sbt/0.13
   - $HOME/.sbt/boot/scala*
-  - $HOME/.sbt/cache
   - $HOME/.sbt/launchers
   - $HOME/.ivy2
 before_cache:


### PR DESCRIPTION
Currently the Cats Travis build seems to be resolving and downloading SBT dependencies every run.  This uses the container based infrastructure to avoid having to cache assets between runs and so shorten builds.

Hat-tip to @rtyley for doing the grunt work of working out what these settings were on another project.