### PR TITLE
Fixed Semigroup and Monoid instances for Kleisli and Cokleisli (#477)

### DIFF
--- a/core/src/main/scala/cats/data/Cokleisli.scala
+++ b/core/src/main/scala/cats/data/Cokleisli.scala
@@ -64,8 +64,8 @@ sealed abstract class CokleisliInstances extends CokleisliInstances0 {
       fa.map(f)
   }
 
-  implicit def cokleisliMonoid[F[_], A](implicit ev: Comonad[F]): Monoid[Cokleisli[F, A, A]] =
-    new CokleisliMonoid[F, A] { def F: Comonad[F] = ev }
+  implicit def cokleisliMonoidK[F[_]](implicit ev: Comonad[F]): MonoidK[Lambda[A => Cokleisli[F, A, A]]] =
+    new CokleisliMonoidK[F] { def F: Comonad[F] = ev }
 }
 
 sealed abstract class CokleisliInstances0 {
@@ -75,8 +75,8 @@ sealed abstract class CokleisliInstances0 {
   implicit def cokleisliProfunctor[F[_]](implicit ev: Functor[F]): Profunctor[Cokleisli[F, ?, ?]] =
     new CokleisliProfunctor[F] { def F: Functor[F] = ev }
 
-  implicit def cokleisliSemigroup[F[_], A](implicit ev: CoflatMap[F]): Semigroup[Cokleisli[F, A, A]] =
-    new CokleisliSemigroup[F, A] { def F: CoflatMap[F] = ev }
+  implicit def cokleisliSemigroupK[F[_]](implicit ev: CoflatMap[F]): SemigroupK[Lambda[A => Cokleisli[F, A, A]]] =
+    new CokleisliSemigroupK[F] { def F: CoflatMap[F] = ev }
 }
 
 private trait CokleisliArrow[F[_]] extends Arrow[Cokleisli[F, ?, ?]] with CokleisliSplit[F] with CokleisliProfunctor[F] {
@@ -124,14 +124,14 @@ private trait CokleisliProfunctor[F[_]] extends Profunctor[Cokleisli[F, ?, ?]] {
     fab.map(f)
 }
 
-private trait CokleisliSemigroup[F[_], A] extends Semigroup[Cokleisli[F, A, A]] {
+private trait CokleisliSemigroupK[F[_]] extends SemigroupK[Lambda[A => Cokleisli[F, A, A]]] {
   implicit def F: CoflatMap[F]
 
-  def combine(a: Cokleisli[F, A, A], b: Cokleisli[F, A, A]): Cokleisli[F, A, A] = a compose b
+  def combine[A](a: Cokleisli[F, A, A], b: Cokleisli[F, A, A]): Cokleisli[F, A, A] = a compose b
 }
 
-private trait CokleisliMonoid[F[_], A] extends Monoid[Cokleisli[F, A, A]] with CokleisliSemigroup[F, A] {
+private trait CokleisliMonoidK[F[_]] extends MonoidK[Lambda[A => Cokleisli[F, A, A]]] with CokleisliSemigroupK[F] {
   implicit def F: Comonad[F]
 
-  def empty: Cokleisli[F, A, A] = Cokleisli(F.extract[A])
+  def empty[A]: Cokleisli[F, A, A] = Cokleisli(F.extract[A])
 }

--- a/core/src/main/scala/cats/data/Kleisli.scala
+++ b/core/src/main/scala/cats/data/Kleisli.scala
@@ -82,8 +82,12 @@ sealed trait KleisliFunctions {
 }
 
 sealed abstract class KleisliInstances extends KleisliInstances0 {
-  implicit def kleisliMonoid[F[_], A](implicit M: Monad[F]): Monoid[Kleisli[F, A, A]] =
-    new KleisliMonoid[F, A] { def F: Monad[F] = M }
+
+  implicit def kleisliMonoid[F[_], A, B](implicit M: Monoid[F[B]]): Monoid[Kleisli[F, A, B]] =
+    new KleisliMonoid[F, A, B] { def FB: Monoid[F[B]] = M }
+
+  implicit def kleisliMonoidK[F[_]](implicit M: Monad[F]): MonoidK[Lambda[A => Kleisli[F, A, A]]] =
+    new KleisliMonoidK[F] { def F: Monad[F] = M }
 
   implicit def kleisliArrow[F[_]](implicit ev: Monad[F]): Arrow[Kleisli[F, ?, ?]] =
     new KleisliArrow[F] { def F: Monad[F] = ev }
@@ -118,8 +122,11 @@ sealed abstract class KleisliInstances0 extends KleisliInstances1 {
       fa.map(f)
   }
 
-  implicit def kleisliSemigroup[F[_], A](implicit ev: FlatMap[F]): Semigroup[Kleisli[F, A, A]] =
-    new KleisliSemigroup[F, A] { def F: FlatMap[F] = ev }
+  implicit def kleisliSemigroup[F[_], A, B](implicit M: Semigroup[F[B]]): Semigroup[Kleisli[F, A, B]] =
+    new KleisliSemigroup[F, A, B] { def FB: Semigroup[F[B]] = M }
+
+  implicit def kleisliSemigroupK[F[_]](implicit ev: FlatMap[F]): SemigroupK[Lambda[A => Kleisli[F, A, A]]] =
+    new KleisliSemigroupK[F] { def F: FlatMap[F] = ev }
 }
 
 sealed abstract class KleisliInstances1 extends KleisliInstances2 {
@@ -194,14 +201,27 @@ private trait KleisliStrong[F[_]] extends Strong[Kleisli[F, ?, ?]] {
     fa.second[C]
 }
 
-private trait KleisliSemigroup[F[_], A] extends Semigroup[Kleisli[F, A, A]] {
-  implicit def F: FlatMap[F]
+private trait KleisliSemigroup[F[_], A, B] extends Semigroup[Kleisli[F, A, B]] {
+  implicit def FB: Semigroup[F[B]]
 
-  override def combine(a: Kleisli[F, A, A], b: Kleisli[F, A, A]): Kleisli[F, A, A] = a compose b
+  override def combine(a: Kleisli[F, A, B], b: Kleisli[F, A, B]): Kleisli[F, A, B] = 
+    Kleisli[F, A, B](x => FB.combine(a.run(x), b.run(x)))
 }
 
-private trait KleisliMonoid[F[_], A] extends Monoid[Kleisli[F, A, A]] with KleisliSemigroup[F, A] {
+private trait KleisliMonoid[F[_], A, B] extends Monoid[Kleisli[F, A, B]] with KleisliSemigroup[F, A, B] {
+  implicit def FB: Monoid[F[B]]
+
+  override def empty = Kleisli[F, A, B](a => FB.empty)
+}
+
+private trait KleisliSemigroupK[F[_]] extends SemigroupK[Lambda[A => Kleisli[F, A, A]]] {
+  implicit def F: FlatMap[F]
+
+  override def combine[A](a: Kleisli[F, A, A], b: Kleisli[F, A, A]): Kleisli[F, A, A] = a compose b
+}
+
+private trait KleisliMonoidK[F[_]] extends MonoidK[Lambda[A => Kleisli[F, A, A]]] with KleisliSemigroupK[F] {
   implicit def F: Monad[F]
 
-  override def empty: Kleisli[F, A, A] = Kleisli(F.pure[A])
+  override def empty[A]: Kleisli[F, A, A] = Kleisli(F.pure[A])
 }

--- a/docs/src/main/tut/kleisli.md
+++ b/docs/src/main/tut/kleisli.md
@@ -112,7 +112,7 @@ map       | Functor
 traverse  | Applicative
 
 ### Type class instances
-The type class instances for `Kleisli`, like that for functions, fix the input type (and the `F[_]`) and leave
+The type class instances for `Kleisli`, like that for functions, often fix the input type (and the `F[_]`) and leave
 the output type free. What type class instances it has tends to depend on what instances the `F[_]` has. For
 instance, `Kleisli[F, A, B]` has a `Functor` instance so long as the chosen `F[_]` does. It has a `Monad`
 instance so long as the chosen `F[_]` does. The instances in Cats are laid out in a way such that implicit
@@ -140,16 +140,27 @@ implicit def kleisliFlatMap[F[_], Z](implicit F: FlatMap[F]): FlatMap[Kleisli[F,
 
 Below is a table of some of the type class instances `Kleisli` can have depending on what instances `F[_]` has.
 
-Type class    | Constraint on `F[_]`
-------------- | -------------------
-Functor       | Functor
-Apply         | Apply
-Applicative   | Applicative
-FlatMap       | FlatMap
-Monad         | Monad
-Arrow         | Monad
-Split         | FlatMap
-Strong        | Functor
+Type class     | Constraint on `F[_]`
+-------------- | -------------------
+Functor        | Functor
+Apply          | Apply
+Applicative    | Applicative
+FlatMap        | FlatMap
+Monad          | Monad
+Arrow          | Monad
+Split          | FlatMap
+Strong         | Functor
+SemigroupK*    | FlatMap
+MonoidK*       | Monad
+
+*These instances only exist for Kleisli arrows with identical input and output types; that is, 
+`Kleisli[F, A, A]` for some type A. These instances use Kleisli composition as the `combine` operation,
+and `Monad.pure` as the `empty` value.
+
+Also, there is an instance of `Monoid[Kleisli[F, A, B]]` if there is an instance of `Monoid[F[B]]`. 
+`Monoid.combine` here creates a new Kleisli arrow which takes an `A` value and feeds it into each 
+of the combined Kleisli arrows, which together return two `F[B]` values. Then, they are combined into one 
+using the `Monoid[F[B]]` instance.
 
 ## Other uses
 ### Monad Transformers

--- a/laws/shared/src/main/scala/cats/laws/discipline/ArbitraryK.scala
+++ b/laws/shared/src/main/scala/cats/laws/discipline/ArbitraryK.scala
@@ -87,8 +87,14 @@ object ArbitraryK {
   implicit def kleisliA[F[_], A](implicit F: ArbitraryK[F]): ArbitraryK[Kleisli[F, A, ?]] =
     new ArbitraryK[Kleisli[F, A, ?]]{ def synthesize[B: Arbitrary]: Arbitrary[Kleisli[F, A, B]] = implicitly }
 
+  implicit def kleisliE[F[_]](implicit F: ArbitraryK[F]): ArbitraryK[Lambda[A => Kleisli[F, A, A]]] =
+    new ArbitraryK[Lambda[A => Kleisli[F, A, A]]]{ def synthesize[B: Arbitrary]: Arbitrary[Kleisli[F, B, B]] = implicitly }
+
   implicit def cokleisliA[F[_], A]: ArbitraryK[Cokleisli[F, A, ?]] =
     new ArbitraryK[Cokleisli[F, A, ?]]{ def synthesize[B: Arbitrary]: Arbitrary[Cokleisli[F, A, B]] = implicitly }
+
+  implicit def cokleisliE[F[_]](implicit F: ArbitraryK[F]): ArbitraryK[Lambda[A => Cokleisli[F, A, A]]] =
+    new ArbitraryK[Lambda[A => Cokleisli[F, A, A]]]{ def synthesize[B: Arbitrary]: Arbitrary[Cokleisli[F, B, B]] = implicitly }
 
   implicit def prodA[F[_], G[_]](implicit F: ArbitraryK[F], G: ArbitraryK[G]): ArbitraryK[Lambda[X => Prod[F, G, X]]] =
     new ArbitraryK[Lambda[X => Prod[F, G, X]]]{ def synthesize[A: Arbitrary]: Arbitrary[Prod[F, G, A]] = implicitly }

--- a/tests/shared/src/test/scala/cats/tests/KleisliTests.scala
+++ b/tests/shared/src/test/scala/cats/tests/KleisliTests.scala
@@ -10,6 +10,7 @@ import cats.laws.discipline.eq._
 import org.scalacheck.Arbitrary
 import org.scalacheck.Prop._
 import algebra.laws.GroupLaws
+import cats.laws.discipline.{SemigroupKTests, MonoidKTests}
 
 class KleisliTests extends CatsSuite {
   implicit def kleisliEq[F[_], A, B](implicit A: Arbitrary[A], FB: Eq[F[B]]): Eq[Kleisli[F, A, B]] =
@@ -64,15 +65,27 @@ class KleisliTests extends CatsSuite {
   }
 
   {
-    implicit val kleisliMonoid = Kleisli.kleisliMonoid[Option, Int]
-    checkAll("Kleisli[Option, Int, Int]", GroupLaws[Kleisli[Option, Int, Int]].monoid)
-    checkAll("Monoid[Kleisli[Option, Int, Int]]", SerializableTests.serializable(kleisliMonoid))
+    implicit val kleisliMonoid = Kleisli.kleisliMonoid[Option, Int, String]
+    checkAll("Kleisli[Option, Int, String]", GroupLaws[Kleisli[Option, Int, String]].monoid)
+    checkAll("Monoid[Kleisli[Option, Int, String]]", SerializableTests.serializable(kleisliMonoid))
   }
 
   {
-    implicit val kleisliSemigroup = Kleisli.kleisliSemigroup[Option, Int]
-    checkAll("Kleisli[Option, Int, Int]", GroupLaws[Kleisli[Option, Int, Int]].semigroup)
-    checkAll("Semigroup[Kleisli[Option, Int, Int]]", SerializableTests.serializable(kleisliSemigroup))
+    implicit val kleisliSemigroup = Kleisli.kleisliSemigroup[Option, Int, String]
+    checkAll("Kleisli[Option, Int, String]", GroupLaws[Kleisli[Option, Int, String]].semigroup)
+    checkAll("Semigroup[Kleisli[Option, Int, String]]", SerializableTests.serializable(kleisliSemigroup))
+  }
+
+  {
+    implicit val kleisliMonoidK = Kleisli.kleisliMonoidK[Option]
+    checkAll("Kleisli[Option, Int, Int]", MonoidKTests[Lambda[A => Kleisli[Option, A, A]]].monoidK[Int])
+    checkAll("MonoidK[Lambda[A => Kleisli[Option, A, A]]]", SerializableTests.serializable(kleisliMonoidK))
+  }
+
+  {
+    implicit val kleisliSemigroupK = Kleisli.kleisliSemigroupK[Option]
+    checkAll("Kleisli[Option, Int, Int]", SemigroupKTests[Lambda[A => Kleisli[Option, A, A]]].semigroupK[Int])
+    checkAll("SemigroupK[Lambda[A => Kleisli[Option, A, A]]]", SerializableTests.serializable(kleisliSemigroupK))
   }
 
   check {


### PR DESCRIPTION
Replaced original `Semigroup` and `Monoid` instances for endomorphic `Kleisli` and `Cokleisli` with `SemigroupK` and `MonoidK` instances, and added additional Semigroup and `Monoid` instances to `Kleisli` that use an underlying `Semigroup` or `Monoid` instance. Updated the documentation to reflect this.