### PR TITLE
add a touch of OptionSyntax

### DIFF
--- a/core/src/main/scala/cats/syntax/all.scala
+++ b/core/src/main/scala/cats/syntax/all.scala
@@ -16,6 +16,7 @@ trait AllSyntax
     with InvariantSyntax
     with MonadCombineSyntax
     with MonadFilterSyntax
+    with OptionSyntax
     with OrderSyntax
     with PartialOrderSyntax
     with ProfunctorSyntax

--- a/core/src/main/scala/cats/syntax/all.scala
+++ b/core/src/main/scala/cats/syntax/all.scala
@@ -8,6 +8,7 @@ trait AllSyntax
     with ComonadSyntax
     with ComposeSyntax
     with ContravariantSyntax
+    with EitherSyntax
     with EqSyntax
     with FlatMapSyntax
     with FoldableSyntax

--- a/core/src/main/scala/cats/syntax/either.scala
+++ b/core/src/main/scala/cats/syntax/either.scala
@@ -1,0 +1,12 @@
+package cats
+package syntax
+
+import cats.data.Xor
+
+trait EitherSyntax {
+  implicit def eitherSyntax[A, B](a: Either[A, B]): EitherOps[A, B] = new EitherOps(a)
+}
+
+class EitherOps[A, B](val a: Either[A, B]) extends AnyVal {
+  def toXor: A Xor B = Xor.fromEither(a)
+}

--- a/core/src/main/scala/cats/syntax/either.scala
+++ b/core/src/main/scala/cats/syntax/either.scala
@@ -4,9 +4,9 @@ package syntax
 import cats.data.Xor
 
 trait EitherSyntax {
-  implicit def eitherSyntax[A, B](a: Either[A, B]): EitherOps[A, B] = new EitherOps(a)
+  implicit def eitherSyntax[A, B](eab: Either[A, B]): EitherOps[A, B] = new EitherOps(eab)
 }
 
-class EitherOps[A, B](val a: Either[A, B]) extends AnyVal {
-  def toXor: A Xor B = Xor.fromEither(a)
+class EitherOps[A, B](val eab: Either[A, B]) extends AnyVal {
+  def toXor: A Xor B = Xor.fromEither(eab)
 }

--- a/core/src/main/scala/cats/syntax/option.scala
+++ b/core/src/main/scala/cats/syntax/option.scala
@@ -6,15 +6,15 @@ import cats.data.Xor
 trait OptionSyntax {
   def none[A] = Option.empty[A]
   implicit def optionIdSyntax[A](a: A): OptionIdOps[A] = new OptionIdOps(a)
-  implicit def optionSyntax[A](a: Option[A]): OptionOps[A] = new OptionOps(a)
+  implicit def optionSyntax[A](oa: Option[A]): OptionOps[A] = new OptionOps(oa)
 }
 
 class OptionIdOps[A](val a: A) extends AnyVal {
   def some: Option[A] = Option(a)
 }
 
-class OptionOps[A](val a: Option[A]) extends AnyVal {
-  def toLeftXor[B](b: => B): A Xor B = a.fold[A Xor B](Xor.Right(b))(Xor.Left(_))
-  def toRightXor[B](b: => B): B Xor A = a.fold[B Xor A](Xor.Left(b))(Xor.Right(_))
-  def orEmpty(implicit A: Monoid[A]): A = a.getOrElse(A.empty)
+class OptionOps[A](val oa: Option[A]) extends AnyVal {
+  def toLeftXor[B](b: => B): A Xor B = oa.fold[A Xor B](Xor.Right(b))(Xor.Left(_))
+  def toRightXor[B](b: => B): B Xor A = oa.fold[B Xor A](Xor.Left(b))(Xor.Right(_))
+  def orEmpty(implicit A: Monoid[A]): A = oa.getOrElse(A.empty)
 }

--- a/core/src/main/scala/cats/syntax/option.scala
+++ b/core/src/main/scala/cats/syntax/option.scala
@@ -1,0 +1,20 @@
+package cats
+package syntax
+
+import cats.data.Xor
+
+trait OptionSyntax {
+  def none[A] = Option.empty[A]
+  implicit def toOptionSyntax[A](a: A): ToOptionOps[A] = new ToOptionOps(a)
+  implicit def optionSyntax[A](a: Option[A]): OptionOps[A] = new OptionOps(a)
+}
+
+class ToOptionOps[A](val a: A) extends AnyVal {
+  def some: Option[A] = Option(a)
+}
+
+class OptionOps[A](val a: Option[A]) extends AnyVal {
+  def toLeftXor[B](b: => B): A Xor B = a.fold[A Xor B](Xor.Right(b))(Xor.Left(_))
+  def toRightXor[B](b: => B): B Xor A = a.fold[B Xor A](Xor.Left(b))(Xor.Right(_))
+  def orEmpty(implicit A: Monoid[A]): A = a.getOrElse(A.empty)
+}

--- a/core/src/main/scala/cats/syntax/option.scala
+++ b/core/src/main/scala/cats/syntax/option.scala
@@ -5,11 +5,11 @@ import cats.data.Xor
 
 trait OptionSyntax {
   def none[A] = Option.empty[A]
-  implicit def toOptionSyntax[A](a: A): ToOptionOps[A] = new ToOptionOps(a)
+  implicit def optionIdSyntax[A](a: A): OptionIdOps[A] = new OptionIdOps(a)
   implicit def optionSyntax[A](a: Option[A]): OptionOps[A] = new OptionOps(a)
 }
 
-class ToOptionOps[A](val a: A) extends AnyVal {
+class OptionIdOps[A](val a: A) extends AnyVal {
   def some: Option[A] = Option(a)
 }
 

--- a/core/src/main/scala/cats/syntax/package.scala
+++ b/core/src/main/scala/cats/syntax/package.scala
@@ -8,6 +8,7 @@ package object syntax {
   object comonad extends ComonadSyntax
   object compose extends ComposeSyntax
   object contravariant extends ContravariantSyntax
+  object either extends EitherSyntax
   object eq extends EqSyntax
   object flatMap extends FlatMapSyntax
   object foldable extends FoldableSyntax

--- a/core/src/main/scala/cats/syntax/package.scala
+++ b/core/src/main/scala/cats/syntax/package.scala
@@ -15,6 +15,7 @@ package object syntax {
   object invariant extends InvariantSyntax
   object monadCombine extends MonadCombineSyntax
   object monadFilter extends MonadFilterSyntax
+  object option extends OptionSyntax
   object order extends OrderSyntax
   object partialOrder extends PartialOrderSyntax
   object profunctor extends ProfunctorSyntax

--- a/core/src/main/scala/cats/syntax/xor.scala
+++ b/core/src/main/scala/cats/syntax/xor.scala
@@ -4,10 +4,10 @@ package syntax
 import cats.data.Xor
 
 trait XorSyntax {
-  implicit def xorSyntax[A](a: A): XorOps[A] = new XorOps(a)
+  implicit def xorIdSyntax[A](a: A): XorIdOps[A] = new XorIdOps(a)
 }
 
-class XorOps[A](val a: A) extends AnyVal {
+class XorIdOps[A](val a: A) extends AnyVal {
   def left[B]: A Xor B = Xor.Left(a)
   def right[B]: B Xor A = Xor.Right(a)
 }


### PR DESCRIPTION
Is there interest in the following syntax?

```scala
scala> none[Int]
res0: Option[Int] = None

scala> 1.some
res1: Option[Int] = Some(1)

scala> none[Int].toRightXor("a")
res2: cats.data.Xor[String,Int] = Left(a)

scala> 2.some.toRightXor("b")
res3: cats.data.Xor[String,Int] = Right(2)

scala> 3.some.toLeftXor("c")
res4: cats.data.Xor[Int,String] = Left(3)

scala> none[List[Int]].orEmpty
res5: List[Int] = List()
```