### PR TITLE
Free touch up

### DIFF
--- a/free/src/main/scala/cats/free/Free.scala
+++ b/free/src/main/scala/cats/free/Free.scala
@@ -47,7 +47,7 @@ import Free._
  * using the heap instead of the stack, allowing tail-call
  * elimination.
  */
-sealed abstract class Free[S[_], A] extends Serializable {
+sealed abstract class Free[S[_], A] extends Product with Serializable {
 
   final def map[B](f: A => B): Free[S, B] =
     flatMap(a => Pure(f(a)))

--- a/free/src/main/scala/cats/free/package.scala
+++ b/free/src/main/scala/cats/free/package.scala
@@ -1,16 +1,7 @@
 package cats
 
 package object free {
-
   /** Alias for the free monad over the `Function0` functor. */
   type Trampoline[A] = Free[Function0, A]
   object Trampoline extends TrampolineFunctions
-
-  /**
-   * Free monad of the free functor (Coyoneda) of S.
-   *
-   * This can be useful because the monad for `Free` requires a functor, and
-   * Coyoneda provides a free functor.
-   */
-  type FreeC[S[_], A] = Free[Coyoneda[S, ?], A]
 }


### PR DESCRIPTION
* Have Free extend Product to avoid strange type inference
* FreeApplicative extends Product and Serializable to avoid strange type inference
* Make FreeApplicative.Ap a case class and remove type casing
* Remove FreeC type alias - Free uses Coyoneda behind the scenes so F[_] is unconstrained