### PR TITLE
Add Coyoneda tests and remove `by`

### DIFF
--- a/free/src/main/scala/cats/free/Coyoneda.scala
+++ b/free/src/main/scala/cats/free/Coyoneda.scala
@@ -50,22 +50,6 @@ object Coyoneda {
   /** `F[A]` converts to `Coyoneda[F,A]` for any `F` */
   def lift[F[_], A](fa: F[A]): Coyoneda[F, A] = apply(fa)(identity[A])
 
-  /**
-   * Represents a partially-built Coyoneda instance. Used in the `by` method.
-   */
-  final class By[F[_]] {
-    def apply[A, B](k: A => B)(implicit F: F[A]): Aux[F, B, A] = Coyoneda(F)(k)
-  }
-
-  /**
-   * Partial application of type parameters to `apply`.
-   *
-   * It can be nicer to say `Coyoneda.by[F]{ x: X => ... }`
-   *
-   * ...instead of `Coyoneda[...](...){ x => ... }`.
-   */
-  def by[F[_]]: By[F] = new By[F]
-
   /** Like `lift(fa).map(_k)`. */
   def apply[F[_], A, B](fa: F[A])(k0: A => B): Aux[F, B, A] =
     new Coyoneda[F, B] {

--- a/free/src/test/scala/cats/free/CoyonedaTests.scala
+++ b/free/src/test/scala/cats/free/CoyonedaTests.scala
@@ -1,0 +1,45 @@
+package cats
+package free
+
+import cats.arrow.NaturalTransformation
+import cats.tests.CatsSuite
+import cats.laws.discipline.{ArbitraryK, FunctorTests, SerializableTests}
+
+import org.scalacheck.{Arbitrary, Gen}
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck.Prop.forAll
+
+class CoyonedaTests extends CatsSuite {
+  implicit def coyonedaArbitraryK[F[_] : Functor](implicit F: ArbitraryK[F]): ArbitraryK[Coyoneda[F, ?]] =
+    new ArbitraryK[Coyoneda[F, ?]]{
+      def synthesize[A: Arbitrary]: Arbitrary[Coyoneda[F, A]] = coyonedaArbitrary[F, A]
+    }
+
+  implicit def coyonedaArbitrary[F[_] : Functor, A : Arbitrary](implicit F: ArbitraryK[F]): Arbitrary[Coyoneda[F, A]] =
+    Arbitrary(F.synthesize[A].arbitrary.map(Coyoneda.lift))
+
+  implicit def coyonedaEq[F[_]: Functor, A](implicit FA: Eq[F[A]]): Eq[Coyoneda[F, A]] =
+    new Eq[Coyoneda[F, A]] {
+      def eqv(a: Coyoneda[F, A], b: Coyoneda[F, A]): Boolean = FA.eqv(a.run, b.run)
+    }
+
+  checkAll("Coyoneda[Option, ?]", FunctorTests[Coyoneda[Option, ?]].functor[Int, Int, Int])
+  checkAll("Functor[Coyoneda[Option, ?]]", SerializableTests.serializable(Functor[Coyoneda[Option, ?]]))
+
+  test("toYoneda and then toCoyoneda is identity")(check {
+    // Issues inferring syntax for Eq, using instance explicitly
+    forAll((y: Coyoneda[Option, Int]) => coyonedaEq[Option, Int].eqv(y.toYoneda.toCoyoneda, y))
+  })
+
+  test("transform and run is same as applying natural trans") {
+    assert {
+      val nt =
+        new NaturalTransformation[Option, List] {
+          def apply[A](fa: Option[A]): List[A] = fa.toList
+        }
+      val o = Option("hello")
+      val c = Coyoneda.lift(o)
+      c.transform(nt).run === nt(o)
+    }
+  }
+}


### PR DESCRIPTION
Not sure what `by` does and how the implicit `F[A]` param would be used.