### PR TITLE
Use type-safe equals checks in tests

### DIFF
--- a/free/src/test/scala/cats/free/FreeApplicativeTests.scala
+++ b/free/src/test/scala/cats/free/FreeApplicativeTests.scala
@@ -40,7 +40,7 @@ class FreeApplicativeTests extends CatsSuite {
     val y = FreeApplicative.pure[Option, Int](n)
     val f = x.map(i => (j: Int) => i + j)
     val r = y.ap(f)
-    assert(r.fold == Apply[Option].map2(o1, o2)(_ + _))
+    r.fold should === (Apply[Option].map2(o1, o2)(_ + _))
   }
 
   test("FreeApplicative#compile") {
@@ -50,7 +50,7 @@ class FreeApplicativeTests extends CatsSuite {
     val nt = NaturalTransformation.id[Id]
     val r1 = y.ap(f)
     val r2 = r1.compile(nt)
-    assert(r1.foldMap(nt) == r2.foldMap(nt))
+    r1.foldMap(nt) should === (r2.foldMap(nt))
   }
 
   test("FreeApplicative#monad") {
@@ -63,6 +63,6 @@ class FreeApplicativeTests extends CatsSuite {
       new NaturalTransformation[Id, Id] {
         def apply[A](fa: Id[A]): Id[A] = fa
       }
-    assert(r1.foldMap(nt) == r2.foldMap(nt))
+    r1.foldMap(nt) should === (r2.foldMap(nt))
   }
 }

--- a/state/src/test/scala/cats/state/WordCountTest.scala
+++ b/state/src/test/scala/cats/state/WordCountTest.scala
@@ -45,8 +45,8 @@ class WordCountTest extends CatsSuite {
     val lineCount = allResults.first.second
     val charCount = allResults.second
     val wordCount = wordCountState.runA(false).run
-    assert(charCount.getConst == 96 &&
-      lineCount.getConst == 2 &&
-      wordCount.getConst == 17)
+    charCount.getConst should === (96)
+    lineCount.getConst should === (2)
+    wordCount.getConst should === (17)
   }
 }

--- a/tests/src/test/scala/cats/tests/EvalTests.scala
+++ b/tests/src/test/scala/cats/tests/EvalTests.scala
@@ -40,7 +40,7 @@ class EvalTests extends CatsSuite {
         result should === (value)
         spin ^= result.##
       }
-      assert(spooky.counter == numEvals)
+      spooky.counter should === (numEvals)
     }
     (0 to 2).foreach(n => nTimes(n, numCalls(n)))
   }

--- a/tests/src/test/scala/cats/tests/FoldableTests.scala
+++ b/tests/src/test/scala/cats/tests/FoldableTests.scala
@@ -57,13 +57,13 @@ class FoldableTestsAdditional extends CatsSuite {
     // some basic sanity checks
     val ns = (1 to 10).toList
     val total = ns.sum
-    assert(F.foldLeft(ns, 0)(_ + _) == total)
-    assert(F.foldRight(ns, Now(0))((x, ly) => ly.map(x + _)).value == total)
-    assert(F.fold(ns) == total)
+    F.foldLeft(ns, 0)(_ + _) should === (total)
+    F.foldRight(ns, Now(0))((x, ly) => ly.map(x + _)).value should === (total)
+    F.fold(ns) should === (total)
 
     // more basic checks
     val names = List("Aaron", "Betty", "Calvin", "Deirdra")
-    assert(F.foldMap(names)(_.length) == names.map(_.length).sum)
+    F.foldMap(names)(_.length) should === (names.map(_.length).sum)
 
     // test trampolining
     val large = (1 to 10000).toList
@@ -71,7 +71,7 @@ class FoldableTestsAdditional extends CatsSuite {
 
     // safely build large lists
     val larger = F.foldRight(large, Now(List.empty[Int]))((x, lxs) => lxs.map((x + 1) :: _))
-    assert(larger.value == large.map(_ + 1))
+    larger.value should === (large.map(_ + 1))
   }
 
   test("Foldable[Stream]") {

--- a/tests/src/test/scala/cats/tests/FuncTests.scala
+++ b/tests/src/test/scala/cats/tests/FuncTests.scala
@@ -42,12 +42,12 @@ class FuncTests extends CatsSuite {
     val g = appFunc { (x: Int) => List(x * 2) }
     val h = f product g
     val x = h.run(1)
-    assert((x.first, x.second) == ((Some(11), List(2))))
+    (x.first, x.second) should === ((Some(11), List(2)))
   }
 
   test("traverse") {
     val f = Func.appFunc { (x: Int) => (Some(x + 10): Option[Int]) }
     val xs = f traverse List(1, 2, 3)
-    assert(xs == Some(List(11, 12, 13)))
+    xs should === (Some(List(11, 12, 13)))
   }
 }

--- a/tests/src/test/scala/cats/tests/KleisliTests.scala
+++ b/tests/src/test/scala/cats/tests/KleisliTests.scala
@@ -109,7 +109,7 @@ class KleisliTests extends CatsSuite {
   test("lift") {
     val f = Kleisli.function { (x: Int) => (Some(x + 1): Option[Int]) }
     val l = f.lift[List]
-    assert((List(1, 2, 3) >>= l.run) == List(Some(2), Some(3), Some(4)))
+    (List(1, 2, 3) >>= l.run) should === (List(Some(2), Some(3), Some(4)))
   }
 
   test("transform") {
@@ -118,7 +118,7 @@ class KleisliTests extends CatsSuite {
     val list = opt.transform(optToList)
 
     val is = 0.to(10).toList
-    assert(is.map(list.run) == is.map(Kleisli.function { (x: Int) => List(x.toDouble) }.run))
+    is.map(list.run) should === (is.map(Kleisli.function { (x: Int) => List(x.toDouble) }.run))
   }
 
   test("local") {
@@ -129,6 +129,6 @@ class KleisliTests extends CatsSuite {
     val kconfig2 = Kleisli.function { (c: Config) => Option(c.i.toDouble) }
 
     val config = Config(0, "cats")
-    assert(kconfig1.run(config) == kconfig2.run(config))
+    kconfig1.run(config) should === (kconfig2.run(config))
   }
 }

--- a/tests/src/test/scala/cats/tests/ListTests.scala
+++ b/tests/src/test/scala/cats/tests/ListTests.scala
@@ -18,11 +18,11 @@ class ListTests extends CatsSuite with GeneratorDrivenPropertyChecks {
 
   test("nel => list => nel returns original nel")(
     forAll { fa: NonEmptyList[Int] =>
-      assert(fa.unwrap.toNel == Some(fa))
+      fa.unwrap.toNel should === (Some(fa))
     }
   )
 
   test("toNel on empty list returns None"){
-    assert(List.empty[Int].toNel == None)
+    List.empty[Int].toNel should === (None)
   }
 }

--- a/tests/src/test/scala/cats/tests/RegressionTests.scala
+++ b/tests/src/test/scala/cats/tests/RegressionTests.scala
@@ -25,6 +25,7 @@ class RegressionTests extends CatsSuite {
   val buf = mutable.ListBuffer.empty[String]
 
   case class Person(id: Int, name: String)
+  implicit val personEq: Eq[Person] = Eq.fromUniversalEquals
 
   def alloc(name: String): State[Int, Person] =
     State { id =>
@@ -36,18 +37,18 @@ class RegressionTests extends CatsSuite {
 
     // test result order
     val ons = List(Option(1), Option(2), Option(3))
-    assert(Traverse[List].sequence(ons) == Some(List(1, 2, 3)))
+    Traverse[List].sequence(ons) should === (Some(List(1, 2, 3)))
 
     // test order of effects using a contrived, unsafe state monad.
     val names = List("Alice", "Bob", "Claire")
     val allocated = names.map(alloc)
     val state = Traverse[List].sequence[State[Int, ?],Person](allocated)
     val (people, counter) = state.run(0)
-    assert(people == List(Person(0, "Alice"), Person(1, "Bob"), Person(2, "Claire")))
-    assert(counter == 3)
+    people should === (List(Person(0, "Alice"), Person(1, "Bob"), Person(2, "Claire")))
+    counter should === (3)
 
     // ensure that side-effects occurred in "correct" order
-    assert(buf.toList == names)
+    buf.toList should === (names)
   }
 
   test("#167: confirm ap2 order") {
@@ -55,7 +56,7 @@ class RegressionTests extends CatsSuite {
       State[String, Unit](s => ((), s + "1")),
       State[String, Unit](s => ((), s + "2"))
     )(State.instance[String].pure((_: Unit, _: Unit) => ())).run("")._2
-    assert(twelve == "12")
+    twelve should === ("12")
   }
 
   test("#167: confirm map2 order") {
@@ -63,7 +64,7 @@ class RegressionTests extends CatsSuite {
       State[String, Unit](s => ((), s + "1")),
       State[String, Unit](s => ((), s + "2"))
     )((_: Unit, _: Unit) => ()).run("")._2
-    assert(twelve == "12")
+    twelve should === ("12")
   }
 
   test("#167: confirm map3 order") {
@@ -72,6 +73,6 @@ class RegressionTests extends CatsSuite {
       State[String, Unit](s => ((), s + "2")),
       State[String, Unit](s => ((), s + "3"))
     )((_: Unit, _: Unit, _: Unit) => ()).run("")._2
-    assert(oneTwoThree == "123")
+    oneTwoThree should === ("123")
   }
 }

--- a/tests/src/test/scala/cats/tests/UnapplyTests.scala
+++ b/tests/src/test/scala/cats/tests/UnapplyTests.scala
@@ -9,11 +9,11 @@ class UnapplyTests extends CatsSuite {
 
   test("Unapply works for stuff already the right kind") {
     val x = Traverse[List].traverseU(List(1,2,3))(Option(_))
-    assert(x == Some(List(1,2,3)))
+    x should === (Some(List(1,2,3)))
   }
 
   test("Unapply works for F[_,_] with the left fixed") {
     val x = Traverse[List].traverseU(List(1,2,3))(Xor.right(_))
-    assert(x == Xor.right(List(1,2,3)))
+    (x: String Xor List[Int]) should === (Xor.right(List(1,2,3)))
   }
 }

--- a/tests/src/test/scala/cats/tests/ValidatedTests.scala
+++ b/tests/src/test/scala/cats/tests/ValidatedTests.scala
@@ -21,7 +21,7 @@ class ValidatedTests extends CatsSuite {
 
   test("ap2 combines failures in order") {
     val plus = (_: Int) + (_: Int)
-    assert(Applicative[Validated[String, ?]].ap2(Invalid("1"), Invalid("2"))(Valid(plus)) == Invalid("12"))
+    Applicative[Validated[String, ?]].ap2(Invalid("1"), Invalid("2"))(Valid(plus)) should === (Invalid("12"))
   }
 
   test("fromTryCatch catches matching exceptions") {

--- a/tests/src/test/scala/cats/tests/XorTTests.scala
+++ b/tests/src/test/scala/cats/tests/XorTTests.scala
@@ -68,17 +68,13 @@ class XorTTests extends CatsSuite {
   }
 
   test("recover ignores unhandled values") {
-    assert {
-      val xort = XorT.left[Id, String, Int]("xort")
-      xort.recover { case "notxort" => 5 } === xort
-    }
+    val xort = XorT.left[Id, String, Int]("xort")
+    xort.recover { case "notxort" => 5 } should === (xort)
   }
 
   test("recover ignores the right side") {
-    assert {
-      val xort = XorT.right[Id, String, Int](10)
-      xort.recover { case "xort" => 5 } === xort
-    }
+    val xort = XorT.right[Id, String, Int](10)
+    xort.recover { case "xort" => 5 } should === (xort)
   }
 
   test("recoverWith recovers handled values") {
@@ -89,16 +85,12 @@ class XorTTests extends CatsSuite {
   }
 
   test("recoverWith ignores unhandled values") {
-    assert {
-      val xort = XorT.left[Id, String, Int]("xort")
-      xort.recoverWith { case "notxort" => XorT.right[Id, String, Int](5) } === xort
-    }
+    val xort = XorT.left[Id, String, Int]("xort")
+    xort.recoverWith { case "notxort" => XorT.right[Id, String, Int](5) } should === (xort)
   }
 
   test("recoverWith ignores the right side") {
-    assert {
-      val xort = XorT.right[Id, String, Int](10)
-      xort.recoverWith { case "xort" => XorT.right[Id, String, Int](5) } === xort
-    }
+    val xort = XorT.right[Id, String, Int](10)
+    xort.recoverWith { case "xort" => XorT.right[Id, String, Int](5) } should === (xort)
   }
 }

--- a/tests/src/test/scala/cats/tests/XorTests.scala
+++ b/tests/src/test/scala/cats/tests/XorTests.scala
@@ -91,17 +91,13 @@ class XorTests extends CatsSuite {
   }
 
   test("recover ignores unhandled values") {
-    assert {
-      val xor = Xor.left[String, Int]("xor")
-      xor.recover { case "notxor" => 5 } === xor
-    }
+    val xor = Xor.left[String, Int]("xor")
+    xor.recover { case "notxor" => 5 } should === (xor)
   }
 
   test("recover ignores the right side") {
-    assert {
-      val xor = Xor.right[String, Int](10)
-      xor.recover { case "xor" => 5 } === xor
-    }
+    val xor = Xor.right[String, Int](10)
+    xor.recover { case "xor" => 5 } should === (xor)
   }
 
   test("recoverWith recovers handled values") {
@@ -112,17 +108,13 @@ class XorTests extends CatsSuite {
   }
 
   test("recoverWith ignores unhandled values") {
-    assert {
-      val xor = Xor.left[String, Int]("xor")
-      xor.recoverWith { case "notxor" => Xor.right[String, Int](5) } === xor
-    }
+    val xor = Xor.left[String, Int]("xor")
+    xor.recoverWith { case "notxor" => Xor.right[String, Int](5) } should === (xor)
   }
 
   test("recoverWith ignores the right side") {
-    assert {
-      val xor = Xor.right[String, Int](10)
-      xor.recoverWith { case "xor" => Xor.right[String, Int](5) } === xor
-    }
+    val xor = Xor.right[String, Int](10)
+    xor.recoverWith { case "xor" => Xor.right[String, Int](5) } should === (xor)
   }
 
   check {


### PR DESCRIPTION
I grabbed the ones that I could easily grep for with `assert`. There are more that I want to change inside Scalacheck `forAll` blocks, but I think I'm going to make that a separate PR that introduces `GeneratorDrivenPropertyChecks` into `CatsSuite`.