### PR TITLE
Add diagrams to scaladoc

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -61,7 +61,8 @@ lazy val docSettings = Seq(
   siteMappings += file("CONTRIBUTING.md") -> "contributing.md",
   scalacOptions in (ScalaUnidoc, unidoc) ++= Seq(
     "-doc-source-url", scmInfo.value.get.browseUrl + "/tree/master€{FILE_PATH}.scala",
-    "-sourcepath", baseDirectory.in(LocalRootProject).value.getAbsolutePath
+    "-sourcepath", baseDirectory.in(LocalRootProject).value.getAbsolutePath,
+    "-diagrams"
   ),
   git.remoteRepo := "git@github.com:non/cats.git",
   includeFilter in makeSite := "*.html" | "*.css" | "*.png" | "*.jpg" | "*.gif" | "*.js" | "*.swf" | "*.yml" | "*.md"


### PR DESCRIPTION
Partial implementation for https://github.com/non/cats/issues/95. Example output [in gitter](https://gitter.im/non/cats?at=55fa781618e0111d7e4f4a8b)

If accepted, gh-pages will have to be pushed too. 