### PR TITLE
Adjust implicit priorities in OneAnd.

### DIFF
--- a/core/src/main/scala/cats/data/OneAnd.scala
+++ b/core/src/main/scala/cats/data/OneAnd.scala
@@ -87,7 +87,7 @@ final case class OneAnd[A, F[_]](head: A, tail: F[A]) {
     s"OneAnd(${A.show(head)}, ${FA.show(tail)})"
 }
 
-trait OneAndInstances {
+trait OneAndInstances extends OneAndLowPriority1 {
 
   implicit def oneAndEq[A, F[_]](implicit A: Eq[A], FA: Eq[F[A]]): Eq[OneAnd[A, F]] =
     new Eq[OneAnd[A, F]]{
@@ -96,12 +96,6 @@ trait OneAndInstances {
 
   implicit def oneAndShow[A, F[_]](implicit A: Show[A], FA: Show[F[A]]): Show[OneAnd[A, F]] =
     Show.show[OneAnd[A, F]](_.show)
-
-  implicit def oneAndFunctor[F[_]](implicit F: Functor[F]): Functor[OneAnd[?, F]] =
-    new Functor[OneAnd[?, F]] {
-      def map[A, B](fa: OneAnd[A, F])(f: A => B): OneAnd[B, F] =
-        OneAnd(f(fa.head), F.map(fa.tail)(f))
-    }
 
   implicit def oneAndSemigroupK[F[_]: MonadCombine]: SemigroupK[OneAnd[?, F]] =
     new SemigroupK[OneAnd[?, F]] {
@@ -137,7 +131,7 @@ trait OneAndInstances {
     }
 }
 
-trait OneAndLowPriority {
+trait OneAndLowPriority0 {
   implicit val nelComonad: Comonad[OneAnd[?, List]] =
     new Comonad[OneAnd[?, List]] {
 
@@ -158,4 +152,12 @@ trait OneAndLowPriority {
     }
 }
 
-object OneAnd extends OneAndInstances with OneAndLowPriority
+trait OneAndLowPriority1 extends OneAndLowPriority0 {
+  implicit def oneAndFunctor[F[_]](implicit F: Functor[F]): Functor[OneAnd[?, F]] =
+    new Functor[OneAnd[?, F]] {
+      def map[A, B](fa: OneAnd[A, F])(f: A => B): OneAnd[B, F] =
+        OneAnd(f(fa.head), F.map(fa.tail)(f))
+    }
+}
+
+object OneAnd extends OneAndInstances

--- a/tests/src/test/scala/cats/tests/OneAndTests.scala
+++ b/tests/src/test/scala/cats/tests/OneAndTests.scala
@@ -33,6 +33,13 @@ class OneAndTests extends CatsSuite {
     checkAll("Foldable[OneAnd[A, ListWrapper]]", SerializableTests.serializable(Foldable[OneAnd[?, ListWrapper]]))
   }
 
+  {
+    // Test functor and subclasses don't have implicit conflicts
+    implicitly[Functor[NonEmptyList]]
+    implicitly[Monad[NonEmptyList]]
+    implicitly[Comonad[NonEmptyList]]
+  }
+
   checkAll("NonEmptyList[Int]", MonadTests[NonEmptyList].monad[Int, Int, Int])
   checkAll("Monad[NonEmptyList[A]]", SerializableTests.serializable(Monad[NonEmptyList]))
 


### PR DESCRIPTION
```
scala> implicitly[Functor[NonEmptyList]]
<console>:27: error: ambiguous implicit values:
 both method oneAndFunctor in trait OneAndInstances ...
 and method oneAndMonad in trait OneAndInstances ...
 match expected type cats.Functor[cats.data.NonEmptyList]
```

There were two bugs: one is that the Monad implicit
conflicts with the Functor implicit. The other is that
this construction doesn't work:

`object OneAnd extends OneAndInstances with OneAndLowPriority`

If it DID work, this ordering would give priority to the
implicits found in OneAndLowPriority, so it's reversed - but
more to the point, implicit priority isn't based on linearization.
One of the traits has to be a subtrait of the other to have
higher priority, and as written they had no relationship.