### PR TITLE
Add Semigroup instance for OneAnd

### DIFF
--- a/core/src/main/scala/cats/data/OneAnd.scala
+++ b/core/src/main/scala/cats/data/OneAnd.scala
@@ -103,6 +103,9 @@ trait OneAndInstances extends OneAndLowPriority1 {
         a combine b
     }
 
+  implicit def oneAndSemigroup[F[_]: MonadCombine, A]: Semigroup[OneAnd[A, F]] =
+    oneAndSemigroupK.algebra
+
   implicit def oneAndFoldable[F[_]](implicit foldable: Foldable[F]): Foldable[OneAnd[?,F]] =
     new Foldable[OneAnd[?,F]] {
       override def foldLeft[A, B](fa: OneAnd[A, F], b: B)(f: (B, A) => B): B =

--- a/tests/src/test/scala/cats/tests/OneAndTests.scala
+++ b/tests/src/test/scala/cats/tests/OneAndTests.scala
@@ -1,7 +1,7 @@
 package cats
 package tests
 
-import algebra.laws.OrderLaws
+import algebra.laws.{GroupLaws, OrderLaws}
 
 import cats.data.{NonEmptyList, OneAnd}
 import cats.laws.discipline.{ComonadTests, FunctorTests, SemigroupKTests, FoldableTests, MonadTests, SerializableTests}
@@ -24,7 +24,9 @@ class OneAndTests extends CatsSuite {
   {
     implicit val monadCombine = ListWrapper.monadCombine
     checkAll("OneAnd[Int, ListWrapper]", SemigroupKTests[OneAnd[?, ListWrapper]].semigroupK[Int])
+    checkAll("OneAnd[Int, List]", GroupLaws[OneAnd[Int, List]].semigroup)
     checkAll("SemigroupK[OneAnd[A, ListWrapper]]", SerializableTests.serializable(SemigroupK[OneAnd[?, ListWrapper]]))
+    checkAll("Semigroup[NonEmptyList[Int]]", SerializableTests.serializable(Semigroup[OneAnd[Int, List]]))
   }
 
   {


### PR DESCRIPTION
Add `Semigroup` instance for OneAnd based on its `SemigroupK`.

I couldn't find any examples on how to write tests for this, so any help is appreciated.