### PR TITLE
Fix copy/paste errors in the contributor's guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ via [Waffle.io](https://waffle.io/non/cats).
 
 Feel free to open an issue if you notice a bug, have an idea for a
 feature, or have a question about the code. Pull requests are also
-gladly accepted. For more information, check out the [contributor guide](CONTRIBUTING.md).
+gladly accepted.
 
 People are expected to follow the
 [Typelevel Code of Conduct](http://typelevel.org/conduct.html) when
@@ -22,11 +22,11 @@ venues.
 We hope that our community will be respectful, helpful, and kind. If
 you find yourself embroiled in a situation that becomes heated, or
 that fails to live up to our expectations, you should disengage and
-contact one of the [project maintainers](#maintainers) in private. We
+contact one of the [project maintainers](README.md#maintainers) in private. We
 hope to avoid letting minor aggressions and misunderstandings escalate
 into larger problems.
 
-If you are being harassed, please contact one of [us](#maintainers)
+If you are being harassed, please contact one of [us](README.md#maintainers)
 immediately so that we can support you.
 
 ## How can I help?


### PR DESCRIPTION
- The second paragraph ended with the sentence "For more information, check out the contributor guide.", I've removed that sentence.
- The 4th and 5th paragraphs contained links to "#maintainers" even though there is no maintainers section in the contributor's guide, I've linked them to the #maintainers section of the readme

Fixes #550