### PR TITLE
Use GeneratorDrivePropertyChecks in tests

### DIFF
--- a/free/src/test/scala/cats/free/CoyonedaTests.scala
+++ b/free/src/test/scala/cats/free/CoyonedaTests.scala
@@ -7,9 +7,8 @@ import cats.laws.discipline.{ArbitraryK, FunctorTests, SerializableTests}
 
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalacheck.Arbitrary.arbitrary
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
 
-class CoyonedaTests extends CatsSuite with GeneratorDrivenPropertyChecks {
+class CoyonedaTests extends CatsSuite {
   implicit def coyonedaArbitraryK[F[_] : Functor](implicit F: ArbitraryK[F]): ArbitraryK[Coyoneda[F, ?]] =
     new ArbitraryK[Coyoneda[F, ?]]{
       def synthesize[A: Arbitrary]: Arbitrary[Coyoneda[F, A]] = coyonedaArbitrary[F, A]

--- a/free/src/test/scala/cats/free/CoyonedaTests.scala
+++ b/free/src/test/scala/cats/free/CoyonedaTests.scala
@@ -7,9 +7,9 @@ import cats.laws.discipline.{ArbitraryK, FunctorTests, SerializableTests}
 
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalacheck.Arbitrary.arbitrary
-import org.scalacheck.Prop.forAll
+import org.scalatest.prop.GeneratorDrivenPropertyChecks
 
-class CoyonedaTests extends CatsSuite {
+class CoyonedaTests extends CatsSuite with GeneratorDrivenPropertyChecks {
   implicit def coyonedaArbitraryK[F[_] : Functor](implicit F: ArbitraryK[F]): ArbitraryK[Coyoneda[F, ?]] =
     new ArbitraryK[Coyoneda[F, ?]]{
       def synthesize[A: Arbitrary]: Arbitrary[Coyoneda[F, A]] = coyonedaArbitrary[F, A]
@@ -26,10 +26,11 @@ class CoyonedaTests extends CatsSuite {
   checkAll("Coyoneda[Option, ?]", FunctorTests[Coyoneda[Option, ?]].functor[Int, Int, Int])
   checkAll("Functor[Coyoneda[Option, ?]]", SerializableTests.serializable(Functor[Coyoneda[Option, ?]]))
 
-  test("toYoneda and then toCoyoneda is identity")(check {
-    // Issues inferring syntax for Eq, using instance explicitly
-    forAll((y: Coyoneda[Option, Int]) => coyonedaEq[Option, Int].eqv(y.toYoneda.toCoyoneda, y))
-  })
+  test("toYoneda and then toCoyoneda is identity"){
+    forAll{ (y: Coyoneda[Option, Int]) =>
+      y.toYoneda.toCoyoneda should === (y)
+    }
+  }
 
   test("transform and run is same as applying natural trans") {
       val nt =

--- a/free/src/test/scala/cats/free/YonedaTests.scala
+++ b/free/src/test/scala/cats/free/YonedaTests.scala
@@ -5,9 +5,8 @@ import cats.tests.CatsSuite
 import cats.laws.discipline.{ArbitraryK, FunctorTests, SerializableTests}
 
 import org.scalacheck.Arbitrary
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
 
-class YonedaTests extends CatsSuite with GeneratorDrivenPropertyChecks {
+class YonedaTests extends CatsSuite {
   implicit def yonedaArbitraryK[F[_] : Functor](implicit F: ArbitraryK[F]): ArbitraryK[Yoneda[F, ?]] =
     new ArbitraryK[Yoneda[F, ?]]{
       def synthesize[A: Arbitrary]: Arbitrary[Yoneda[F, A]] =

--- a/free/src/test/scala/cats/free/YonedaTests.scala
+++ b/free/src/test/scala/cats/free/YonedaTests.scala
@@ -5,9 +5,9 @@ import cats.tests.CatsSuite
 import cats.laws.discipline.{ArbitraryK, FunctorTests, SerializableTests}
 
 import org.scalacheck.Arbitrary
-import org.scalacheck.Prop.forAll
+import org.scalatest.prop.GeneratorDrivenPropertyChecks
 
-class YonedaTests extends CatsSuite {
+class YonedaTests extends CatsSuite with GeneratorDrivenPropertyChecks {
   implicit def yonedaArbitraryK[F[_] : Functor](implicit F: ArbitraryK[F]): ArbitraryK[Yoneda[F, ?]] =
     new ArbitraryK[Yoneda[F, ?]]{
       def synthesize[A: Arbitrary]: Arbitrary[Yoneda[F, A]] =
@@ -24,7 +24,9 @@ class YonedaTests extends CatsSuite {
   checkAll("Yoneda[Option, ?]", FunctorTests[Yoneda[Option, ?]].functor[Int, Int, Int])
   checkAll("Functor[Yoneda[Option, ?]]", SerializableTests.serializable(Functor[Yoneda[Option, ?]]))
 
-  test("toCoyoneda and then toYoneda is identity")(check {
-    forAll((y: Yoneda[Option, Int]) => y.toCoyoneda.toYoneda === y)
-  })
+  test("toCoyoneda and then toYoneda is identity"){
+    forAll{ (y: Yoneda[Option, Int]) =>
+      y.toCoyoneda.toYoneda should === (y)
+    }
+  }
 }

--- a/state/src/test/scala/cats/state/StateTTests.scala
+++ b/state/src/test/scala/cats/state/StateTTests.scala
@@ -5,9 +5,8 @@ import cats.tests.CatsSuite
 import cats.laws.discipline.{ArbitraryK, EqK, MonadStateTests, MonoidKTests, SerializableTests}
 import cats.laws.discipline.eq._
 import org.scalacheck.{Arbitrary, Gen}
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
 
-class StateTTests extends CatsSuite with GeneratorDrivenPropertyChecks {
+class StateTTests extends CatsSuite {
   import StateTTests._
 
   test("basic state usage"){

--- a/state/src/test/scala/cats/state/StateTTests.scala
+++ b/state/src/test/scala/cats/state/StateTTests.scala
@@ -4,9 +4,10 @@ package state
 import cats.tests.CatsSuite
 import cats.laws.discipline.{ArbitraryK, EqK, MonadStateTests, MonoidKTests, SerializableTests}
 import cats.laws.discipline.eq._
-import org.scalacheck.{Arbitrary, Gen, Prop}, Prop.forAll
+import org.scalacheck.{Arbitrary, Gen}
+import org.scalatest.prop.GeneratorDrivenPropertyChecks
 
-class StateTTests extends CatsSuite {
+class StateTTests extends CatsSuite with GeneratorDrivenPropertyChecks {
   import StateTTests._
 
   test("basic state usage"){
@@ -19,25 +20,25 @@ class StateTTests extends CatsSuite {
     x.runS(0).run should === (100001)
   }
 
-  test("State.pure and StateT.pure are consistent")(check {
+  test("State.pure and StateT.pure are consistent"){
     forAll { (s: String, i: Int) =>
       val state: State[String, Int] = State.pure(i)
       val stateT: State[String, Int] = StateT.pure(i)
-      state.run(s).run === stateT.run(s).run
+      state.run(s).run should === (stateT.run(s).run)
     }
-  })
+  }
 
   test("Apply syntax is usable on State") {
     val x = add1 *> add1
     x.runS(0).run should === (2)
   }
 
-  test("Singleton and instance inspect are consistent")(check {
+  test("Singleton and instance inspect are consistent"){
     forAll { (s: String, i: Int) =>
-      State.inspect[Int, String](_.toString).run(i).run ===
-        State.pure[Int, Unit](()).inspect(_.toString).run(i).run
+      State.inspect[Int, String](_.toString).run(i).run should === (
+        State.pure[Int, Unit](()).inspect(_.toString).run(i).run)
     }
-  })
+  }
 
   checkAll("StateT[Option, Int, Int]", MonadStateTests[StateT[Option, ?, ?], Int].monadState[Int, Int, Int])
   checkAll("MonadState[StateT[Option, ?, ?], Int]", SerializableTests.serializable(MonadState[StateT[Option, ?, ?], Int]))

--- a/tests/src/test/scala/cats/tests/CatsSuite.scala
+++ b/tests/src/test/scala/cats/tests/CatsSuite.scala
@@ -8,7 +8,7 @@ import cats.syntax.{AllSyntax, EqOps}
 
 import org.scalactic.anyvals.{PosZDouble, PosInt}
 import org.scalatest.{FunSuite, PropSpec, Matchers}
-import org.scalatest.prop.{Configuration, PropertyChecks}
+import org.scalatest.prop.{Configuration, GeneratorDrivenPropertyChecks}
 import org.typelevel.discipline.scalatest.Discipline
 
 import org.scalacheck.{Arbitrary, Gen}
@@ -32,7 +32,7 @@ trait TestSettings extends Configuration with Matchers {
  * An opinionated stack of traits to improve consistency and reduce
  * boilerplate in Cats tests.
  */
-trait CatsSuite extends FunSuite with Matchers with Discipline with TestSettings with AllInstances with AllSyntax with TestInstances with StrictCatsEquality {
+trait CatsSuite extends FunSuite with Matchers with GeneratorDrivenPropertyChecks with Discipline with TestSettings with AllInstances with AllSyntax with TestInstances with StrictCatsEquality {
   implicit override val generatorDrivenConfig: PropertyCheckConfiguration =
     checkConfiguration
 

--- a/tests/src/test/scala/cats/tests/CatsSuite.scala
+++ b/tests/src/test/scala/cats/tests/CatsSuite.scala
@@ -41,14 +41,6 @@ trait CatsSuite extends FunSuite with Matchers with Discipline with TestSettings
   override def eqSyntax[A: Eq](a: A): EqOps[A] = new EqOps[A](a)
 }
 
-trait CatsProps extends PropSpec with PropertyChecks with TestSettings with TestInstances {
-  implicit override val generatorDrivenConfig: PropertyCheckConfiguration =
-    checkConfiguration
-
-  // disable scalatest's ===
-  override def convertToEqualizer[T](left: T): Equalizer[T] = ???
-}
-
 trait SlowCatsSuite extends CatsSuite {
   implicit override val generatorDrivenConfig: PropertyCheckConfiguration =
     slowCheckConfiguration

--- a/tests/src/test/scala/cats/tests/EitherTests.scala
+++ b/tests/src/test/scala/cats/tests/EitherTests.scala
@@ -3,7 +3,6 @@ package tests
 
 import cats.laws.discipline.{TraverseTests, MonadTests, SerializableTests}
 import algebra.laws.OrderLaws
-import org.scalacheck.Prop._
 
 class EitherTests extends CatsSuite {
   checkAll("Either[Int, Int]", MonadTests[Either[Int, ?]].monad[Int, Int, Int])
@@ -30,9 +29,9 @@ class EitherTests extends CatsSuite {
     assert(!partialOrder.isInstanceOf[Order[_]])
   }
 
-  test("show isn't empty")(check {
+  test("show isn't empty") {
     forAll { (e: Either[Int, String]) =>
-      show.show(e).nonEmpty
+      show.show(e).nonEmpty should === (true)
     }
-  })
+  }
 }

--- a/tests/src/test/scala/cats/tests/FoldableTests.scala
+++ b/tests/src/test/scala/cats/tests/FoldableTests.scala
@@ -16,29 +16,29 @@ abstract class FoldableCheck[F[_]: ArbitraryK: Foldable](name: String) extends C
   test("summation") {
     forAll { (fa: F[Int]) =>
       val total = iterator(fa).sum
-      fa.foldLeft(0)(_ + _) shouldBe total
-      fa.foldRight(Now(0))((x, ly) => ly.map(x + _)).value shouldBe total
-      fa.fold shouldBe total
-      fa.foldMap(identity) shouldBe total
+      fa.foldLeft(0)(_ + _) should === (total)
+      fa.foldRight(Now(0))((x, ly) => ly.map(x + _)).value should === (total)
+      fa.fold should === (total)
+      fa.foldMap(identity) should === (total)
     }
   }
 
   test("find/exists/forall/filter_/dropWhile_") {
     forAll { (fa: F[Int], n: Int) =>
-      fa.find(_ > n)   shouldBe iterator(fa).find(_ > n)
-      fa.exists(_ > n) shouldBe iterator(fa).exists(_ > n)
-      fa.forall(_ > n) shouldBe iterator(fa).forall(_ > n)
-      fa.filter_(_ > n) shouldBe iterator(fa).filter(_ > n).toList
-      fa.dropWhile_(_ > n) shouldBe iterator(fa).dropWhile(_ > n).toList
+      fa.find(_ > n)   should === (iterator(fa).find(_ > n))
+      fa.exists(_ > n) should === (iterator(fa).exists(_ > n))
+      fa.forall(_ > n) should === (iterator(fa).forall(_ > n))
+      fa.filter_(_ > n) should === (iterator(fa).filter(_ > n).toList)
+      fa.dropWhile_(_ > n) should === (iterator(fa).dropWhile(_ > n).toList)
     }
   }
 
   test("toList/isEmpty/nonEmpty") {
     forAll { (fa: F[Int]) =>
-      fa.toList shouldBe iterator(fa).toList
-      fa.toStreaming.toList shouldBe iterator(fa).toList
-      fa.isEmpty shouldBe iterator(fa).isEmpty
-      fa.nonEmpty shouldBe iterator(fa).nonEmpty
+      fa.toList should === (iterator(fa).toList)
+      fa.toStreaming.toList should === (iterator(fa).toList)
+      fa.isEmpty should === (iterator(fa).isEmpty)
+      fa.nonEmpty should === (iterator(fa).nonEmpty)
     }
   }
 }

--- a/tests/src/test/scala/cats/tests/IorTests.scala
+++ b/tests/src/test/scala/cats/tests/IorTests.scala
@@ -7,9 +7,8 @@ import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.eq._
 import org.scalacheck.Arbitrary
 import org.scalacheck.Arbitrary._
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
 
-class IorTests extends CatsSuite with GeneratorDrivenPropertyChecks {
+class IorTests extends CatsSuite {
   checkAll("Ior[String, Int]", MonadTests[String Ior ?].monad[Int, Int, Int])
   checkAll("Monad[String Ior ?]]", SerializableTests.serializable(Monad[String Ior ?]))
 

--- a/tests/src/test/scala/cats/tests/IorTests.scala
+++ b/tests/src/test/scala/cats/tests/IorTests.scala
@@ -4,115 +4,116 @@ package tests
 import cats.data.{Xor, Ior}
 import cats.laws.discipline.{TraverseTests, MonadTests, SerializableTests}
 import cats.laws.discipline.arbitrary._
+import cats.laws.discipline.eq._
 import org.scalacheck.Arbitrary
 import org.scalacheck.Arbitrary._
-import org.scalacheck.Prop._
-import org.scalacheck.Prop.BooleanOperators
+import org.scalatest.prop.GeneratorDrivenPropertyChecks
 
-class IorTests extends CatsSuite {
+class IorTests extends CatsSuite with GeneratorDrivenPropertyChecks {
   checkAll("Ior[String, Int]", MonadTests[String Ior ?].monad[Int, Int, Int])
   checkAll("Monad[String Ior ?]]", SerializableTests.serializable(Monad[String Ior ?]))
 
   checkAll("Ior[String, Int] with Option", TraverseTests[String Ior ?].traverse[Int, Int, Int, Int, Option, Option])
   checkAll("Traverse[String Ior ?]", SerializableTests.serializable(Traverse[String Ior ?]))
 
-  check {
+  test("left Option is defined left and both") {
     forAll { (i: Int Ior String) =>
-      (i.isLeft || i.isBoth) == i.left.isDefined
+      (i.isLeft || i.isBoth) should === (i.left.isDefined)
     }
   }
 
-  check {
+  test("right Option is defined for right and both") {
     forAll { (i: Int Ior String) =>
-      (i.isRight || i.isBoth) == i.right.isDefined
+      (i.isRight || i.isBoth) should === (i.right.isDefined)
     }
   }
 
-  check {
+  test("onlyLeftOrRight") {
     forAll { (i: Int Ior String) =>
-      i.onlyLeft.map(Xor.left).orElse(i.onlyRight.map(Xor.right)) == i.onlyLeftOrRight
+      i.onlyLeft.map(Xor.left).orElse(i.onlyRight.map(Xor.right)) should === (i.onlyLeftOrRight)
     }
   }
 
-  check {
+  test("onlyBoth consistent with left and right") {
     forAll { (i: Int Ior String) =>
-      i.onlyBoth == (for {
+      i.onlyBoth should === (for {
         left <- i.left
         right <- i.right
       } yield (left, right))
     }
   }
 
-  check {
+  test("pad") {
     forAll { (i: Int Ior String) =>
-      i.pad == ((i.left, i.right))
+      i.pad should === ((i.left, i.right))
     }
   }
 
-  check {
+  test("unwrap consistent with isBoth") {
     forAll { (i: Int Ior String) =>
-      i.unwrap.isRight == i.isBoth
+      i.unwrap.isRight should === (i.isBoth)
     }
   }
 
-  check {
+  test("isLeft consistent with toOption") {
     forAll { (i: Int Ior String) =>
-      i.isLeft == i.toOption.isEmpty
+      i.isLeft should === (i.toOption.isEmpty)
     }
   }
 
-  check {
+  test("isLeft consistent with toList") {
     forAll { (i: Int Ior String) =>
-      i.isLeft == i.toList.isEmpty
+      i.isLeft should === (i.toList.isEmpty)
     }
   }
 
-  check {
+  test("isLeft consistent with forall and exists") {
     forAll { (i: Int Ior String, p: String => Boolean) =>
-      i.isLeft ==> (i.forall(p) && !i.exists(p))
-    }
-  }
-
-  check {
-    forAll { (i: Int Ior String, f: Int => Double) =>
-      i.leftMap(f).swap == i.swap.map(f)
-    }
-  }
-
-  check {
-    forAll { (i: Int) =>
-      Ior.left[Int, String](i).foreach { _ => fail("should not be called") }
-      true
-    }
-  }
-
-  check {
-    forAll { (i: Int Ior String) =>
-      (i.isRight || i.isBoth) ==> {
-        var count = 0
-        i.foreach { _ => count += 1 }
-        count == 1
+      whenever(i.isLeft) {
+        (i.forall(p) && !i.exists(p)) should === (true)
       }
     }
   }
 
-  check {
+  test("leftMap then swap equivalent to swap then map") {
+    forAll { (i: Int Ior String, f: Int => Double) =>
+      i.leftMap(f).swap should === (i.swap.map(f))
+    }
+  }
+
+  test("foreach is noop for left") {
+    forAll { (i: Int) =>
+      Ior.left[Int, String](i).foreach { _ => fail("should not be called") }
+    }
+  }
+
+  test("foreach runs for right and both") {
+    forAll { (i: Int Ior String) =>
+      whenever(i.isRight || i.isBoth) {
+        var count = 0
+        i.foreach { _ => count += 1 }
+        count should === (1)
+      }
+    }
+  }
+
+  test("show isn't empty") {
     val iorShow = implicitly[Show[Int Ior String]]
 
     forAll { (i: Int Ior String) =>
-      iorShow.show(i).size > 0
+      iorShow.show(i).nonEmpty should === (true)
     }
   }
 
-  check {
+  test("append left") {
     forAll { (i: Int Ior String, j: Int Ior String) =>
-      i.append(j).left == i.left.map(_ + j.left.getOrElse(0)).orElse(j.left)
+      i.append(j).left should === (i.left.map(_ + j.left.getOrElse(0)).orElse(j.left))
     }
   }
 
-  check {
+  test("append right") {
     forAll { (i: Int Ior String, j: Int Ior String) =>
-      i.append(j).right == i.right.map(_ + j.right.getOrElse("")).orElse(j.right)
+      i.append(j).right should === (i.right.map(_ + j.right.getOrElse("")).orElse(j.right))
     }
   }
 }

--- a/tests/src/test/scala/cats/tests/KleisliTests.scala
+++ b/tests/src/test/scala/cats/tests/KleisliTests.scala
@@ -8,11 +8,11 @@ import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.eq._
 import org.scalacheck.Arbitrary
-import org.scalacheck.Prop._
+import org.scalatest.prop.GeneratorDrivenPropertyChecks
 import algebra.laws.GroupLaws
 import cats.laws.discipline.{SemigroupKTests, MonoidKTests}
 
-class KleisliTests extends CatsSuite {
+class KleisliTests extends CatsSuite with GeneratorDrivenPropertyChecks {
   implicit def kleisliEq[F[_], A, B](implicit A: Arbitrary[A], FB: Eq[F[B]]): Eq[Kleisli[F, A, B]] =
     Eq.by[Kleisli[F, A, B], A => F[B]](_.run)
 
@@ -94,15 +94,15 @@ class KleisliTests extends CatsSuite {
     checkAll("SemigroupK[Lambda[A => Kleisli[Option, A, A]]]", SerializableTests.serializable(kleisliSemigroupK))
   }
 
-  check {
+  test("local composes functions") {
     forAll { (f: Int => Option[String], g: Int => Int, i: Int) =>
-      f(g(i)) == Kleisli.local[Option, String, Int](g)(Kleisli.function(f)).run(i)
+      f(g(i)) should === (Kleisli.local[Option, String, Int](g)(Kleisli.function(f)).run(i))
     }
   }
 
-  check {
+  test("pure consistent with ask") {
     forAll { (i: Int) =>
-      Kleisli.pure[Option, Int, Int](i).run(i) == Kleisli.ask[Option, Int].run(i)
+      Kleisli.pure[Option, Int, Int](i).run(i) should === (Kleisli.ask[Option, Int].run(i))
     }
   }
 

--- a/tests/src/test/scala/cats/tests/KleisliTests.scala
+++ b/tests/src/test/scala/cats/tests/KleisliTests.scala
@@ -8,11 +8,10 @@ import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.eq._
 import org.scalacheck.Arbitrary
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
 import algebra.laws.GroupLaws
 import cats.laws.discipline.{SemigroupKTests, MonoidKTests}
 
-class KleisliTests extends CatsSuite with GeneratorDrivenPropertyChecks {
+class KleisliTests extends CatsSuite {
   implicit def kleisliEq[F[_], A, B](implicit A: Arbitrary[A], FB: Eq[F[B]]): Eq[Kleisli[F, A, B]] =
     Eq.by[Kleisli[F, A, B], A => F[B]](_.run)
 

--- a/tests/src/test/scala/cats/tests/ListTests.scala
+++ b/tests/src/test/scala/cats/tests/ListTests.scala
@@ -4,9 +4,8 @@ package tests
 import cats.data.NonEmptyList
 import cats.laws.discipline.{TraverseTests, CoflatMapTests, MonadCombineTests, SerializableTests}
 import cats.laws.discipline.arbitrary._
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
 
-class ListTests extends CatsSuite with GeneratorDrivenPropertyChecks {
+class ListTests extends CatsSuite {
   checkAll("List[Int]", CoflatMapTests[List].coflatMap[Int, Int, Int])
   checkAll("CoflatMap[List]", SerializableTests.serializable(CoflatMap[List]))
 

--- a/tests/src/test/scala/cats/tests/NaturalTransformationTests.scala
+++ b/tests/src/test/scala/cats/tests/NaturalTransformationTests.scala
@@ -3,9 +3,9 @@ package tests
 
 import cats.arrow.NaturalTransformation
 
-import org.scalacheck.Prop.forAll
+import org.scalatest.prop.GeneratorDrivenPropertyChecks
 
-class NaturalTransformationTests extends CatsSuite {
+class NaturalTransformationTests extends CatsSuite with GeneratorDrivenPropertyChecks {
   val listToOption =
     new NaturalTransformation[List, Option] {
       def apply[A](fa: List[A]): Option[A] = fa.headOption
@@ -16,23 +16,23 @@ class NaturalTransformationTests extends CatsSuite {
       def apply[A](fa: Option[A]): List[A] = fa.toList
     }
 
-  test("compose")(check {
+  test("compose") {
     forAll { (list: List[Int]) =>
       val listToList = optionToList.compose(listToOption)
-      listToList(list) == list.take(1)
+      listToList(list) should === (list.take(1))
     }
-  })
+  }
 
-  test("andThen")(check {
+  test("andThen") {
     forAll { (list: List[Int]) =>
       val listToList = listToOption.andThen(optionToList)
-      listToList(list) == list.take(1)
+      listToList(list) should === (list.take(1))
     }
-  })
+  }
 
-  test("id is identity")(check {
+  test("id is identity") {
     forAll { (list: List[Int]) =>
-      NaturalTransformation.id[List].apply(list) == list
+      NaturalTransformation.id[List].apply(list) should === (list)
     }
-  })
+  }
 }

--- a/tests/src/test/scala/cats/tests/NaturalTransformationTests.scala
+++ b/tests/src/test/scala/cats/tests/NaturalTransformationTests.scala
@@ -3,9 +3,8 @@ package tests
 
 import cats.arrow.NaturalTransformation
 
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
 
-class NaturalTransformationTests extends CatsSuite with GeneratorDrivenPropertyChecks {
+class NaturalTransformationTests extends CatsSuite {
   val listToOption =
     new NaturalTransformation[List, Option] {
       def apply[A](fa: List[A]): Option[A] = fa.headOption

--- a/tests/src/test/scala/cats/tests/OneAndTests.scala
+++ b/tests/src/test/scala/cats/tests/OneAndTests.scala
@@ -7,11 +7,10 @@ import cats.data.{NonEmptyList, OneAnd}
 import cats.laws.discipline.{ComonadTests, FunctorTests, SemigroupKTests, FoldableTests, MonadTests, SerializableTests}
 import cats.laws.discipline.arbitrary.{evalArbitrary, oneAndArbitrary}
 
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
 
 import scala.util.Random
 
-class OneAndTests extends CatsSuite with GeneratorDrivenPropertyChecks {
+class OneAndTests extends CatsSuite {
   checkAll("OneAnd[Int, List]", OrderLaws[OneAnd[Int, List]].eqv)
 
   // Test instances that have more general constraints

--- a/tests/src/test/scala/cats/tests/OneAndTests.scala
+++ b/tests/src/test/scala/cats/tests/OneAndTests.scala
@@ -7,11 +7,11 @@ import cats.data.{NonEmptyList, OneAnd}
 import cats.laws.discipline.{ComonadTests, FunctorTests, SemigroupKTests, FoldableTests, MonadTests, SerializableTests}
 import cats.laws.discipline.arbitrary.{evalArbitrary, oneAndArbitrary}
 
-import org.scalacheck.Prop._
+import org.scalatest.prop.GeneratorDrivenPropertyChecks
 
 import scala.util.Random
 
-class OneAndTests extends CatsSuite {
+class OneAndTests extends CatsSuite with GeneratorDrivenPropertyChecks {
   checkAll("OneAnd[Int, List]", OrderLaws[OneAnd[Int, List]].eqv)
 
   // Test instances that have more general constraints
@@ -48,38 +48,40 @@ class OneAndTests extends CatsSuite {
   checkAll("NonEmptyList[Int]", ComonadTests[NonEmptyList].comonad[Int, Int, Int])
   checkAll("Comonad[NonEmptyList[A]]", SerializableTests.serializable(Comonad[NonEmptyList]))
 
-  test("Creating OneAnd + unwrap is identity")(check {
-    forAll { (list: List[Int]) => (list.size >= 1) ==> {
-      val oneAnd = NonEmptyList(list.head, list.tail: _*)
-      list == oneAnd.unwrap
-    }}
-  })
+  test("Creating OneAnd + unwrap is identity") {
+    forAll { (list: List[Int]) =>
+      whenever(list.size >= 1) {
+        val oneAnd = NonEmptyList(list.head, list.tail: _*)
+        list should === (oneAnd.unwrap)
+      }
+    }
+  }
 
-  test("NonEmptyList#filter is consistent with List#filter")(check {
+  test("NonEmptyList#filter is consistent with List#filter") {
     forAll { (nel: NonEmptyList[Int], p: Int => Boolean) =>
       val list = nel.unwrap
-      nel.filter(p) == list.filter(p)
+      nel.filter(p) should === (list.filter(p))
     }
-  })
+  }
 
-  test("NonEmptyList#find is consistent with List#find")(check {
+  test("NonEmptyList#find is consistent with List#find") {
     forAll { (nel: NonEmptyList[Int], p: Int => Boolean) =>
       val list = nel.unwrap
-      nel.find(p) == list.find(p)
+      nel.find(p) should === (list.find(p))
     }
-  })
+  }
 
-  test("NonEmptyList#exists is consistent with List#exists")(check {
+  test("NonEmptyList#exists is consistent with List#exists") {
     forAll { (nel: NonEmptyList[Int], p: Int => Boolean) =>
       val list = nel.unwrap
-      nel.exists(p) == list.exists(p)
+      nel.exists(p) should === (list.exists(p))
     }
-  })
+  }
 
-  test("NonEmptyList#forall is consistent with List#forall")(check {
+  test("NonEmptyList#forall is consistent with List#forall") {
     forAll { (nel: NonEmptyList[Int], p: Int => Boolean) =>
       val list = nel.unwrap
-      nel.forall(p) == list.forall(p)
+      nel.forall(p) should === (list.forall(p))
     }
-  })
+  }
 }

--- a/tests/src/test/scala/cats/tests/OptionTTests.scala
+++ b/tests/src/test/scala/cats/tests/OptionTTests.scala
@@ -5,9 +5,8 @@ import cats.data.{OptionT, Xor}
 import cats.laws.discipline.{MonadTests, SerializableTests}
 import cats.laws.discipline.arbitrary._
 import org.scalacheck.{Arbitrary, Gen}
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
 
-class OptionTTests extends CatsSuite with GeneratorDrivenPropertyChecks {
+class OptionTTests extends CatsSuite {
 
   test("fold and cata consistent") {
     forAll { (o: OptionT[List, Int], s: String, f: Int => String) =>

--- a/tests/src/test/scala/cats/tests/OptionTTests.scala
+++ b/tests/src/test/scala/cats/tests/OptionTTests.scala
@@ -4,112 +4,113 @@ import cats.{Id, Monad}
 import cats.data.{OptionT, Xor}
 import cats.laws.discipline.{MonadTests, SerializableTests}
 import cats.laws.discipline.arbitrary._
-import org.scalacheck.{Arbitrary, Gen, Prop}, Prop.forAll
+import org.scalacheck.{Arbitrary, Gen}
+import org.scalatest.prop.GeneratorDrivenPropertyChecks
 
-class OptionTTests extends CatsSuite {
+class OptionTTests extends CatsSuite with GeneratorDrivenPropertyChecks {
 
-  test("fold and cata consistent")(check {
+  test("fold and cata consistent") {
     forAll { (o: OptionT[List, Int], s: String, f: Int => String) =>
-      o.fold(s)(f) == o.cata(s, f)
+      o.fold(s)(f) should === (o.cata(s, f))
     }
-  })
+  }
 
-  test("OptionT[Id, A].fold consistent with Option.fold")(check {
+  test("OptionT[Id, A].fold consistent with Option.fold") {
     forAll { (o: Option[Int], s: String, f: Int => String) =>
-      o.fold(s)(f) == OptionT[Id, Int](o).fold(s)(f)
+      o.fold(s)(f) should === (OptionT[Id, Int](o).fold(s)(f))
     }
-  })
+  }
 
-  test("OptionT[Id, A].getOrElse consistent with Option.getOrElse")(check {
+  test("OptionT[Id, A].getOrElse consistent with Option.getOrElse") {
     forAll { (o: Option[Int], i: Int) =>
-      o.getOrElse(i) == OptionT[Id, Int](o).getOrElse(i)
+      o.getOrElse(i) should === (OptionT[Id, Int](o).getOrElse(i))
     }
-  })
+  }
 
-  test("OptionT[Id, A].getOrElseF consistent with Option.getOrElse")(check {
+  test("OptionT[Id, A].getOrElseF consistent with Option.getOrElse") {
     forAll { (o: Option[Int], i: Int) =>
-      o.getOrElse(i) == OptionT[Id, Int](o).getOrElseF(i)
+      o.getOrElse(i) should === (OptionT[Id, Int](o).getOrElseF(i))
     }
-  })
+  }
 
-  test("OptionT[Id, A].collect consistent with Option.collect")(check {
+  test("OptionT[Id, A].collect consistent with Option.collect") {
     forAll { (o: Option[Int], f: Int => Option[String]) =>
       val p = Function.unlift(f)
-      o.collect(p) == OptionT[Id, Int](o).collect(p).value
+      o.collect(p) should === (OptionT[Id, Int](o).collect(p).value)
     }
-  })
+  }
 
-  test("OptionT[Id, A].exists consistent with Option.exists")(check {
+  test("OptionT[Id, A].exists consistent with Option.exists") {
     forAll { (o: Option[Int], f: Int => Boolean) =>
-      o.exists(f) == OptionT[Id, Int](o).exists(f)
+      o.exists(f) should === (OptionT[Id, Int](o).exists(f))
     }
-  })
+  }
 
-  test("OptionT[Id, A].filter consistent with Option.filter")(check {
+  test("OptionT[Id, A].filter consistent with Option.filter") {
     forAll { (o: Option[Int], f: Int => Boolean) =>
-      o.filter(f) == OptionT[Id, Int](o).filter(f).value
+      o.filter(f) should === (OptionT[Id, Int](o).filter(f).value)
     }
-  })
+  }
 
-  test("OptionT[Id, A].filterNot consistent with Option.filterNot")(check {
+  test("OptionT[Id, A].filterNot consistent with Option.filterNot") {
     forAll { (o: Option[Int], f: Int => Boolean) =>
-      o.filterNot(f) == OptionT[Id, Int](o).filterNot(f).value
+      o.filterNot(f) should === (OptionT[Id, Int](o).filterNot(f).value)
     }
-  })
+  }
 
-  test("OptionT[Id, A].forall consistent with Option.forall")(check {
+  test("OptionT[Id, A].forall consistent with Option.forall") {
     forAll { (o: Option[Int], f: Int => Boolean) =>
-      o.forall(f) == OptionT[Id, Int](o).forall(f)
+      o.forall(f) should === (OptionT[Id, Int](o).forall(f))
     }
-  })
+  }
 
-  test("OptionT[Id, A].isDefined consistent with Option.isDefined")(check {
+  test("OptionT[Id, A].isDefined consistent with Option.isDefined") {
     forAll { o: Option[Int] =>
-      o.isDefined == OptionT[Id, Int](o).isDefined
+      o.isDefined should === (OptionT[Id, Int](o).isDefined)
     }
-  })
+  }
 
-  test("OptionT[Id, A].isEmpty consistent with Option.isEmpty")(check {
+  test("OptionT[Id, A].isEmpty consistent with Option.isEmpty") {
     forAll { o: Option[Int] =>
-      o.isEmpty == OptionT[Id, Int](o).isEmpty
+      o.isEmpty should === (OptionT[Id, Int](o).isEmpty)
     }
-  })
+  }
 
-  test("orElse and orElseF consistent")(check {
+  test("orElse and orElseF consistent") {
     forAll { (o1: OptionT[List, Int], o2: OptionT[List, Int]) =>
-      o1.orElse(o2) == o1.orElseF(o2.value)
+      o1.orElse(o2) should === (o1.orElseF(o2.value))
     }
-  })
+  }
 
-  test("OptionT[Id, A].toRight consistent with Xor.fromOption")(check {
+  test("OptionT[Id, A].toRight consistent with Xor.fromOption") {
     forAll { (o: OptionT[Id, Int], s: String) =>
-      o.toRight(s).value == Xor.fromOption(o.value, s)
+      o.toRight(s).value should === (Xor.fromOption(o.value, s))
     }
-  })
+  }
 
-  test("toRight consistent with isDefined")(check {
+  test("toRight consistent with isDefined") {
     forAll { (o: OptionT[List, Int], s: String) =>
-      o.toRight(s).isRight == o.isDefined
+      o.toRight(s).isRight should === (o.isDefined)
     }
-  })
+  }
 
-  test("toLeft consistent with isDefined")(check {
+  test("toLeft consistent with isDefined") {
     forAll { (o: OptionT[List, Int], s: String) =>
-      o.toLeft(s).isLeft == o.isDefined
+      o.toLeft(s).isLeft should === (o.isDefined)
     }
-  })
+  }
 
-  test("isDefined is negation of isEmpty")(check {
+  test("isDefined is negation of isEmpty") {
     forAll { (o: OptionT[List, Int]) =>
-      o.isDefined == o.isEmpty.map(! _)
+      o.isDefined should === (o.isEmpty.map(! _))
     }
-  })
+  }
 
-  test("fromOption")(check {
+  test("fromOption") {
     forAll { (o: Option[Int]) =>
-      List(o) == OptionT.fromOption[List](o).value
+      List(o) should === (OptionT.fromOption[List](o).value)
     }
-  })
+  }
 
   checkAll("OptionT[List, Int]", MonadTests[OptionT[List, ?]].monad[Int, Int, Int])
   checkAll("MonadOptionT[List, ?]]", SerializableTests.serializable(Monad[OptionT[List, ?]]))

--- a/tests/src/test/scala/cats/tests/StreamingTests.scala
+++ b/tests/src/test/scala/cats/tests/StreamingTests.scala
@@ -6,7 +6,6 @@ import algebra.laws.OrderLaws
 import cats.data.Streaming
 import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.{TraverseTests, CoflatMapTests, MonadCombineTests, SerializableTests}
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
 
 class StreamingTests extends CatsSuite {
   checkAll("Streaming[Int]", CoflatMapTests[Streaming].coflatMap[Int, Int, Int])
@@ -22,7 +21,7 @@ class StreamingTests extends CatsSuite {
   checkAll("Order[Streaming[Int]]", SerializableTests.serializable(Order[Streaming[Int]]))
 }
 
-class AdHocStreamingTests extends CatsSuite with GeneratorDrivenPropertyChecks {
+class AdHocStreamingTests extends CatsSuite {
 
   // convert List[A] to Streaming[A]
   def convert[A](as: List[A]): Streaming[A] =

--- a/tests/src/test/scala/cats/tests/StreamingTests.scala
+++ b/tests/src/test/scala/cats/tests/StreamingTests.scala
@@ -6,6 +6,7 @@ import algebra.laws.OrderLaws
 import cats.data.Streaming
 import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.{TraverseTests, CoflatMapTests, MonadCombineTests, SerializableTests}
+import org.scalatest.prop.GeneratorDrivenPropertyChecks
 
 class StreamingTests extends CatsSuite {
   checkAll("Streaming[Int]", CoflatMapTests[Streaming].coflatMap[Int, Int, Int])
@@ -21,15 +22,15 @@ class StreamingTests extends CatsSuite {
   checkAll("Order[Streaming[Int]]", SerializableTests.serializable(Order[Streaming[Int]]))
 }
 
-class AdHocStreamingTests extends CatsProps {
+class AdHocStreamingTests extends CatsSuite with GeneratorDrivenPropertyChecks {
 
   // convert List[A] to Streaming[A]
   def convert[A](as: List[A]): Streaming[A] =
     Streaming.fromList(as)
 
-  property("fromList/toList") {
+  test("fromList/toList") {
     forAll { (xs: List[Int]) =>
-      convert(xs).toList shouldBe xs
+      convert(xs).toList should === (xs)
     }
   }
 
@@ -37,7 +38,7 @@ class AdHocStreamingTests extends CatsProps {
   def test[A, B](xs: List[A])(f: Streaming[A] => B)(g: List[A] => B): Unit =
     f(convert(xs)) shouldBe g(xs)
 
-  property("map") {
+  test("map") {
     forAll { (xs: List[Int], f: Int => Double) =>
       test(xs)(_.map(f).toList)(_.map(f))
     }
@@ -47,49 +48,49 @@ class AdHocStreamingTests extends CatsProps {
   def convertF[A, B](f: A => List[B]): A => Streaming[B] =
     (a: A) => Streaming.fromList(f(a))
 
-  property("flatMap") {
+  test("flatMap") {
     forAll { (xs: List[Int], f: Int => List[Double]) =>
       test(xs)(_.flatMap(convertF(f)).toList)(_.flatMap(f))
     }
   }
 
-  property("filter") {
+  test("filter") {
     forAll { (xs: List[Int], f: Int => Boolean) =>
       test(xs)(_.filter(f).toList)(_.filter(f))
     }
   }
 
-  property("foldLeft") {
+  test("foldLeft") {
     forAll { (xs: List[String], n: Int, f: (Int, String) => Int) =>
       test(xs)(_.foldLeft(n)(f))(_.foldLeft(n)(f))
     }
   }
 
-  property("isEmpty") {
+  test("isEmpty") {
     forAll { (xs: List[String], n: Int, f: (Int, String) => Int) =>
       test(xs)(_.isEmpty)(_.isEmpty)
     }
   }
 
-  property("concat") {
+  test("concat") {
     forAll { (xs: List[Int], ys: List[Int]) =>
       (convert(xs) concat convert(ys)).toList shouldBe (xs ::: ys)
     }
   }
 
-  property("zip") {
+  test("zip") {
     forAll { (xs: List[Int], ys: List[Int]) =>
       (convert(xs) zip convert(ys)).toList shouldBe (xs zip ys)
     }
   }
 
-  property("zipWithIndex") {
+  test("zipWithIndex") {
     forAll { (xs: List[Int], ys: List[Int]) =>
       test(xs)(_.zipWithIndex.toList)(_.zipWithIndex)
     }
   }
 
-  property("unzip") {
+  test("unzip") {
     forAll { (xys: List[(Int, Int)]) =>
       test(xys) { s =>
         val (xs, ys): (Streaming[Int], Streaming[Int]) = s.unzip
@@ -98,56 +99,55 @@ class AdHocStreamingTests extends CatsProps {
     }
   }
 
-  property("exists") {
+  test("exists") {
     forAll { (xs: List[Int], f: Int => Boolean) =>
       test(xs)(_.exists(f))(_.exists(f))
     }
   }
 
-  property("forall") {
+  test("forall") {
     forAll { (xs: List[Int], f: Int => Boolean) =>
       test(xs)(_.forall(f))(_.forall(f))
     }
   }
 
-  property("take") {
+  test("take") {
     forAll { (xs: List[Int], n: Int) =>
       test(xs)(_.take(n).toList)(_.take(n))
     }
   }
 
-  property("drop") {
+  test("drop") {
     forAll { (xs: List[Int], n: Int) =>
       test(xs)(_.drop(n).toList)(_.drop(n))
     }
   }
 
-  property("takeWhile") {
+  test("takeWhile") {
     forAll { (xs: List[Int], f: Int => Boolean) =>
       test(xs)(_.takeWhile(f).toList)(_.takeWhile(f))
     }
   }
 
-  property("dropWhile") {
+  test("dropWhile") {
     forAll { (xs: List[Int], f: Int => Boolean) =>
       test(xs)(_.dropWhile(f).toList)(_.dropWhile(f))
     }
   }
 
-  property("tails") {
+  test("tails") {
     forAll { (xs: List[Int]) =>
       test(xs)(_.tails.map(_.toList).toList)(_.tails.toList)
     }
   }
 
-  property("merge") {
-    import cats.std.int._
+  test("merge") {
     forAll { (xs: List[Int], ys: List[Int]) =>
       (convert(xs.sorted) merge convert(ys.sorted)).toList shouldBe (xs ::: ys).sorted
     }
   }
 
-  property("product") {
+  test("product") {
     forAll { (xs: List[Int], ys: List[Int]) =>
       val result = (convert(xs) product convert(ys)).iterator.toSet
       val expected = (for { x <- xs; y <- ys } yield (x, y)).toSet
@@ -166,7 +166,7 @@ class AdHocStreamingTests extends CatsProps {
     positiveRationals.take(e.size).iterator.toSet shouldBe e
   }
 
-  property("interleave") {
+  test("interleave") {
     forAll { (xs: Vector[Int]) =>
       // not a complete test but it'll have to do for now
       val s = Streaming.fromVector(xs)
@@ -190,96 +190,95 @@ class AdHocStreamingTests extends CatsProps {
   val veryDangerous: Streaming[Int] =
     1 %:: bomb
 
-  property("lazy uncons") {
+  test("lazy uncons") {
     veryDangerous.uncons.map(_._1) shouldBe Some(1)
   }
 
   def isok[U](body: => U): Unit =
     Try(body).isSuccess shouldBe true
 
-  property("lazy map") {
+  test("lazy map") {
     isok(bomb.map(_ + 1))
   }
 
-  property("lazy flatMap") {
+  test("lazy flatMap") {
     isok(bomb.flatMap(n => Streaming(n, n)))
   }
 
-  property("lazy filter") {
+  test("lazy filter") {
     isok(bomb.filter(_ > 10))
   }
 
-  property("lazy foldRight") {
+  test("lazy foldRight") {
     isok(bomb.foldRight(Now(0))((x, total) => total.map(_ + x)))
   }
 
-  property("lazy peekEmpty") {
+  test("lazy peekEmpty") {
     bomb.peekEmpty shouldBe None
   }
 
-  property("lazy concat") {
+  test("lazy concat") {
     isok(bomb concat bomb)
   }
 
-  property("lazier concat") {
+  test("lazier concat") {
     isok(bomb concat Always(sys.error("ouch"): Streaming[Int]))
   }
 
-  property("lazy zip") {
+  test("lazy zip") {
     isok(bomb zip dangerous)
     isok(dangerous zip bomb)
   }
 
-  property("lazy zipWithIndex") {
+  test("lazy zipWithIndex") {
     isok(bomb.zipWithIndex)
   }
 
-  property("lazy izip") {
+  test("lazy izip") {
     isok(bomb izip dangerous)
     isok(dangerous izip bomb)
   }
 
-  property("lazy unzip") {
+  test("lazy unzip") {
     val bombBomb: Streaming[(Int, Int)] = bomb.map(n => (n, n))
     isok { val t: (Streaming[Int], Streaming[Int]) = bombBomb.unzip }
   }
 
-  property("lazy merge") {
-    import cats.std.int._
+  test("lazy merge") {
     isok(bomb merge bomb)
   }
 
-  property("lazy interleave") {
+  test("lazy interleave") {
     isok(bomb interleave bomb)
   }
 
-  property("lazy product") {
+  test("lazy product") {
     isok(bomb product bomb)
   }
 
-  property("lazy take") {
+  test("lazy take") {
     isok(bomb.take(10))
     isok(bomb.take(0))
   }
 
-  property("take up to the last valid element"){
+  test("take up to the last valid element"){
     isok(dangerous.take(3).toList)
   }
 
-  property("lazy drop") {
+  test("lazy drop") {
     isok(bomb.drop(10))
     isok(bomb.drop(0))
   }
 
-  property("lazy takeWhile") {
+  test("lazy takeWhile") {
     isok(bomb.takeWhile(_ < 10))
   }
 
-  property("lazy dropWhile") {
+  test("lazy dropWhile") {
     isok(bomb.takeWhile(_ < 10))
   }
 
-  property("lazy tails") {
+  test("lazy tails") {
     isok(bomb.tails)
   }
 }

--- a/tests/src/test/scala/cats/tests/ValidatedTests.scala
+++ b/tests/src/test/scala/cats/tests/ValidatedTests.scala
@@ -6,13 +6,12 @@ import cats.data.Validated.{Valid, Invalid}
 import cats.laws.discipline.{TraverseTests, ApplicativeTests, SerializableTests}
 import org.scalacheck.{Gen, Arbitrary}
 import org.scalacheck.Arbitrary._
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
 import cats.laws.discipline.arbitrary._
 import algebra.laws.OrderLaws
 
 import scala.util.Try
 
-class ValidatedTests extends CatsSuite with GeneratorDrivenPropertyChecks {
+class ValidatedTests extends CatsSuite {
   checkAll("Validated[String, Int]", ApplicativeTests[Validated[String,?]].applicative[Int, Int, Int])
   checkAll("Applicative[Validated[String,?]]", SerializableTests.serializable(Applicative[Validated[String,?]]))
 

--- a/tests/src/test/scala/cats/tests/XorTTests.scala
+++ b/tests/src/test/scala/cats/tests/XorTTests.scala
@@ -5,9 +5,8 @@ import cats.data.{Xor, XorT}
 import cats.laws.discipline.{MonadErrorTests, MonoidKTests, SerializableTests}
 import cats.laws.discipline.arbitrary._
 
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
 
-class XorTTests extends CatsSuite with GeneratorDrivenPropertyChecks {
+class XorTTests extends CatsSuite {
   checkAll("XorT[List, String, Int]", MonadErrorTests[XorT[List, ?, ?], String].monadError[Int, Int, Int])
   checkAll("XorT[List, String, Int]", MonoidKTests[XorT[List, String, ?]].monoidK[Int])
   checkAll("MonadError[XorT[List, ?, ?]]", SerializableTests.serializable(MonadError[XorT[List, ?, ?], String]))

--- a/tests/src/test/scala/cats/tests/XorTTests.scala
+++ b/tests/src/test/scala/cats/tests/XorTTests.scala
@@ -5,66 +5,64 @@ import cats.data.{Xor, XorT}
 import cats.laws.discipline.{MonadErrorTests, MonoidKTests, SerializableTests}
 import cats.laws.discipline.arbitrary._
 
-import org.scalacheck.Prop.forAll
+import org.scalatest.prop.GeneratorDrivenPropertyChecks
 
-class XorTTests extends CatsSuite {
+class XorTTests extends CatsSuite with GeneratorDrivenPropertyChecks {
   checkAll("XorT[List, String, Int]", MonadErrorTests[XorT[List, ?, ?], String].monadError[Int, Int, Int])
   checkAll("XorT[List, String, Int]", MonoidKTests[XorT[List, String, ?]].monoidK[Int])
   checkAll("MonadError[XorT[List, ?, ?]]", SerializableTests.serializable(MonadError[XorT[List, ?, ?], String]))
 
-  test("toValidated")(check {
+  test("toValidated") {
     forAll { (xort: XorT[List, String, Int]) =>
-      xort.toValidated.map(_.toXor) == xort.value
+      xort.toValidated.map(_.toXor) should === (xort.value)
     }
-  })
+  }
 
-  test("withValidated")(check {
+  test("withValidated") {
     forAll { (xort: XorT[List, String, Int], f: String => Char, g: Int => Double) =>
-      xort.withValidated(_.bimap(f, g)) == xort.bimap(f, g)
+      xort.withValidated(_.bimap(f, g)) should === (xort.bimap(f, g))
     }
-  })
+  }
 
-  test("fromXor")(check {
+  test("fromXor") {
     forAll { (xor: Xor[String, Int]) =>
-      Some(xor.isLeft) == XorT.fromXor[Option](xor).isLeft
+      Some(xor.isLeft) should === (XorT.fromXor[Option](xor).isLeft)
     }
-  })
+  }
 
-  test("isLeft negation of isRight")(check {
+  test("isLeft negation of isRight") {
     forAll { (xort: XorT[List, String, Int]) =>
-      xort.isLeft == xort.isRight.map(! _)
+      xort.isLeft should === (xort.isRight.map(! _))
     }
-  })
+  }
 
-  test("double swap is noop")(check {
+  test("double swap is noop") {
     forAll { (xort: XorT[List, String, Int]) =>
-      xort.swap.swap === xort
+      xort.swap.swap should === (xort)
     }
-  })
+  }
 
-  test("swap negates isRight")(check {
+  test("swap negates isRight") {
     forAll { (xort: XorT[List, String, Int]) =>
-      xort.swap.isRight == xort.isRight.map(! _)
+      xort.swap.isRight should === (xort.isRight.map(! _))
     }
-  })
+  }
 
-  test("toOption on Right returns Some")(check {
+  test("toOption on Right returns Some") {
     forAll { (xort: XorT[List, String, Int]) =>
-      xort.toOption.map(_.isDefined) == xort.isRight
+      xort.toOption.map(_.isDefined) should === (xort.isRight)
     }
-  })
+  }
 
-  test("toEither preserves isRight")(check {
+  test("toEither preserves isRight") {
     forAll { (xort: XorT[List, String, Int]) =>
-      xort.toEither.map(_.isRight) == xort.isRight
+      xort.toEither.map(_.isRight) should === (xort.isRight)
     }
-  })
+  }
 
   test("recover recovers handled values") {
-    assert {
-      val xort = XorT.left[Id, String, Int]("xort")
-      xort.recover { case "xort" => 5 }.isRight
-    }
+    val xort = XorT.left[Id, String, Int]("xort")
+    xort.recover { case "xort" => 5 }.isRight should === (true)
   }
 
   test("recover ignores unhandled values") {
@@ -78,10 +76,8 @@ class XorTTests extends CatsSuite {
   }
 
   test("recoverWith recovers handled values") {
-    assert {
-      val xort = XorT.left[Id, String, Int]("xort")
-      xort.recoverWith { case "xort" => XorT.right[Id, String, Int](5) }.isRight
-    }
+    val xort = XorT.left[Id, String, Int]("xort")
+    xort.recoverWith { case "xort" => XorT.right[Id, String, Int](5) }.isRight should === (true)
   }
 
   test("recoverWith ignores unhandled values") {

--- a/tests/src/test/scala/cats/tests/XorTests.scala
+++ b/tests/src/test/scala/cats/tests/XorTests.scala
@@ -7,12 +7,11 @@ import cats.laws.discipline.arbitrary.xorArbitrary
 import cats.laws.discipline.{TraverseTests, MonadErrorTests, SerializableTests}
 import algebra.laws.{GroupLaws, OrderLaws}
 import org.scalacheck.{Arbitrary, Gen}
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
 import org.scalacheck.Arbitrary._
 
 import scala.util.Try
 
-class XorTests extends CatsSuite with GeneratorDrivenPropertyChecks {
+class XorTests extends CatsSuite {
   checkAll("Xor[String, Int]", GroupLaws[Xor[String, Int]].monoid)
 
   checkAll("Xor[String, Int]", MonadErrorTests[Xor, String].monadError[Int, Int, Int])

--- a/tests/src/test/scala/cats/tests/XorTests.scala
+++ b/tests/src/test/scala/cats/tests/XorTests.scala
@@ -5,21 +5,23 @@ import cats.data.Xor
 import cats.data.Xor._
 import cats.laws.discipline.arbitrary.xorArbitrary
 import cats.laws.discipline.{TraverseTests, MonadErrorTests, SerializableTests}
+import algebra.laws.{GroupLaws, OrderLaws}
 import org.scalacheck.{Arbitrary, Gen}
-import org.scalacheck.Prop._
-import org.scalacheck.Prop.BooleanOperators
+import org.scalatest.prop.GeneratorDrivenPropertyChecks
 import org.scalacheck.Arbitrary._
 
 import scala.util.Try
 
-class XorTests extends CatsSuite {
-  checkAll("Xor[String, Int]", algebra.laws.GroupLaws[Xor[String, Int]].monoid)
+class XorTests extends CatsSuite with GeneratorDrivenPropertyChecks {
+  checkAll("Xor[String, Int]", GroupLaws[Xor[String, Int]].monoid)
 
   checkAll("Xor[String, Int]", MonadErrorTests[Xor, String].monadError[Int, Int, Int])
   checkAll("MonadError[Xor, String]", SerializableTests.serializable(MonadError[Xor, String]))
 
   checkAll("Xor[String, Int] with Option", TraverseTests[Xor[String, ?]].traverse[Int, Int, Int, Int, Option, Option])
   checkAll("Traverse[Xor[String,?]]", SerializableTests.serializable(Traverse[Xor[String, ?]]))
+
+  checkAll("Xor[Int, String]", OrderLaws[String Xor Int].order)
 
   implicit val arbitraryXor: Arbitrary[Xor[Int, String]] = Arbitrary {
     for {
@@ -39,55 +41,56 @@ class XorTests extends CatsSuite {
     }
   }
 
-  check{
+  test("fromTry is left for failed Try") {
     forAll { t: Try[Int] =>
-      t.isFailure == Xor.fromTry(t).isLeft
+      t.isFailure should === (Xor.fromTry(t).isLeft)
     }
   }
 
-  check{
+  test("fromEither isRight consistent with Either.isRight"){
     forAll { e: Either[Int, String] =>
-      Xor.fromEither(e).isRight == e.isRight
+      Xor.fromEither(e).isRight should === (e.isRight)
     }
   }
 
-  check{
+  test("fromOption isLeft consistent with Option.isEmpty") {
     forAll { (o: Option[Int], s: String) =>
-      Xor.fromOption(o, s).isLeft == o.isEmpty
+      Xor.fromOption(o, s).isLeft should === (o.isEmpty)
     }
   }
 
-  check {
+  test("double swap is identity") {
     forAll { (x: Int Xor String) =>
-      x.swap.swap == x
+      x.swap.swap should === (x)
     }
   }
 
-  check {
+  test("foreach is noop for left") {
     forAll { (x: Int Xor String) =>
       var count = 0
       x.foreach{ _ => count += 1}
-      (count == 0) == x.isLeft
+      (count == 0) should === (x.isLeft)
     }
   }
 
-  check {
+  test("getOrElse ignores default for right") {
     forAll { (x: Int Xor String, s: String, t: String) =>
-      x.isRight ==> (x.getOrElse(s) == x.getOrElse(t))
+      whenever(x.isRight) {
+        x.getOrElse(s) should === (x.getOrElse(t))
+      }
     }
   }
 
-  check {
+  test("orElse") {
     forAll { (x: Int Xor String, y: Int Xor String) =>
-      (x.orElse(y) == x) || (x.orElse(y) == y)
+      val z = x.orElse(y)
+      (z === (x)) || (z === (y)) should === (true)
     }
   }
 
   test("recover recovers handled values") {
-    assert {
-      val xor = Xor.left[String, Int]("xor")
-      xor.recover { case "xor" => 5 }.isRight
-    }
+    val xor = Xor.left[String, Int]("xor")
+    xor.recover { case "xor" => 5 }.isRight should === (true)
   }
 
   test("recover ignores unhandled values") {
@@ -101,10 +104,8 @@ class XorTests extends CatsSuite {
   }
 
   test("recoverWith recovers handled values") {
-    assert {
-      val xor = Xor.left[String, Int]("xor")
-      xor.recoverWith { case "xor" => Xor.right[String, Int](5) }.isRight
-    }
+    val xor = Xor.left[String, Int]("xor")
+    xor.recoverWith { case "xor" => Xor.right[String, Int](5) }.isRight should === (true)
   }
 
   test("recoverWith ignores unhandled values") {
@@ -117,78 +118,61 @@ class XorTests extends CatsSuite {
     xor.recoverWith { case "xor" => Xor.right[String, Int](5) } should === (xor)
   }
 
-  check {
+  test("valueOr consistent with swap then map then merge") {
     forAll { (x: Int Xor String, f: Int => String) =>
-      x.valueOr(f) == x.swap.map(f).merge
+      x.valueOr(f) should === (x.swap.map(f).merge)
     }
   }
 
-  check {
+  test("isLeft implies forall") {
     forAll { (x: Int Xor String, p: String => Boolean) =>
-      x.isLeft ==> x.forall(p)
+      whenever(x.isLeft) {
+        x.forall(p) should === (true)
+      }
     }
   }
 
-  check {
+  test("isLeft implies exists is false") {
     forAll { (x: Int Xor String, p: String => Boolean) =>
-      x.isLeft ==> !x.exists(p)
+      whenever(x.isLeft) {
+        x.exists(p) should === (false)
+      }
     }
   }
 
-  check {
+  test("ensure on left is identity") {
     forAll { (x: Int Xor String, i: Int, p: String => Boolean) =>
-      x.isLeft ==> (x.ensure(i)(p) == x)
+      whenever(x.isLeft) {
+        x.ensure(i)(p) should === (x)
+      }
     }
   }
 
-  check {
+  test("toIor then toXor is identity") {
     forAll { (x: Int Xor String) =>
-      x.toIor.toXor == x
+      x.toIor.toXor should === (x)
     }
   }
 
-  check {
+  test("isLeft consistency") {
     forAll { (x: Int Xor String) =>
-      x.toEither.isLeft == x.isLeft &&
-      x.toOption.isEmpty == x.isLeft &&
-      x.toList.isEmpty == x.isLeft &&
-      x.toValidated.isInvalid == x.isLeft
+      x.isLeft should === (x.toEither.isLeft)
+      x.isLeft should === (x.toOption.isEmpty)
+      x.isLeft should === (x.toList.isEmpty)
+      x.isLeft should === (x.toValidated.isInvalid)
     }
   }
 
-  check {
+  test("withValidated") {
     forAll { (x: Int Xor String, f: Int => Double) =>
-      x.withValidated(_.bimap(f, identity)) == x.leftMap(f)
+      x.withValidated(_.bimap(f, identity)) should === (x.leftMap(f))
     }
   }
 
-  check {
+  test("combine is right iff both operands are right") {
     forAll { (x: Int Xor String, y: Int Xor String) =>
-      x.combine(y).isRight == (x.isRight && y.isRight)
+      x.combine(y).isRight should === (x.isRight && y.isRight)
     }
   }
 
-  check {
-    forAll { (x: Int Xor String) =>
-      val equality = implicitly[Eq[Int Xor String]]
-      equality.eqv(x, x)
-    }
-  }
-
-  check {
-    forAll { (x: Int Xor String) =>
-      val partialOrder = implicitly[PartialOrder[Int Xor String]]
-      partialOrder.partialCompare(x, x) == 0 &&
-      partialOrder.eqv(x, x)
-    }
-  }
-
-  check {
-    forAll { (x: Int Xor String) =>
-      val order = implicitly[Order[Int Xor String]]
-      order.compare(x, x) == 0 &&
-      order.partialCompare(x, x) == 0 &&
-      order.eqv(x, x)
-    }
-  }
 }


### PR DESCRIPTION
This makes CatsSuite extend Scalatest's GeneratorDrivenPropertyChecks, which allows us to use Scalatest matches inside of our `forAll`-style generator-driven property checks.

Example:

### old
```scala
test("OptionT[Id, A].isEmpty consistent with Option.isEmpty")(check {
  forAll { o: Option[Int] =>
    o.isEmpty == OptionT[Id, Int](o).isEmpty
  }
})
```

### new
```scala
test("OptionT[Id, A].isEmpty consistent with Option.isEmpty") {
  forAll { o: Option[Int] =>
    o.isEmpty should === (OptionT[Id, Int](o).isEmpty)
  }
}
```

This allows us to drop the awkward `check` call and use a type-safe equals comparison.

For those of you looking at this and thinking "wow, I can't believe this person is meticulous enough to go through and change all of these": hi, I'm Cody; I don't believe we've met. In my defense, a vim macro or two did a lot of the work.