### PR TITLE
Change MonadError from F[_, _] to F[_]

### DIFF
--- a/core/src/main/scala/cats/MonadError.scala
+++ b/core/src/main/scala/cats/MonadError.scala
@@ -4,12 +4,12 @@ package cats
   *
   * This type class allows one to abstract over error-handling monads.
   */
-trait MonadError[F[_, _], E] extends Monad[F[E, ?]] {
-  def raiseError[A](e: E): F[E, A]
+trait MonadError[F[_], E] extends Monad[F] {
+  def raiseError[A](e: E): F[A]
 
-  def handleError[A](fea: F[E, A])(f: E => F[E, A]): F[E, A]
+  def handleError[A](fea: F[A])(f: E => F[A]): F[A]
 }
 
 object MonadError {
-  def apply[F[_, _], E](implicit F: MonadError[F, E]): MonadError[F, E] = F
+  def apply[F[_], E](implicit F: MonadError[F, E]): MonadError[F, E] = F
 }

--- a/core/src/main/scala/cats/MonadReader.scala
+++ b/core/src/main/scala/cats/MonadReader.scala
@@ -1,14 +1,14 @@
 package cats
 
 /** A monad that has the ability to read from an environment. */
-trait MonadReader[F[_, _], R] extends Monad[F[R, ?]] {
+trait MonadReader[F[_], R] extends Monad[F] {
   /** Get the environment */
-  def ask: F[R, R]
+  def ask: F[R]
 
   /** Modify the environment */
-  def local[A](f: R => R)(fa: F[R, A]): F[R, A]
+  def local[A](f: R => R)(fa: F[A]): F[A]
 }
 
 object MonadReader {
-  def apply[F[_, _], R](implicit F: MonadReader[F, R]): MonadReader[F, R] = F
+  def apply[F[_], R](implicit F: MonadReader[F, R]): MonadReader[F, R] = F
 }

--- a/core/src/main/scala/cats/MonadState.scala
+++ b/core/src/main/scala/cats/MonadState.scala
@@ -6,7 +6,7 @@ package cats
   * dealing with large monad transformer stacks. For instance:
   *
   * {{{
-  * val M = MonadState[StateT[List, ?, ?], Int]
+  * val M = MonadState[StateT[List, Int, ?], Int]
   * import M._
   *
   * for {
@@ -16,16 +16,16 @@ package cats
   * } yield r
   * }}}
   */
-trait MonadState[F[_, _], S] extends Monad[F[S, ?]] {
-  def get: F[S, S]
+trait MonadState[F[_], S] extends Monad[F] {
+  def get: F[S]
 
-  def set(s: S): F[S, Unit]
+  def set(s: S): F[Unit]
 
-  def modify(f: S => S): F[S, Unit] = flatMap(get)(s => set(f(s)))
+  def modify(f: S => S): F[Unit] = flatMap(get)(s => set(f(s)))
 
-  def inspect[A](f: S => A): F[S, A] = map(get)(f)
+  def inspect[A](f: S => A): F[A] = map(get)(f)
 }
 
 object MonadState {
-  def apply[F[_, _], S](implicit F: MonadState[F, S]): MonadState[F, S] = F
+  def apply[F[_], S](implicit F: MonadState[F, S]): MonadState[F, S] = F
 }

--- a/core/src/main/scala/cats/data/Kleisli.scala
+++ b/core/src/main/scala/cats/data/Kleisli.scala
@@ -103,8 +103,8 @@ sealed abstract class KleisliInstances extends KleisliInstances0 {
         f.compose(g)
     }
 
-  implicit def kleisliMonadReader[F[_]: Monad, A]: MonadReader[Kleisli[F, ?, ?], A] =
-    new MonadReader[Kleisli[F, ?, ?], A] {
+  implicit def kleisliMonadReader[F[_]: Monad, A]: MonadReader[Kleisli[F, A, ?], A] =
+    new MonadReader[Kleisli[F, A, ?], A] {
       def pure[B](x: B): Kleisli[F, A, B] =
         Kleisli.pure[F, A, B](x)
 

--- a/core/src/main/scala/cats/data/Xor.scala
+++ b/core/src/main/scala/cats/data/Xor.scala
@@ -162,8 +162,8 @@ sealed abstract class XorInstances extends XorInstances1 {
       def combine(x: A Xor B, y: A Xor B): A Xor B = x combine y
     }
 
-  implicit def xorInstances[A]: Traverse[A Xor ?] with MonadError[Xor, A ] =
-    new Traverse[A Xor ?] with MonadError[Xor, A] {
+  implicit def xorInstances[A]: Traverse[A Xor ?] with MonadError[Xor[A, ?], A] =
+    new Traverse[A Xor ?] with MonadError[Xor[A, ?], A] {
       def traverse[F[_]: Applicative, B, C](fa: A Xor B)(f: B => F[C]): F[A Xor C] = fa.traverse(f)
       def foldLeft[B, C](fa: A Xor B, c: C)(f: (C, B) => C): C = fa.foldLeft(c)(f)
       def foldRight[B, C](fa: A Xor B, lc: Eval[C])(f: (B, Eval[C]) => Eval[C]): Eval[C] = fa.foldRight(lc)(f)

--- a/core/src/main/scala/cats/data/XorT.scala
+++ b/core/src/main/scala/cats/data/XorT.scala
@@ -179,7 +179,7 @@ private[data] abstract class XorTInstances1 extends XorTInstances2 {
 }
 
 private[data] abstract class XorTInstances2 extends XorTInstances3 {
-  implicit def xorTMonadError[F[_], L](implicit F: Monad[F]): MonadError[XorT[F, ?, ?], L] = {
+  implicit def xorTMonadError[F[_], L](implicit F: Monad[F]): MonadError[XorT[F, L, ?], L] = {
     implicit val F0 = F
     new XorTMonadError[F, L] { implicit val F = F0 }
   }
@@ -203,7 +203,7 @@ private[data] trait XorTFunctor[F[_], L] extends Functor[XorT[F, L, ?]] {
   override def map[A, B](fa: XorT[F, L, A])(f: A => B): XorT[F, L, B] = fa map f
 }
 
-private[data] trait XorTMonadError[F[_], L] extends MonadError[XorT[F, ?, ?], L] with XorTFunctor[F, L] {
+private[data] trait XorTMonadError[F[_], L] extends MonadError[XorT[F, L, ?], L] with XorTFunctor[F, L] {
   implicit val F: Monad[F]
   def pure[A](a: A): XorT[F, L, A] = XorT.pure[F, L, A](a)
   def flatMap[A, B](fa: XorT[F, L, A])(f: A => XorT[F, L, B]): XorT[F, L, B] = fa flatMap f

--- a/core/src/main/scala/cats/std/function.scala
+++ b/core/src/main/scala/cats/std/function.scala
@@ -33,8 +33,8 @@ trait Function1Instances {
         fa.compose(f)
     }
 
-  implicit def function1Covariant[T1]: MonadReader[? => ?, T1] =
-    new MonadReader[? => ?, T1] {
+  implicit def function1Covariant[T1]: MonadReader[T1 => ?, T1] =
+    new MonadReader[T1 => ?, T1] {
       def pure[R](r: R): T1 => R = _ => r
 
       def flatMap[R1, R2](fa: T1 => R1)(f: R1 => T1 => R2): T1 => R2 =

--- a/core/src/main/scala/cats/std/future.scala
+++ b/core/src/main/scala/cats/std/future.scala
@@ -8,8 +8,8 @@ import scala.concurrent.duration.FiniteDuration
 
 trait FutureInstances extends FutureInstances1 {
 
-  implicit def futureInstance(implicit ec: ExecutionContext): MonadError[Lambda[(E, A) => Future[A]], Throwable] with CoflatMap[Future] =
-    new FutureCoflatMap with MonadError[Lambda[(E, A) => Future[A]], Throwable]{
+  implicit def futureInstance(implicit ec: ExecutionContext): MonadError[Future, Throwable] with CoflatMap[Future] =
+    new FutureCoflatMap with MonadError[Future, Throwable]{
       def pure[A](x: A): Future[A] = Future.successful(x)
 
       override def pureEval[A](x: Eval[A]): Future[A] = Future(x.value)

--- a/js/src/test/scala/cats/tests/FutureTests.scala
+++ b/js/src/test/scala/cats/tests/FutureTests.scala
@@ -43,6 +43,6 @@ class FutureTests extends CatsSuite {
   implicit val nonFatalArbitrary: Arbitrary[Throwable] =
     Arbitrary(arbitrary[Exception].map(identity))
 
-  checkAll("Future[Int]", MonadErrorTests[Lambda[(E, A) => Future[A]], Throwable].monadError[Int, Int, Int])
+  checkAll("Future[Int]", MonadErrorTests[Future, Throwable].monadError[Int, Int, Int])
   checkAll("Future[Int]", ComonadTests[Future].comonad[Int, Int, Int])
 }

--- a/jvm/src/test/scala/cats/tests/FutureTests.scala
+++ b/jvm/src/test/scala/cats/tests/FutureTests.scala
@@ -41,6 +41,6 @@ class FutureTests extends CatsSuite {
   implicit val nonFatalArbitrary: Arbitrary[Throwable] =
     Arbitrary(arbitrary[Exception].map(identity))
 
-  checkAll("Future[Int]", MonadErrorTests[Lambda[(E, A) => Future[A]], Throwable].monadError[Int, Int, Int])
+  checkAll("Future[Int]", MonadErrorTests[Future, Throwable].monadError[Int, Int, Int])
   checkAll("Future[Int]", ComonadTests[Future].comonad[Int, Int, Int])
 }

--- a/laws/src/main/scala/cats/laws/MonadErrorLaws.scala
+++ b/laws/src/main/scala/cats/laws/MonadErrorLaws.scala
@@ -2,20 +2,20 @@ package cats
 package laws
 
 // Taken from http://functorial.com/psc-pages/docs/Control/Monad/Error/Class/index.html
-trait MonadErrorLaws[F[_, _], E] extends MonadLaws[F[E, ?]] {
+trait MonadErrorLaws[F[_], E] extends MonadLaws[F] {
   implicit override def F: MonadError[F, E]
 
-  def monadErrorLeftZero[A, B](e: E, f: A => F[E, B]): IsEq[F[E, B]] =
+  def monadErrorLeftZero[A, B](e: E, f: A => F[B]): IsEq[F[B]] =
     F.flatMap(F.raiseError[A](e))(f) <-> F.raiseError[B](e)
 
-  def monadErrorHandle[A](e: E, f: E => F[E, A]): IsEq[F[E, A]] =
+  def monadErrorHandle[A](e: E, f: E => F[A]): IsEq[F[A]] =
     F.handleError(F.raiseError[A](e))(f) <-> f(e)
 
-  def monadErrorPure[A](a: A, f: E => F[E, A]): IsEq[F[E, A]] =
+  def monadErrorPure[A](a: A, f: E => F[A]): IsEq[F[A]] =
     F.handleError(F.pure(a))(f) <-> F.pure(a)
 }
 
 object MonadErrorLaws {
-  def apply[F[_, _], E](implicit ev: MonadError[F, E]): MonadErrorLaws[F, E] =
+  def apply[F[_], E](implicit ev: MonadError[F, E]): MonadErrorLaws[F, E] =
     new MonadErrorLaws[F, E] { def F: MonadError[F, E] = ev }
 }

--- a/laws/src/main/scala/cats/laws/MonadReaderLaws.scala
+++ b/laws/src/main/scala/cats/laws/MonadReaderLaws.scala
@@ -2,23 +2,23 @@ package cats
 package laws
 
 // Taken from http://functorial.com/psc-pages/docs/Control/Monad/Reader/Class/index.html
-trait MonadReaderLaws[F[_, _], R] extends MonadLaws[F[R, ?]] {
+trait MonadReaderLaws[F[_], R] extends MonadLaws[F] {
   implicit override def F: MonadReader[F, R]
 
-  val monadReaderAskIdempotent: IsEq[F[R, R]] =
+  val monadReaderAskIdempotent: IsEq[F[R]] =
     F.flatMap(F.ask)(_ => F.ask) <-> F.ask
 
-  def monadReaderLocalAsk(f: R => R): IsEq[F[R, R]] =
+  def monadReaderLocalAsk(f: R => R): IsEq[F[R]] =
     F.local(f)(F.ask) <-> F.map(F.ask)(f)
 
-  def monadReaderLocalPure[A](a: A, f: R => R): IsEq[F[R, A]] =
+  def monadReaderLocalPure[A](a: A, f: R => R): IsEq[F[A]] =
     F.local(f)(F.pure(a)) <-> F.pure(a)
 
-  def monadReaderLocalFlatMap[A, B](fra: F[R, A], f: A => F[R, B], g: R => R): IsEq[F[R, B]] =
+  def monadReaderLocalFlatMap[A, B](fra: F[A], f: A => F[B], g: R => R): IsEq[F[B]] =
     F.local(g)(F.flatMap(fra)(f)) <-> F.flatMap(F.local(g)(fra))(a => F.local(g)(f(a)))
 }
 
 object MonadReaderLaws {
-  def apply[F[_, _], R](implicit FR: MonadReader[F, R]): MonadReaderLaws[F, R] =
+  def apply[F[_], R](implicit FR: MonadReader[F, R]): MonadReaderLaws[F, R] =
     new MonadReaderLaws[F, R] { def F: MonadReader[F, R] = FR }
 }

--- a/laws/src/main/scala/cats/laws/MonadStateLaws.scala
+++ b/laws/src/main/scala/cats/laws/MonadStateLaws.scala
@@ -2,23 +2,23 @@ package cats
 package laws
 
 // Taken from http://functorial.com/psc-pages/docs/Control/Monad/State/Class/index.html
-trait MonadStateLaws[F[_, _], S] extends MonadLaws[F[S, ?]] {
+trait MonadStateLaws[F[_], S] extends MonadLaws[F] {
   implicit override def F: MonadState[F, S]
 
-  val monadStateGetIdempotent: IsEq[F[S, S]] =
+  val monadStateGetIdempotent: IsEq[F[S]] =
     F.flatMap(F.get)(_ => F.get) <-> F.get
 
-  def monadStateSetTwice(s: S, t: S): IsEq[F[S, Unit]] =
+  def monadStateSetTwice(s: S, t: S): IsEq[F[Unit]] =
     F.flatMap(F.set(s))(_ => F.set(t)) <-> F.set(t)
 
-  def monadStateSetGet(s: S): IsEq[F[S, S]] =
+  def monadStateSetGet(s: S): IsEq[F[S]] =
     F.flatMap(F.set(s))(_ => F.get) <-> F.flatMap(F.set(s))(_ => F.pure(s))
 
-  val monadStateGetSet: IsEq[F[S, Unit]] =
+  val monadStateGetSet: IsEq[F[Unit]] =
     F.flatMap(F.get)(F.set) <-> F.pure(())
 }
 
 object MonadStateLaws {
-  def apply[F[_, _], S](implicit FS: MonadState[F, S]): MonadStateLaws[F, S] =
+  def apply[F[_], S](implicit FS: MonadState[F, S]): MonadStateLaws[F, S] =
     new MonadStateLaws[F, S] { def F: MonadState[F, S] = FS }
 }

--- a/laws/src/main/scala/cats/laws/discipline/Eq.scala
+++ b/laws/src/main/scala/cats/laws/discipline/Eq.scala
@@ -41,4 +41,8 @@ object eq {
       eqSA.eqv(f, g) && eqA.eqv(f.empty, g.empty)
     }
   }
+
+  implicit val unitEq: Eq[Unit] = new Eq[Unit] {
+    def eqv(a: Unit, b: Unit): Boolean = true
+  }
 }

--- a/laws/src/main/scala/cats/laws/discipline/MonadErrorTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/MonadErrorTests.scala
@@ -5,20 +5,20 @@ package discipline
 import org.scalacheck.{Arbitrary, Prop}
 import org.scalacheck.Prop.forAll
 
-trait MonadErrorTests[F[_, _], E] extends MonadTests[F[E, ?]] {
+trait MonadErrorTests[F[_], E] extends MonadTests[F] {
   def laws: MonadErrorLaws[F, E]
 
-  implicit def arbitraryK: ArbitraryK[F[E, ?]]
-  implicit def eqK: EqK[F[E, ?]]
+  implicit def arbitraryK: ArbitraryK[F]
+  implicit def eqK: EqK[F]
 
   implicit def arbitraryE: Arbitrary[E]
   implicit def eqE: Eq[E]
 
   def monadError[A: Arbitrary: Eq, B: Arbitrary: Eq, C: Arbitrary: Eq]: RuleSet = {
-    implicit def ArbFEA: Arbitrary[F[E, A]] = arbitraryK.synthesize[A]
-    implicit def ArbFEB: Arbitrary[F[E, B]] = arbitraryK.synthesize[B]
-    implicit def EqFEA: Eq[F[E, A]] = eqK.synthesize[A]
-    implicit def EqFEB: Eq[F[E, B]] = eqK.synthesize[B]
+    implicit def ArbFEA: Arbitrary[F[A]] = arbitraryK.synthesize[A]
+    implicit def ArbFEB: Arbitrary[F[B]] = arbitraryK.synthesize[B]
+    implicit def EqFEA: Eq[F[A]] = eqK.synthesize[A]
+    implicit def EqFEB: Eq[F[B]] = eqK.synthesize[B]
 
     new RuleSet {
       def name: String = "monadError"
@@ -34,12 +34,12 @@ trait MonadErrorTests[F[_, _], E] extends MonadTests[F[E, ?]] {
 }
 
 object MonadErrorTests {
-  def apply[F[_, _], E: Arbitrary: Eq](implicit FE: MonadError[F, E], ArbKFE: ArbitraryK[F[E, ?]], EqKFE: EqK[F[E, ?]]): MonadErrorTests[F, E] =
+  def apply[F[_], E: Arbitrary: Eq](implicit FE: MonadError[F, E], ArbKF: ArbitraryK[F], EqKF: EqK[F]): MonadErrorTests[F, E] =
     new MonadErrorTests[F, E] {
       def arbitraryE: Arbitrary[E] = implicitly[Arbitrary[E]]
-      def arbitraryK: ArbitraryK[F[E, ?]] = ArbKFE
+      def arbitraryK: ArbitraryK[F] = ArbKF
       def eqE: Eq[E] = Eq[E]
-      def eqK: EqK[F[E, ?]] = EqKFE
+      def eqK: EqK[F] = EqKF
       def laws: MonadErrorLaws[F, E] = MonadErrorLaws[F, E]
     }
 }

--- a/laws/src/main/scala/cats/laws/discipline/MonadReaderTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/MonadReaderTests.scala
@@ -5,22 +5,22 @@ package discipline
 import org.scalacheck.{Arbitrary, Prop}
 import org.scalacheck.Prop.forAll
 
-trait MonadReaderTests[F[_, _], R] extends MonadTests[F[R, ?]] {
+trait MonadReaderTests[F[_], R] extends MonadTests[F] {
   def laws: MonadReaderLaws[F, R]
 
-  implicit def arbitraryK: ArbitraryK[F[R, ?]]
-  implicit def eqK: EqK[F[R, ?]]
+  implicit def arbitraryK: ArbitraryK[F]
+  implicit def eqK: EqK[F]
 
   def monadReader[A: Arbitrary: Eq, B: Arbitrary: Eq, C: Arbitrary: Eq](implicit
-    ArbF: ArbitraryK[F[R, ?]],
-    EqFA: Eq[F[R, A]],
-    EqFB: Eq[F[R, B]],
-    EqFC: Eq[F[R, C]],
-    EqFR: Eq[F[R, R]],
+    ArbF: ArbitraryK[F],
+    EqFA: Eq[F[A]],
+    EqFB: Eq[F[B]],
+    EqFC: Eq[F[C]],
+    EqFR: Eq[F[R]],
     ArbE: Arbitrary[R]
   ): RuleSet = {
-    implicit def ArbFRA: Arbitrary[F[R, A]] = ArbF.synthesize[A]
-    implicit def ArbFRB: Arbitrary[F[R, B]] = ArbF.synthesize[B]
+    implicit def ArbFRA: Arbitrary[F[A]] = ArbF.synthesize[A]
+    implicit def ArbFRB: Arbitrary[F[B]] = ArbF.synthesize[B]
 
     new RuleSet {
       def name: String = "monadReader"
@@ -37,10 +37,10 @@ trait MonadReaderTests[F[_, _], R] extends MonadTests[F[R, ?]] {
 }
 
 object MonadReaderTests {
-  def apply[F[_, _], R](implicit FR: MonadReader[F, R], arbKFR: ArbitraryK[F[R, ?]], eqKFR: EqK[F[R, ?]]): MonadReaderTests[F, R] =
+  def apply[F[_], R](implicit FR: MonadReader[F, R], arbKFR: ArbitraryK[F], eqKFR: EqK[F]): MonadReaderTests[F, R] =
     new MonadReaderTests[F, R] {
-      def arbitraryK: ArbitraryK[F[R, ?]] = arbKFR
-      def eqK: EqK[F[R, ?]] = eqKFR
+      def arbitraryK: ArbitraryK[F] = arbKFR
+      def eqK: EqK[F] = eqKFR
       def laws: MonadReaderLaws[F, R] = MonadReaderLaws[F, R]
     }
 }

--- a/laws/src/main/scala/cats/laws/discipline/MonadStateTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/MonadStateTests.scala
@@ -2,26 +2,27 @@ package cats
 package laws
 package discipline
 
+import eq.unitEq
 import org.scalacheck.{Arbitrary, Prop}
 import org.scalacheck.Prop.forAll
 
-trait MonadStateTests[F[_, _], S] extends MonadTests[F[S, ?]] {
+trait MonadStateTests[F[_], S] extends MonadTests[F] {
   def laws: MonadStateLaws[F, S]
 
-  implicit def arbitraryK: ArbitraryK[F[S, ?]]
-  implicit def eqK: EqK[F[S, ?]]
+  implicit def arbitraryK: ArbitraryK[F]
+  implicit def eqK: EqK[F]
 
   def monadState[A: Arbitrary: Eq, B: Arbitrary: Eq, C: Arbitrary: Eq](implicit
-    ArbF: ArbitraryK[F[S, ?]],
-    EqFA: Eq[F[S, A]],
-    EqFB: Eq[F[S, B]],
-    EqFC: Eq[F[S, C]],
-    EqFS: Eq[F[S, S]],
-    EqFU: Eq[F[S, Unit]],
+    EqS: Eq[S],
     ArbS: Arbitrary[S]
   ): RuleSet = {
-    implicit def ArbFEA: Arbitrary[F[S, A]] = ArbF.synthesize[A]
-    implicit def ArbFEB: Arbitrary[F[S, B]] = ArbF.synthesize[B]
+    implicit def ArbFEA: Arbitrary[F[A]] = arbitraryK.synthesize[A]
+    implicit def ArbFEB: Arbitrary[F[B]] = arbitraryK.synthesize[B]
+    implicit def EqFA: Eq[F[A]] = eqK.synthesize[A]
+    implicit def EqFB: Eq[F[B]] = eqK.synthesize[B]
+    implicit def EqFC: Eq[F[C]] = eqK.synthesize[C]
+    implicit def EqFS: Eq[F[S]] = eqK.synthesize[S]
+    implicit def EqFUnit: Eq[F[Unit]] = eqK.synthesize[Unit]
 
     new RuleSet {
       def name: String = "monadState"
@@ -38,10 +39,10 @@ trait MonadStateTests[F[_, _], S] extends MonadTests[F[S, ?]] {
 }
 
 object MonadStateTests {
-  def apply[F[_, _], S](implicit FS: MonadState[F, S], arbKFS: ArbitraryK[F[S, ?]], eqKFS: EqK[F[S, ?]]): MonadStateTests[F, S] =
+  def apply[F[_], S](implicit FS: MonadState[F, S], arbKFS: ArbitraryK[F], eqKFS: EqK[F]): MonadStateTests[F, S] =
     new MonadStateTests[F, S] {
-      def arbitraryK: ArbitraryK[F[S, ?]] = arbKFS
-      def eqK: EqK[F[S, ?]] = eqKFS
+      def arbitraryK: ArbitraryK[F] = arbKFS
+      def eqK: EqK[F] = eqKFS
       def laws: MonadStateLaws[F, S] = MonadStateLaws[F, S]
     }
 }

--- a/state/src/main/scala/cats/state/StateT.scala
+++ b/state/src/main/scala/cats/state/StateT.scala
@@ -99,8 +99,8 @@ object StateT extends StateTInstances {
 }
 
 sealed abstract class StateTInstances extends StateTInstances0 {
-  implicit def stateTMonadState[F[_], S](implicit F: Monad[F]): MonadState[StateT[F, ?, ?], S] =
-    new MonadState[StateT[F, ?, ?], S] {
+  implicit def stateTMonadState[F[_], S](implicit F: Monad[F]): MonadState[StateT[F, S, ?], S] =
+    new MonadState[StateT[F, S, ?], S] {
       def pure[A](a: A): StateT[F, S, A] =
         StateT.pure(a)
 
@@ -117,7 +117,7 @@ sealed abstract class StateTInstances extends StateTInstances0 {
 }
 
 sealed abstract class StateTInstances0 {
-  implicit def stateMonadState[S]: MonadState[State[?, ?], S] =
+  implicit def stateMonadState[S]: MonadState[State[S, ?], S] =
     StateT.stateTMonadState[Trampoline, S]
 }
 

--- a/state/src/test/scala/cats/state/StateTTests.scala
+++ b/state/src/test/scala/cats/state/StateTTests.scala
@@ -39,8 +39,8 @@ class StateTTests extends CatsSuite {
     }
   })
 
-  checkAll("StateT[Option, Int, Int]", MonadStateTests[StateT[Option, ?, ?], Int].monadState[Int, Int, Int])
-  checkAll("MonadState[StateT[Option, ?, ?], Int]", SerializableTests.serializable(MonadState[StateT[Option, ?, ?], Int]))
+  checkAll("StateT[Option, Int, Int]", MonadStateTests[StateT[Option, Int, ?], Int].monadState[Int, Int, Int])
+  checkAll("MonadState[StateT[Option, ?, ?], Int]", SerializableTests.serializable(MonadState[StateT[Option, Int, ?], Int]))
 }
 
 object StateTTests {

--- a/tests/src/test/scala/cats/tests/FunctionTests.scala
+++ b/tests/src/test/scala/cats/tests/FunctionTests.scala
@@ -10,8 +10,8 @@ class FunctionTests extends CatsSuite {
   checkAll("Function0[Int]", BimonadTests[Function0].bimonad[Int, Int, Int])
   checkAll("Bimonad[Function0]", SerializableTests.serializable(Comonad[Function0]))
 
-  checkAll("Function1[Int, Int]", MonadReaderTests[Function1, Int].monadReader[Int, Int, Int])
-  checkAll("MonadReader[Function1, Int]", SerializableTests.serializable(MonadReader[Function1, Int]))
+  checkAll("Function1[Int, Int]", MonadReaderTests[Int => ?, Int].monadReader[Int, Int, Int])
+  checkAll("MonadReader[Int => ?, Int]", SerializableTests.serializable(MonadReader[Int => ?, Int]))
 
   checkAll("Function1[Int, Int]", ArrowTests[Function1].arrow[Int, Int, Int, Int, Int, Int])
   checkAll("Arrow[Function1]", SerializableTests.serializable(Arrow[Function1]))

--- a/tests/src/test/scala/cats/tests/KleisliTests.scala
+++ b/tests/src/test/scala/cats/tests/KleisliTests.scala
@@ -30,8 +30,8 @@ class KleisliTests extends CatsSuite {
 
   {
     implicit val kleisliMonadReader = Kleisli.kleisliMonadReader[Option, Int]
-    checkAll("Kleisli[Option, Int, Int]", MonadReaderTests[Kleisli[Option, ?, ?], Int].monadReader[Int, Int, Int])
-    checkAll("MonadReader[Kleisli[Option, ?, ?], Int]", SerializableTests.serializable(MonadReader[Kleisli[Option, ?, ?], Int]))
+    checkAll("Kleisli[Option, Int, Int]", MonadReaderTests[Kleisli[Option, Int, ?], Int].monadReader[Int, Int, Int])
+    checkAll("MonadReader[Kleisli[Option, ?, ?], Int]", SerializableTests.serializable(MonadReader[Kleisli[Option, Int, ?], Int]))
   }
 
   {

--- a/tests/src/test/scala/cats/tests/XorTTests.scala
+++ b/tests/src/test/scala/cats/tests/XorTTests.scala
@@ -8,9 +8,9 @@ import cats.laws.discipline.arbitrary._
 import org.scalacheck.Prop.forAll
 
 class XorTTests extends CatsSuite {
-  checkAll("XorT[List, String, Int]", MonadErrorTests[XorT[List, ?, ?], String].monadError[Int, Int, Int])
+  checkAll("XorT[List, String, Int]", MonadErrorTests[XorT[List, String, ?], String].monadError[Int, Int, Int])
   checkAll("XorT[List, String, Int]", MonoidKTests[XorT[List, String, ?]].monoidK[Int])
-  checkAll("MonadError[XorT[List, ?, ?]]", SerializableTests.serializable(MonadError[XorT[List, ?, ?], String]))
+  checkAll("MonadError[XorT[List, ?, ?]]", SerializableTests.serializable(MonadError[XorT[List, String, ?], String]))
 
   test("toValidated")(check {
     forAll { (xort: XorT[List, String, Int]) =>

--- a/tests/src/test/scala/cats/tests/XorTests.scala
+++ b/tests/src/test/scala/cats/tests/XorTests.scala
@@ -15,8 +15,8 @@ import scala.util.Try
 class XorTests extends CatsSuite {
   checkAll("Xor[String, Int]", algebra.laws.GroupLaws[Xor[String, Int]].monoid)
 
-  checkAll("Xor[String, Int]", MonadErrorTests[Xor, String].monadError[Int, Int, Int])
-  checkAll("MonadError[Xor, String]", SerializableTests.serializable(MonadError[Xor, String]))
+  checkAll("Xor[String, Int]", MonadErrorTests[Xor[String, ?], String].monadError[Int, Int, Int])
+  checkAll("MonadError[Xor, String]", SerializableTests.serializable(MonadError[Xor[String, ?], String]))
 
   checkAll("Xor[String, Int] with Option", TraverseTests[Xor[String, ?]].traverse[Int, Int, Int, Int, Option, Option])
   checkAll("Traverse[Xor[String,?]]", SerializableTests.serializable(Traverse[Xor[String, ?]]))


### PR DESCRIPTION
I was working with MonadError today and the `F[_, _]` approach made me use
quite a few type lambdas when I was working with types like Future/Task.
Since the error type is already encoded as another type parameter, as
far as I know we don't really lose anything by using a type constructor
with a single parameter for `F`.

It's quite possible that there's a reason for using `F[_, _]`. If anyone
knows of one, please speak up.