### PR TITLE
Add laws for Bifunctor

### DIFF
--- a/laws/src/main/scala/cats/laws/BifunctorLaws.scala
+++ b/laws/src/main/scala/cats/laws/BifunctorLaws.scala
@@ -1,0 +1,25 @@
+package cats.laws
+
+import cats.functor.Bifunctor
+import cats.syntax.bifunctor._
+
+/**
+ * Laws that must be obeyed by any `Bifunctor`.
+ */
+trait BifunctorLaws[F[_, _]] {
+  implicit def F: Bifunctor[F]
+
+  def bifunctorIdentity[A, B](fa: F[A, B]): IsEq[F[A, B]] =
+    fa.bimap(identity, identity) <-> fa
+
+  def bifunctorComposition[A, B, C, X, Y, Z](fa: F[A, X], f: A => B, f2: B => C, g: X => Y, g2: Y => Z): IsEq[F[C, Z]] = {
+    fa.bimap(f, g).bimap(f2, g2) <-> fa.bimap(f andThen f2, g andThen g2)
+  }
+}
+
+object BifunctorLaws {
+  def apply[F[_,_]](implicit ev: Bifunctor[F]): BifunctorLaws[F] =
+    new BifunctorLaws[F] {
+      def F: Bifunctor[F] = ev
+    }
+}


### PR DESCRIPTION
Added 2 laws for Bifunctor

BifunctorIdentity enforces that applying the identity function via bimap returns the original value

BifunctorComposition enforces that applying functions via consecutive applications of bimap returns the same result as applying the composition of the functions via a single application of bimap

Fixes #557 