### PR TITLE
Bump scalacheck version to 1.12.5

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -48,7 +48,7 @@ lazy val commonJvmSettings = Seq(
 lazy val catsSettings = buildSettings ++ commonSettings ++ publishSettings ++ scoverageSettings
 
 lazy val disciplineDependencies = Seq(
-  libraryDependencies += "org.scalacheck" %%% "scalacheck" % "1.12.4",
+  libraryDependencies += "org.scalacheck" %%% "scalacheck" % "1.12.5",
   libraryDependencies += "org.typelevel" %%% "discipline" % "0.4"
 )
 


### PR DESCRIPTION
Increments scalacheck to version 1.12.5 fixing an annoying bug https://github.com/rickynils/scalacheck/issues/173 whereby scalacheck was preventing test arguments from being passed to the test runner.