### PR TITLE
Add syntax test for |@| on FreeApplicative

### DIFF
--- a/free/src/test/scala/cats/free/FreeApplicativeTests.scala
+++ b/free/src/test/scala/cats/free/FreeApplicativeTests.scala
@@ -65,4 +65,14 @@ class FreeApplicativeTests extends CatsSuite {
       }
     r1.foldMap(nt) should === (r2.foldMap(nt))
   }
+
+  // Ensure that syntax and implicit resolution work as expected.
+  // If it compiles, it passes the "test".
+  object SyntaxTests {
+
+    // fixed by #568
+    val fli1 = FreeApplicative.lift[List, Int](List(1, 3, 5, 7))
+    val fli2 = FreeApplicative.lift[List, Int](List(1, 3, 5, 7))
+    (fli1 |@| fli2).map(_ + _)
+  }
 }


### PR DESCRIPTION
This is a test that is fixed by #568. I just thought it might be nice to have a regression test for the specific case that was discovered to not work before that PR.

Big thanks to @stew for the fix and @smungee for reporting the issue.