### PR TITLE
Add FreeApplicative.analyze

### DIFF
--- a/free/src/main/scala/cats/free/FreeApplicative.scala
+++ b/free/src/main/scala/cats/free/FreeApplicative.scala
@@ -2,6 +2,7 @@ package cats
 package free
 
 import cats.arrow.NaturalTransformation
+import cats.data.Const
 
 /** Applicative Functor for Free */
 sealed abstract class FreeApplicative[F[_], A] extends Product with Serializable { self =>
@@ -45,6 +46,12 @@ sealed abstract class FreeApplicative[F[_], A] extends Product with Serializable
         def apply[B](fa: F[B]): FA[G, B] = lift(f(fa))
       }
     }
+
+  /** Interpret this algebra into a Monoid */
+  def analyze[M:Monoid](f: F ~> λ[α => M]): M =
+    foldMap[Const[M, ?]](new (F ~> Const[M, ?]) {
+      def apply[X](x: F[X]): Const[M,X] = Const(f(x))
+    }).getConst
 
   /** Compile this FreeApplicative algebra into a Free algebra. */
   final def monad: Free[F, A] =

--- a/free/src/test/scala/cats/free/FreeApplicativeTests.scala
+++ b/free/src/test/scala/cats/free/FreeApplicativeTests.scala
@@ -4,6 +4,7 @@ package free
 import cats.arrow.NaturalTransformation
 import cats.laws.discipline.{ArbitraryK, ApplicativeTests, SerializableTests}
 import cats.tests.CatsSuite
+import cats.data.Const
 
 import org.scalacheck.{Arbitrary, Gen}
 
@@ -74,5 +75,18 @@ class FreeApplicativeTests extends CatsSuite {
     val fli1 = FreeApplicative.lift[List, Int](List(1, 3, 5, 7))
     val fli2 = FreeApplicative.lift[List, Int](List(1, 3, 5, 7))
     (fli1 |@| fli2).map(_ + _)
+  }
+
+  test("FreeApplicative#analyze") {
+    type G[A] = List[Int]
+    val countingNT = new NaturalTransformation[List, G] {
+      def apply[A](la: List[A]): G[A] = List(la.length)
+    }
+
+    val fli1 = FreeApplicative.lift[List, Int](List(1, 3, 5, 7))
+    fli1.analyze[G[Int]](countingNT) should === (List(4))
+
+    val fli2 = FreeApplicative.lift[List, Int](List.empty)
+    fli2.analyze[G[Int]](countingNT) should ===(List(0))
   }
 }


### PR DESCRIPTION
In trying to port the FreeApplicative example from @jdegoes's ScalaWorld
2015 talk[1] to cats, I found that cats does not have a
FreeApplicative.analyze method, which allows us to compile a
FreeApplicative into a monoid.

This commit adds FreeApplicative.analyze, as well as a new test for
this, as per a discussion on gitter [2].

[1] https://github.com/jdegoes/scalaworld-2015/blob/master/src/main/scala/asmfree.scala#L32
[2] https://gitter.im/non/cats?at=561ed5373a0d354869528194