### PR TITLE
Improve the type signature of orElse

### DIFF
--- a/core/src/main/scala/cats/data/Xor.scala
+++ b/core/src/main/scala/cats/data/Xor.scala
@@ -38,8 +38,10 @@ sealed abstract class Xor[+A, +B] extends Product with Serializable {
 
   def getOrElse[BB >: B](default: => BB): BB = fold(_ => default, identity)
 
-  def orElse[AA >: A, BB >: B](fallback: => AA Xor BB): AA Xor BB =
-    fold(_ => fallback, _ => this)
+  def orElse[C, BB >: B](fallback: => C Xor BB): C Xor BB = this match {
+    case Xor.Left(_)      => fallback
+    case r @ Xor.Right(_) => r
+  }
 
   def recover[BB >: B](pf: PartialFunction[A, BB]): A Xor BB = this match {
     case Xor.Left(a) if pf.isDefinedAt(a) => Xor.right(pf(a))


### PR DESCRIPTION
The whole point of orElse is to drop the left hand value of a Disjunction, no sense having the type that is dropped influence the resulting type.

Let me know if I am missing something! :-)