### PR TITLE
Rename *Aux helper classes to *Curried

### DIFF
--- a/core/src/main/scala/cats/data/OptionT.scala
+++ b/core/src/main/scala/cats/data/OptionT.scala
@@ -97,8 +97,8 @@ object OptionT extends OptionTInstances {
   /**
    * Transforms an `Option` into an `OptionT`, lifted into the specified `Applicative`.
    *
-   * Note: The return type is a FromOptionCurried[F], which has an apply method on it, allowing
-   * you to call fromOption like this:
+   * Note: The return type is a FromOptionPartiallyApplied[F], which has an apply method
+   * on it, allowing you to call fromOption like this:
    * {{{
    * val t: Option[Int] = ...
    * val x: OptionT[List, Int] = fromOption[List](t)
@@ -106,9 +106,9 @@ object OptionT extends OptionTInstances {
    *
    * The reason for the indirection is to emulate currying type parameters.
    */
-  def fromOption[F[_]]: FromOptionCurried[F] = new FromOptionCurried
+  def fromOption[F[_]]: FromOptionPartiallyApplied[F] = new FromOptionPartiallyApplied
 
-  class FromOptionCurried[F[_]] private[OptionT] {
+  class FromOptionPartiallyApplied[F[_]] private[OptionT] {
     def apply[A](value: Option[A])(implicit F: Applicative[F]): OptionT[F, A] =
       OptionT(F.pure(value))
   }

--- a/core/src/main/scala/cats/data/OptionT.scala
+++ b/core/src/main/scala/cats/data/OptionT.scala
@@ -97,7 +97,7 @@ object OptionT extends OptionTInstances {
   /**
    * Transforms an `Option` into an `OptionT`, lifted into the specified `Applicative`.
    *
-   * Note: The return type is a FromOptionAux[F], which has an apply method on it, allowing
+   * Note: The return type is a FromOptionCurried[F], which has an apply method on it, allowing
    * you to call fromOption like this:
    * {{{
    * val t: Option[Int] = ...
@@ -106,9 +106,9 @@ object OptionT extends OptionTInstances {
    *
    * The reason for the indirection is to emulate currying type parameters.
    */
-  def fromOption[F[_]]: FromOptionAux[F] = new FromOptionAux
+  def fromOption[F[_]]: FromOptionCurried[F] = new FromOptionCurried
 
-  class FromOptionAux[F[_]] private[OptionT] {
+  class FromOptionCurried[F[_]] private[OptionT] {
     def apply[A](value: Option[A])(implicit F: Applicative[F]): OptionT[F, A] =
       OptionT(F.pure(value))
   }

--- a/core/src/main/scala/cats/data/Validated.scala
+++ b/core/src/main/scala/cats/data/Validated.scala
@@ -231,9 +231,9 @@ trait ValidatedFunctions {
    * val result: Validated[NumberFormatException, Int] = fromTryCatch[NumberFormatException] { "foo".toInt }
    * }}}
    */
-  def fromTryCatch[T >: Null <: Throwable]: FromTryCatchAux[T] = new FromTryCatchAux[T]
+  def fromTryCatch[T >: Null <: Throwable]: FromTryCatchCurried[T] = new FromTryCatchCurried[T]
 
-  final class FromTryCatchAux[T] private[ValidatedFunctions] {
+  final class FromTryCatchCurried[T] private[ValidatedFunctions] {
     def apply[A](f: => A)(implicit T: ClassTag[T]): Validated[T, A] = {
       try {
         valid(f)

--- a/core/src/main/scala/cats/data/Validated.scala
+++ b/core/src/main/scala/cats/data/Validated.scala
@@ -231,9 +231,9 @@ trait ValidatedFunctions {
    * val result: Validated[NumberFormatException, Int] = fromTryCatch[NumberFormatException] { "foo".toInt }
    * }}}
    */
-  def fromTryCatch[T >: Null <: Throwable]: FromTryCatchCurried[T] = new FromTryCatchCurried[T]
+  def fromTryCatch[T >: Null <: Throwable]: FromTryCatchPartiallyApplied[T] = new FromTryCatchPartiallyApplied[T]
 
-  final class FromTryCatchCurried[T] private[ValidatedFunctions] {
+  final class FromTryCatchPartiallyApplied[T] private[ValidatedFunctions] {
     def apply[A](f: => A)(implicit T: ClassTag[T]): Validated[T, A] = {
       try {
         valid(f)

--- a/core/src/main/scala/cats/data/Xor.scala
+++ b/core/src/main/scala/cats/data/Xor.scala
@@ -220,10 +220,10 @@ trait XorFunctions {
    * val result: NumberFormatException Xor Int = fromTryCatch[NumberFormatException] { "foo".toInt }
    * }}}
    */
-  def fromTryCatch[T >: Null <: Throwable]: FromTryCatchCurried[T] =
-    new FromTryCatchCurried[T]
+  def fromTryCatch[T >: Null <: Throwable]: FromTryCatchPartiallyApplied[T] =
+    new FromTryCatchPartiallyApplied[T]
 
-  final class FromTryCatchCurried[T] private[XorFunctions] {
+  final class FromTryCatchPartiallyApplied[T] private[XorFunctions] {
     def apply[A](f: => A)(implicit T: ClassTag[T]): T Xor A =
       try {
         right(f)

--- a/core/src/main/scala/cats/data/Xor.scala
+++ b/core/src/main/scala/cats/data/Xor.scala
@@ -220,10 +220,10 @@ trait XorFunctions {
    * val result: NumberFormatException Xor Int = fromTryCatch[NumberFormatException] { "foo".toInt }
    * }}}
    */
-  def fromTryCatch[T >: Null <: Throwable]: FromTryCatchAux[T] =
-    new FromTryCatchAux[T]
+  def fromTryCatch[T >: Null <: Throwable]: FromTryCatchCurried[T] =
+    new FromTryCatchCurried[T]
 
-  final class FromTryCatchAux[T] private[XorFunctions] {
+  final class FromTryCatchCurried[T] private[XorFunctions] {
     def apply[A](f: => A)(implicit T: ClassTag[T]): T Xor A =
       try {
         right(f)

--- a/core/src/main/scala/cats/data/XorT.scala
+++ b/core/src/main/scala/cats/data/XorT.scala
@@ -123,8 +123,8 @@ trait XorTFunctions {
 
   /** Transforms an `Xor` into an `XorT`, lifted into the specified `Applicative`.
    *
-   * Note: The return type is a FromXorCurried[F], which has an apply method on it, allowing
-   * you to call fromXor like this:
+   * Note: The return type is a FromXorPartiallyApplied[F], which has an apply method
+   * on it, allowing you to call fromXor like this:
    * {{{
    * val t: Xor[String, Int] = ...
    * val x: XorT[Option, String, Int] = fromXor[Option](t)
@@ -132,9 +132,9 @@ trait XorTFunctions {
    *
    * The reason for the indirection is to emulate currying type parameters.
    */
-  final def fromXor[F[_]]: FromXorCurried[F] = new FromXorCurried
+  final def fromXor[F[_]]: FromXorPartiallyApplied[F] = new FromXorPartiallyApplied
 
-  final class FromXorCurried[F[_]] private[XorTFunctions] {
+  final class FromXorPartiallyApplied[F[_]] private[XorTFunctions] {
     def apply[E, A](xor: Xor[E, A])(implicit F: Applicative[F]): XorT[F, E, A] =
       XorT(F.pure(xor))
   }

--- a/core/src/main/scala/cats/data/XorT.scala
+++ b/core/src/main/scala/cats/data/XorT.scala
@@ -123,7 +123,7 @@ trait XorTFunctions {
 
   /** Transforms an `Xor` into an `XorT`, lifted into the specified `Applicative`.
    *
-   * Note: The return type is a FromXorAux[F], which has an apply method on it, allowing
+   * Note: The return type is a FromXorCurried[F], which has an apply method on it, allowing
    * you to call fromXor like this:
    * {{{
    * val t: Xor[String, Int] = ...
@@ -132,9 +132,9 @@ trait XorTFunctions {
    *
    * The reason for the indirection is to emulate currying type parameters.
    */
-  final def fromXor[F[_]]: FromXorAux[F] = new FromXorAux
+  final def fromXor[F[_]]: FromXorCurried[F] = new FromXorCurried
 
-  final class FromXorAux[F[_]] private[XorTFunctions] {
+  final class FromXorCurried[F[_]] private[XorTFunctions] {
     def apply[E, A](xor: Xor[E, A])(implicit F: Applicative[F]): XorT[F, E, A] =
       XorT(F.pure(xor))
   }


### PR DESCRIPTION
We currently have a few helper classes that have an `Aux` suffix
for emulating currying type parameters. These helper classes have
an `apply` method which allows some type parameters of a function
to be inferred while others need to be specified. @tpolecat has
nice explanation of this trick here:

http://tpolecat.github.io/2015/07/30/infer.html

Unfortunately the suffix `Aux` is an overloaded term that is most
prominently used to provide terser syntax for type refinements, e.g.:

```scala
type Aux[F[_], A, B] = Coyoneda[F, A] { type Pivot = B }
```

I'm wondering if we should use `Curried` instead of `Aux` for classes
that enable type parameter currying. This could make the purpose of
those classes clearer to those who are unfamiliar with this trick.