### PR TITLE
Add test of Bimonad laws for Eval

### DIFF
--- a/tests/src/test/scala/cats/tests/EvalTests.scala
+++ b/tests/src/test/scala/cats/tests/EvalTests.scala
@@ -2,7 +2,8 @@ package cats
 package tests
 
 import scala.math.min
-import cats.laws.discipline.{BimonadTests, SerializableTests}
+
+// TODO: monad laws
 
 class EvalTests extends CatsSuite {
 
@@ -73,8 +74,4 @@ class EvalTests extends CatsSuite {
   test("by-name: Eval.always(_)") {
     runValue(999)(always)(n => n)
   }
-
-  checkAll("Eval[Int]", BimonadTests[Eval].bimonad[Int, Int, Int])
-  checkAll("Bimonad[Eval]", SerializableTests.serializable(Bimonad[Eval]))
-
 }

--- a/tests/src/test/scala/cats/tests/EvalTests.scala
+++ b/tests/src/test/scala/cats/tests/EvalTests.scala
@@ -2,8 +2,7 @@ package cats
 package tests
 
 import scala.math.min
-
-// TODO: monad laws
+import cats.laws.discipline.{BimonadTests, SerializableTests}
 
 class EvalTests extends CatsSuite {
 
@@ -74,4 +73,8 @@ class EvalTests extends CatsSuite {
   test("by-name: Eval.always(_)") {
     runValue(999)(always)(n => n)
   }
+
+  checkAll("Eval[Int]", BimonadTests[Eval].bimonad[Int, Int, Int])
+  checkAll("Bimonad[Eval]", SerializableTests.serializable(Bimonad[Eval]))
+
 }

--- a/tests/src/test/scala/cats/tests/FunctionTests.scala
+++ b/tests/src/test/scala/cats/tests/FunctionTests.scala
@@ -9,7 +9,7 @@ import cats.laws.discipline.arbitrary._
 
 class FunctionTests extends CatsSuite {
   checkAll("Function0[Int]", BimonadTests[Function0].bimonad[Int, Int, Int])
-  checkAll("Bimonad[Function0]", SerializableTests.serializable(Bimonad[Function0]))
+  checkAll("Bimonad[Function0]", SerializableTests.serializable(Comonad[Function0]))
 
   checkAll("Function1[Int, Int]", MonadReaderTests[Int => ?, Int].monadReader[Int, Int, Int])
   checkAll("MonadReader[Int => ?, Int]", SerializableTests.serializable(MonadReader[Int => ?, Int]))

--- a/tests/src/test/scala/cats/tests/FunctionTests.scala
+++ b/tests/src/test/scala/cats/tests/FunctionTests.scala
@@ -9,7 +9,7 @@ import cats.laws.discipline.arbitrary._
 
 class FunctionTests extends CatsSuite {
   checkAll("Function0[Int]", BimonadTests[Function0].bimonad[Int, Int, Int])
-  checkAll("Bimonad[Function0]", SerializableTests.serializable(Comonad[Function0]))
+  checkAll("Bimonad[Function0]", SerializableTests.serializable(Bimonad[Function0]))
 
   checkAll("Function1[Int, Int]", MonadReaderTests[Int => ?, Int].monadReader[Int, Int, Int])
   checkAll("MonadReader[Int => ?, Int]", SerializableTests.serializable(MonadReader[Int => ?, Int]))


### PR DESCRIPTION
* Adds basic law checking for the Eval Bimonad instance.
* Adds a check that the instance is also serializable

Additionally, in Function Tests
* Changes serializable test for Bimonad[Function0] to use Bimonad instance instead of Comonad instance.

Let me know if these make sense or if some additional checks would be better.

Also, just kind of learning the discipline stuff, so if I’ve misunderstood anything about how they work let me know.

Also, my commits got a bit messy and reverted. I can tidy them if needed. It is really just the last two commits - as the middle two commits were reverts.