### PR TITLE
Add two new laws for Bimonad.

### DIFF
--- a/laws/src/main/scala/cats/laws/BimonadLaws.scala
+++ b/laws/src/main/scala/cats/laws/BimonadLaws.scala
@@ -3,6 +3,9 @@ package laws
 
 /**
  * Laws that must be obeyed by any `Bimonad`.
+ *
+ * For more information, see definition 4.1 from this paper:
+ * http://arxiv.org/pdf/0710.1163v3.pdf
  */
 trait BimonadLaws[F[_]] extends MonadLaws[F] with ComonadLaws[F] {
   implicit override def F: Bimonad[F]
@@ -12,6 +15,12 @@ trait BimonadLaws[F[_]] extends MonadLaws[F] with ComonadLaws[F] {
 
   def extractPureIsId[A](fa: F[A]): IsEq[F[A]] =
     F.pure(F.extract(fa)) <-> fa
+
+  def extractFlatMapEntwining[A](ffa: F[F[A]]): IsEq[A] =
+    F.extract(F.flatten(ffa)) <-> F.extract(F.map(ffa)(F.extract))
+
+  def pureCoflatMapEntwining[A](a: A): IsEq[F[F[A]]] =
+    F.coflatten(F.pure(a)) <-> F.map(F.pure(a))(F.pure)
 }
 
 object BimonadLaws {

--- a/laws/src/main/scala/cats/laws/discipline/BimonadTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/BimonadTests.scala
@@ -11,14 +11,18 @@ trait BimonadTests[F[_]] extends MonadTests[F] with ComonadTests[F] {
 
   def bimonad[A: Arbitrary: Eq, B: Arbitrary: Eq, C: Arbitrary: Eq]: RuleSet = {
     implicit val arbfa: Arbitrary[F[A]] = ArbitraryK[F].synthesize[A]
+    implicit val arbffa: Arbitrary[F[F[A]]] = ArbitraryK[F].synthesize[F[A]]
     implicit val eqfa: Eq[F[A]] = EqK[F].synthesize[A]
+    implicit val eqffa: Eq[F[F[A]]] = EqK[F].synthesize[F[A]]
     new RuleSet {
       def name: String = "bimonad"
       def bases: Seq[(String, RuleSet)] = Nil
       def parents: Seq[RuleSet] = Seq(monad[A, B, C], comonad[A, B, C])
       def props: Seq[(String, Prop)] = Seq(
         "pure andThen extract = id" -> forAll(laws.pureExtractIsId[A] _),
-        "extract andThen pure = id" -> forAll(laws.extractPureIsId[A] _)
+        "extract andThen pure = id" -> forAll(laws.extractPureIsId[A] _),
+        "extract/flatMap entwining" -> forAll(laws.extractFlatMapEntwining[A] _),
+        "pure/coflatMap entwining" -> forAll(laws.pureCoflatMapEntwining[A] _)
       )
     }
   }


### PR DESCRIPTION
These laws are taken from this paper:
http://arxiv.org/pdf/0710.1163v3.pdf

Thanks to @jedws and @tpolecat for bringing this up.

We may also want to remove one of our existing
laws (F.pure(F.extract(fa)) <-> fa), but for now
I have left it alone.

This fixes #595 