### PR TITLE
Remove Bimonad law: F.pure(F.extract(fa)) <-> fa

### DIFF
--- a/laws/src/main/scala/cats/laws/BimonadLaws.scala
+++ b/laws/src/main/scala/cats/laws/BimonadLaws.scala
@@ -13,9 +13,6 @@ trait BimonadLaws[F[_]] extends MonadLaws[F] with ComonadLaws[F] {
   def pureExtractIsId[A](a: A): IsEq[A] =
     F.extract(F.pure(a)) <-> a
 
-  def extractPureIsId[A](fa: F[A]): IsEq[F[A]] =
-    F.pure(F.extract(fa)) <-> fa
-
   def extractFlatMapEntwining[A](ffa: F[F[A]]): IsEq[A] =
     F.extract(F.flatten(ffa)) <-> F.extract(F.map(ffa)(F.extract))
 

--- a/laws/src/main/scala/cats/laws/discipline/BimonadTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/BimonadTests.scala
@@ -12,6 +12,7 @@ trait BimonadTests[F[_]] extends MonadTests[F] with ComonadTests[F] {
   def bimonad[A: Arbitrary: Eq, B: Arbitrary: Eq, C: Arbitrary: Eq]: RuleSet = {
     implicit val arbfa: Arbitrary[F[A]] = ArbitraryK[F].synthesize[A]
     implicit val arbffa: Arbitrary[F[F[A]]] = ArbitraryK[F].synthesize[F[A]]
+    implicit val eqfa: Eq[F[A]] = EqK[F].synthesize[A]
     implicit val eqffa: Eq[F[F[A]]] = EqK[F].synthesize[F[A]]
     new RuleSet {
       def name: String = "bimonad"

--- a/laws/src/main/scala/cats/laws/discipline/BimonadTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/BimonadTests.scala
@@ -12,7 +12,6 @@ trait BimonadTests[F[_]] extends MonadTests[F] with ComonadTests[F] {
   def bimonad[A: Arbitrary: Eq, B: Arbitrary: Eq, C: Arbitrary: Eq]: RuleSet = {
     implicit val arbfa: Arbitrary[F[A]] = ArbitraryK[F].synthesize[A]
     implicit val arbffa: Arbitrary[F[F[A]]] = ArbitraryK[F].synthesize[F[A]]
-    implicit val eqfa: Eq[F[A]] = EqK[F].synthesize[A]
     implicit val eqffa: Eq[F[F[A]]] = EqK[F].synthesize[F[A]]
     new RuleSet {
       def name: String = "bimonad"
@@ -20,7 +19,6 @@ trait BimonadTests[F[_]] extends MonadTests[F] with ComonadTests[F] {
       def parents: Seq[RuleSet] = Seq(monad[A, B, C], comonad[A, B, C])
       def props: Seq[(String, Prop)] = Seq(
         "pure andThen extract = id" -> forAll(laws.pureExtractIsId[A] _),
-        "extract andThen pure = id" -> forAll(laws.extractPureIsId[A] _),
         "extract/flatMap entwining" -> forAll(laws.extractFlatMapEntwining[A] _),
         "pure/coflatMap entwining" -> forAll(laws.pureCoflatMapEntwining[A] _)
       )


### PR DESCRIPTION
This picks up the question @non asked in https://github.com/non/cats/issues/595#issuecomment-153259535 and removes one of the `Bimonad` laws: `F.pure(F.extract(fa)) <-> fa`. @milessabin noted on Gitter that this law makes any `Bimonad` isomorphic to `Id` (modulo evaluation order) and I think that makes `Bimonad` less useful. For example, `NonEmptyList` which is both monadic and comonadic isn't a lawful `Bimonad` because of the above law and I think it could be a lawful `Bimonad` if we remove that law (but I haven't proved that).

If people find this law useful I'd suggest introducing another type class which extends `Bimonad` and has this additional law.