### PR TITLE
Remove Validated.filter

### DIFF
--- a/core/src/main/scala/cats/data/Validated.scala
+++ b/core/src/main/scala/cats/data/Validated.scala
@@ -39,15 +39,6 @@ sealed abstract class Validated[+E, +A] extends Product with Serializable {
   def forall(f: A => Boolean): Boolean = fold(_ => true, f)
 
   /**
-   * If the value is Valid but the predicate fails, return an empty
-   * Invalid value, otherwise leaves the value unchanged.  This method
-   * is mostly useful for allowing validated values to be used in a
-   * for comprehension with pattern matching.
-   */
-  def filter[EE >: E](pred: A => Boolean)(implicit M: Monoid[EE]): Validated[EE,A] =
-    fold(Invalid.apply, a => if(pred(a)) this else Invalid(M.empty))
-
-  /**
    * Return this if it is Valid, or else fall back to the given default.
    */
   def orElse[EE >: E, AA >: A](default: => Validated[EE,AA]): Validated[EE,AA] =

--- a/tests/src/test/scala/cats/tests/ValidatedTests.scala
+++ b/tests/src/test/scala/cats/tests/ValidatedTests.scala
@@ -42,14 +42,6 @@ class ValidatedTests extends CatsSuite {
     }
   }
 
-  test("filter makes non-matching entries invalid") {
-    Valid(1).filter[String](_ % 2 == 0).isInvalid should ===(true)
-  }
-
-  test("filter leaves matching entries valid") {
-    Valid(2).filter[String](_ % 2 == 0).isValid should ===(true)
-  }
-
   test("ValidatedNel") {
     forAll { (e: String) =>
       val manual = Validated.invalid[NonEmptyList[String], Int](NonEmptyList(e))


### PR DESCRIPTION
I think this was leftover from copy/paste from `Xor`. It mentions that
it's useful when using `Validated` in for-comprehensions, but you can't
actually use `Validated` in for-comprehensions since it doesn't have a
`flatMap` method :).

Also, `Xor` no longer has a `filter` method. It was removed in #276
since using the monoid zero when the predicate doesn't match is rather
arbitrary and can lead to surprises. I think we should follow that
precedent for `Validated`.