### PR TITLE
XorT.toOption returns an OptionT

### DIFF
--- a/core/src/main/scala/cats/data/XorT.scala
+++ b/core/src/main/scala/cats/data/XorT.scala
@@ -39,7 +39,7 @@ case class XorT[F[_], A, B](value: F[A Xor B]) {
 
   def toEither(implicit F: Functor[F]): F[Either[A, B]] = F.map(value)(_.toEither)
 
-  def toOption(implicit F: Functor[F]): F[Option[B]] = F.map(value)(_.toOption)
+  def toOption(implicit F: Functor[F]): OptionT[F, B] = OptionT(F.map(value)(_.toOption))
 
   def to[G[_]](implicit functorF: Functor[F], monoidKG: MonoidK[G], applicativeG: Applicative[G]): F[G[B]] =
     functorF.map(value)(_.to[G, B])

--- a/tests/src/test/scala/cats/tests/XorTTests.scala
+++ b/tests/src/test/scala/cats/tests/XorTTests.scala
@@ -50,7 +50,7 @@ class XorTTests extends CatsSuite {
 
   test("toOption on Right returns Some") {
     forAll { (xort: XorT[List, String, Int]) =>
-      xort.toOption.map(_.isDefined) should === (xort.isRight)
+      xort.toOption.isDefined should === (xort.isRight)
     }
   }
 


### PR DESCRIPTION
This makes `toOption` on `XorT[F, A, B]` return `OptionT[F, B]` instead
of `F[Option[B]]`. This makes it symmetrical with `toRight` and `toLeft`
on `OptionT`. My assumption here is that if you are working with `XorT`
instead of `F[Xor...]` that you would also prefer to work with `OptionT`
rather than `F[Option[...]]`. And if not, it's easy enough to call
`.value`.