### PR TITLE
Add Validated.andThen

### DIFF
--- a/core/src/main/scala/cats/data/Validated.scala
+++ b/core/src/main/scala/cats/data/Validated.scala
@@ -155,6 +155,12 @@ sealed abstract class Validated[+E, +A] extends Product with Serializable {
   def show[EE >: E, AA >: A](implicit EE: Show[EE], AA: Show[AA]): String =
     fold(e => s"Invalid(${EE.show(e)})",
          a => s"Valid(${AA.show(a)})")
+
+  def andThen[EE >: E, B](f: A => Validated[EE, B]): Validated[EE, B] =
+    this match {
+      case Valid(a) => f(a)
+      case i @ Invalid(_) => i
+    }
 }
 
 object Validated extends ValidatedInstances with ValidatedFunctions{

--- a/core/src/main/scala/cats/data/Validated.scala
+++ b/core/src/main/scala/cats/data/Validated.scala
@@ -156,6 +156,19 @@ sealed abstract class Validated[+E, +A] extends Product with Serializable {
     fold(e => s"Invalid(${EE.show(e)})",
          a => s"Valid(${AA.show(a)})")
 
+  /**
+   * Apply a function (that returns a `Validated`) in the valid case.
+   * Otherwise return the original `Validated`.
+   *
+   * This allows "chained" validation: the output of one validation can be fed
+   * into another validation function.
+   *
+   * This function is similar to `Xor.flatMap`. It's not called `flatMap`,
+   * because by Cats convention, `flatMap` is a monadic bind that is consistent
+   * with `ap`. This method is not consistent with [[ap]] (or other
+   * `Apply`-based methods), because it has "fail-fast" behavior as opposed to
+   * accumulating validation failures.
+   */
   def andThen[EE >: E, B](f: A => Validated[EE, B]): Validated[EE, B] =
     this match {
       case Valid(a) => f(a)

--- a/docs/src/main/tut/xor.md
+++ b/docs/src/main/tut/xor.md
@@ -37,6 +37,10 @@ How then do we communicate an error? By making it explicit in the data type we r
 
 ## Xor
 
+### `Xor` vs `Validated`
+
+In general, `Validated` is used to accumulate errors, while `Xor` is used to short-circuit a computation upon the first error. For more information, see the `Validated` vs `Xor` section of the [`Validated` documentation]({{ baseurl }}/tut/validated.html).
+
 ### Why not `Either`
 `Xor` is very similar to `scala.util.Either` - in fact, they are *isomorphic* (that is,
 any `Either` value can be rewritten as an `Xor` value, and vice versa).

--- a/tests/src/test/scala/cats/tests/ValidatedTests.scala
+++ b/tests/src/test/scala/cats/tests/ValidatedTests.scala
@@ -100,4 +100,20 @@ class ValidatedTests extends CatsSuite {
       show.show(v).nonEmpty should === (true)
     }
   }
+
+  test("andThen consistent with Xor's flatMap"){
+    forAll { (v: Validated[String, Int], f: Int => Validated[String, Int]) =>
+      v.andThen(f) should === (v.withXor(_.flatMap(f(_).toXor)))
+    }
+  }
+
+  test("ad-hoc andThen tests"){
+    def even(i: Int): Validated[String, Int] =
+      if (i % 2 == 0) Validated.valid(i)
+      else Validated.invalid(s"$i is not even")
+
+    (Validated.valid(3) andThen even) should === (Validated.invalid("3 is not even"))
+    (Validated.valid(4) andThen even) should === (Validated.valid(4))
+    (Validated.invalid("foo") andThen even) should === (Validated.invalid("foo"))
+  }
 }


### PR DESCRIPTION
Fixes #604.

This is essentially `flatMap` for `Validated`, but since `flatMap`
suggests monadic bind in Cats and this is not consistent with `ap`,
another name is being used.

This PR is not complete yet. I need to add a Scaladoc comment and tut documentation about this change. However, I figured there might be some discussion about the name of the method, so I want to wait until a name is decided to start writing docs :). Is `andThen` too overloaded?