### PR TITLE
Make a bunch of instances traits/classes private/sealed

### DIFF
--- a/core/src/main/scala/cats/Eval.scala
+++ b/core/src/main/scala/cats/Eval.scala
@@ -271,7 +271,7 @@ object Eval extends EvalInstances {
   }
 }
 
-trait EvalInstances extends EvalInstances0 {
+private[cats] trait EvalInstances extends EvalInstances0 {
 
   implicit val evalBimonad: Bimonad[Eval] =
     new Bimonad[Eval] {
@@ -293,7 +293,7 @@ trait EvalInstances extends EvalInstances0 {
     new EvalGroup[A] { val algebra = Group[A] }
 }
 
-trait EvalInstances0 extends EvalInstances1 {
+private[cats] trait EvalInstances0 extends EvalInstances1 {
   implicit def evalPartialOrder[A: PartialOrder]: PartialOrder[Eval[A]] =
     new PartialOrder[Eval[A]] {
       def partialCompare(lx: Eval[A], ly: Eval[A]): Double =
@@ -304,7 +304,7 @@ trait EvalInstances0 extends EvalInstances1 {
     new EvalMonoid[A] { val algebra = Monoid[A] }
 }
 
-trait EvalInstances1 {
+private[cats] trait EvalInstances1 {
   implicit def evalEq[A: Eq]: Eq[Eval[A]] =
     new Eq[Eval[A]] {
       def eqv(lx: Eval[A], ly: Eval[A]): Boolean =

--- a/core/src/main/scala/cats/Unapply.scala
+++ b/core/src/main/scala/cats/Unapply.scala
@@ -49,7 +49,7 @@ object Unapply extends Unapply2Instances {
   }
 }
 
-sealed abstract class Unapply2Instances extends Unapply3Instances {
+private[cats] sealed abstract class Unapply2Instances extends Unapply3Instances {
 
   // the type we will instantiate when we find a type class instance
   // for a type in the shape F[_,_] when we fix the left type
@@ -136,7 +136,7 @@ sealed abstract class Unapply2Instances extends Unapply3Instances {
   }
 }
 
-sealed abstract class Unapply3Instances {
+private[cats] sealed abstract class Unapply3Instances {
 
   // the type we will instantiate when we find a type class instance
   // for a type in the shape of a Monad Transformer with 3 type params

--- a/core/src/main/scala/cats/data/Cokleisli.scala
+++ b/core/src/main/scala/cats/data/Cokleisli.scala
@@ -49,7 +49,7 @@ sealed trait CokleisliFunctions {
     Cokleisli(f)
 }
 
-sealed abstract class CokleisliInstances extends CokleisliInstances0 {
+private[data] sealed abstract class CokleisliInstances extends CokleisliInstances0 {
   implicit def cokleisliArrow[F[_]](implicit ev: Comonad[F]): Arrow[Cokleisli[F, ?, ?]] =
     new CokleisliArrow[F] { def F: Comonad[F] = ev }
 
@@ -68,7 +68,7 @@ sealed abstract class CokleisliInstances extends CokleisliInstances0 {
     new CokleisliMonoidK[F] { def F: Comonad[F] = ev }
 }
 
-sealed abstract class CokleisliInstances0 {
+private[data] sealed abstract class CokleisliInstances0 {
   implicit def cokleisliSplit[F[_]](implicit ev: CoflatMap[F]): Split[Cokleisli[F, ?, ?]] =
     new CokleisliSplit[F] { def F: CoflatMap[F] = ev }
 

--- a/core/src/main/scala/cats/data/Const.scala
+++ b/core/src/main/scala/cats/data/Const.scala
@@ -36,7 +36,7 @@ object Const extends ConstInstances {
     Const(A.empty)
 }
 
-sealed abstract class ConstInstances extends ConstInstances0 {
+private[data] sealed abstract class ConstInstances extends ConstInstances0 {
   implicit def constOrder[A: Order, B]: Order[Const[A, B]] = new Order[Const[A, B]] {
     def compare(x: Const[A, B], y: Const[A, B]): Int =
       x compare y
@@ -64,7 +64,7 @@ sealed abstract class ConstInstances extends ConstInstances0 {
   }
 }
 
-sealed abstract class ConstInstances0 extends ConstInstances1 {
+private[data] sealed abstract class ConstInstances0 extends ConstInstances1 {
   implicit def constPartialOrder[A: PartialOrder, B]: PartialOrder[Const[A, B]] = new PartialOrder[Const[A, B]]{
     def partialCompare(x: Const[A, B], y: Const[A, B]): Double =
       x partialCompare y
@@ -79,7 +79,7 @@ sealed abstract class ConstInstances0 extends ConstInstances1 {
   }
 }
 
-sealed abstract class ConstInstances1 {
+private[data] sealed abstract class ConstInstances1 {
   implicit def constEq[A: Eq, B]: Eq[Const[A, B]] = new Eq[Const[A, B]] {
     def eqv(x: Const[A, B], y: Const[A, B]): Boolean =
       x === y

--- a/core/src/main/scala/cats/data/Func.scala
+++ b/core/src/main/scala/cats/data/Func.scala
@@ -31,21 +31,21 @@ object Func extends FuncInstances {
     appFunc({ a: A => RR.subst(f(a)) })(RR.TC)
 }
 
-abstract class FuncInstances extends FuncInstances0 {
+private[data] abstract class FuncInstances extends FuncInstances0 {
   implicit def funcApplicative[F[_], C](implicit FF: Applicative[F]): Applicative[Lambda[X => Func[F, C, X]]] =
     new FuncApplicative[F, C] {
       def F: Applicative[F] = FF
     }
 }
 
-abstract class FuncInstances0 extends FuncInstances1 {
+private[data] abstract class FuncInstances0 extends FuncInstances1 {
   implicit def funcApply[F[_], C](implicit FF: Apply[F]): Apply[Lambda[X => Func[F, C, X]]] =
     new FuncApply[F, C] {
       def F: Apply[F] = FF
     }
 }
 
-abstract class FuncInstances1 {
+private[data] abstract class FuncInstances1 {
   implicit def funcFunctor[F[_], C](implicit FF: Functor[F]): Functor[Lambda[X => Func[F, C, X]]] =
     new FuncFunctor[F, C] {
       def F: Functor[F] = FF
@@ -110,14 +110,14 @@ sealed abstract class AppFunc[F[_], A, B] extends Func[F, A, B] { self =>
 
 object AppFunc extends AppFuncInstances
 
-abstract class AppFuncInstances {
+private[data] abstract class AppFuncInstances {
   implicit def appFuncApplicative[F[_], C](implicit FF: Applicative[F]): Applicative[Lambda[X => AppFunc[F, C, X]]] =
     new AppFuncApplicative[F, C] {
       def F: Applicative[F] = FF
     }
 }
 
-sealed trait AppFuncApplicative[F[_], C] extends Applicative[Lambda[X => AppFunc[F, C, X]]] {
+private[data] sealed trait AppFuncApplicative[F[_], C] extends Applicative[Lambda[X => AppFunc[F, C, X]]] {
   def F: Applicative[F]
   override def map[A, B](fa: AppFunc[F, C, A])(f: A => B): AppFunc[F, C, B] =
     fa.map(f)

--- a/core/src/main/scala/cats/data/Ior.scala
+++ b/core/src/main/scala/cats/data/Ior.scala
@@ -131,7 +131,7 @@ object Ior extends IorInstances with IorFunctions {
   final case class Both[+A, +B](a: A, b: B) extends (A Ior B)
 }
 
-sealed abstract class IorInstances extends IorInstances0 {
+private[data] sealed abstract class IorInstances extends IorInstances0 {
   implicit def iorEq[A: Eq, B: Eq]: Eq[A Ior B] = new Eq[A Ior B] {
     def eqv(x: A Ior B, y: A Ior B): Boolean = x === y
   }
@@ -151,7 +151,7 @@ sealed abstract class IorInstances extends IorInstances0 {
     }
 }
 
-sealed abstract class IorInstances0 {
+private[data] sealed abstract class IorInstances0 {
 
   implicit def iorInstances[A]: Traverse[A Ior ?] with Functor[A Ior ?] = new Traverse[A Ior ?] with Functor[A Ior ?] {
     def traverse[F[_]: Applicative, B, C](fa: A Ior B)(f: B => F[C]): F[A Ior C] =

--- a/core/src/main/scala/cats/data/Kleisli.scala
+++ b/core/src/main/scala/cats/data/Kleisli.scala
@@ -66,7 +66,7 @@ final case class Kleisli[F[_], A, B](run: A => F[B]) { self =>
 
 object Kleisli extends KleisliInstances with KleisliFunctions
 
-sealed trait KleisliFunctions {
+private[data] sealed trait KleisliFunctions {
   /** creates a [[Kleisli]] from a function */
   def function[F[_], A, B](f: A => F[B]): Kleisli[F, A, B] =
     Kleisli(f)
@@ -81,7 +81,7 @@ sealed trait KleisliFunctions {
     Kleisli(f andThen fa.run)
 }
 
-sealed abstract class KleisliInstances extends KleisliInstances0 {
+private[data] sealed abstract class KleisliInstances extends KleisliInstances0 {
 
   implicit def kleisliMonoid[F[_], A, B](implicit M: Monoid[F[B]]): Monoid[Kleisli[F, A, B]] =
     new KleisliMonoid[F, A, B] { def FB: Monoid[F[B]] = M }
@@ -118,7 +118,7 @@ sealed abstract class KleisliInstances extends KleisliInstances0 {
     }
 }
 
-sealed abstract class KleisliInstances0 extends KleisliInstances1 {
+private[data] sealed abstract class KleisliInstances0 extends KleisliInstances1 {
   implicit def kleisliSplit[F[_]](implicit ev: FlatMap[F]): Split[Kleisli[F, ?, ?]] =
     new KleisliSplit[F] { def F: FlatMap[F] = ev }
 
@@ -140,7 +140,7 @@ sealed abstract class KleisliInstances0 extends KleisliInstances1 {
     new KleisliSemigroupK[F] { def F: FlatMap[F] = ev }
 }
 
-sealed abstract class KleisliInstances1 extends KleisliInstances2 {
+private[data] sealed abstract class KleisliInstances1 extends KleisliInstances2 {
   implicit def kleisliApplicative[F[_]: Applicative, A]: Applicative[Kleisli[F, A, ?]] = new Applicative[Kleisli[F, A, ?]] {
     def pure[B](x: B): Kleisli[F, A, B] =
       Kleisli.pure[F, A, B](x)
@@ -150,7 +150,7 @@ sealed abstract class KleisliInstances1 extends KleisliInstances2 {
   }
 }
 
-sealed abstract class KleisliInstances2 extends KleisliInstances3 {
+private[data] sealed abstract class KleisliInstances2 extends KleisliInstances3 {
   implicit def kleisliApply[F[_]: Apply, A]: Apply[Kleisli[F, A, ?]] = new Apply[Kleisli[F, A, ?]] {
     def ap[B, C](fa: Kleisli[F, A, B])(f: Kleisli[F, A, B => C]): Kleisli[F, A, C] =
       fa(f)
@@ -160,7 +160,7 @@ sealed abstract class KleisliInstances2 extends KleisliInstances3 {
   }
 }
 
-sealed abstract class KleisliInstances3 {
+private[data] sealed abstract class KleisliInstances3 {
   implicit def kleisliFunctor[F[_]: Functor, A]: Functor[Kleisli[F, A, ?]] = new Functor[Kleisli[F, A, ?]] {
     def map[B, C](fa: Kleisli[F, A, B])(f: B => C): Kleisli[F, A, C] =
       fa.map(f)

--- a/core/src/main/scala/cats/data/OneAnd.scala
+++ b/core/src/main/scala/cats/data/OneAnd.scala
@@ -87,7 +87,7 @@ final case class OneAnd[F[_], A](head: A, tail: F[A]) {
     s"OneAnd(${A.show(head)}, ${FA.show(tail)})"
 }
 
-trait OneAndInstances extends OneAndLowPriority1 {
+private[data] sealed trait OneAndInstances extends OneAndLowPriority1 {
 
   implicit def oneAndEq[A, F[_]](implicit A: Eq[A], FA: Eq[F[A]]): Eq[OneAnd[F, A]] =
     new Eq[OneAnd[F, A]]{

--- a/core/src/main/scala/cats/data/OptionT.scala
+++ b/core/src/main/scala/cats/data/OptionT.scala
@@ -114,7 +114,7 @@ object OptionT extends OptionTInstances {
   }
 }
 
-trait OptionTInstances1 {
+private[data] sealed trait OptionTInstances1 {
   implicit def optionTFunctor[F[_]:Functor]: Functor[OptionT[F, ?]] =
     new Functor[OptionT[F, ?]] {
       override def map[A, B](fa: OptionT[F, A])(f: A => B): OptionT[F, B] =
@@ -122,7 +122,7 @@ trait OptionTInstances1 {
     }
 }
 
-trait OptionTInstances extends OptionTInstances1 {
+private[data] sealed trait OptionTInstances extends OptionTInstances1 {
   implicit def optionTMonadCombine[F[_]](implicit F: Monad[F]): MonadCombine[OptionT[F, ?]] =
     new MonadCombine[OptionT[F, ?]] {
       def pure[A](a: A): OptionT[F, A] = OptionT.pure(a)

--- a/core/src/main/scala/cats/data/Prod.scala
+++ b/core/src/main/scala/cats/data/Prod.scala
@@ -21,7 +21,7 @@ object Prod extends ProdInstances {
     Some((x.first, x.second))
 }
 
-sealed abstract class ProdInstances extends ProdInstance0 {
+private[data] sealed abstract class ProdInstances extends ProdInstance0 {
   implicit def prodAlternative[F[_], G[_]](implicit FF: Alternative[F], GG: Alternative[G]): Alternative[Lambda[X => Prod[F, G, X]]] = new ProdAlternative[F, G] {
     def F: Alternative[F] = FF
     def G: Alternative[G] = GG

--- a/core/src/main/scala/cats/data/Streaming.scala
+++ b/core/src/main/scala/cats/data/Streaming.scala
@@ -847,7 +847,7 @@ object Streaming extends StreamingInstances {
     }
 }
 
-trait StreamingInstances extends StreamingInstances1 {
+private[data] sealed trait StreamingInstances extends StreamingInstances1 {
 
   implicit val streamInstance: Traverse[Streaming] with MonadCombine[Streaming] with CoflatMap[Streaming] =
     new Traverse[Streaming] with MonadCombine[Streaming] with CoflatMap[Streaming] {
@@ -910,7 +910,7 @@ trait StreamingInstances extends StreamingInstances1 {
     }
 }
 
-trait StreamingInstances1 extends StreamingInstances2 {
+private[data] sealed trait StreamingInstances1 extends StreamingInstances2 {
   implicit def streamPartialOrder[A: PartialOrder]: PartialOrder[Streaming[A]] =
     new PartialOrder[Streaming[A]] {
       def partialCompare(x: Streaming[A], y: Streaming[A]): Double =
@@ -919,7 +919,7 @@ trait StreamingInstances1 extends StreamingInstances2 {
     }
 }
 
-trait StreamingInstances2 {
+private[data] sealed trait StreamingInstances2 {
   implicit def streamEq[A: Eq]: Eq[Streaming[A]] =
     new Eq[Streaming[A]] {
       def eqv(x: Streaming[A], y: Streaming[A]): Boolean =

--- a/core/src/main/scala/cats/data/StreamingT.scala
+++ b/core/src/main/scala/cats/data/StreamingT.scala
@@ -423,7 +423,7 @@ object StreamingT extends StreamingTInstances {
   }
 }
 
-trait StreamingTInstances extends StreamingTInstances1 {
+private[data] sealed trait StreamingTInstances extends StreamingTInstances1 {
 
   implicit def streamingTInstance[F[_]: Monad]: MonadCombine[StreamingT[F, ?]] with CoflatMap[StreamingT[F, ?]] =
     new MonadCombine[StreamingT[F, ?]] with CoflatMap[StreamingT[F, ?]] {
@@ -448,7 +448,7 @@ trait StreamingTInstances extends StreamingTInstances1 {
     }
 }
 
-trait StreamingTInstances1 extends StreamingTInstances2 {
+private[data] sealed trait StreamingTInstances1 extends StreamingTInstances2 {
   implicit def streamingTPartialOrder[F[_], A](implicit ev: Monad[F], eva: PartialOrder[F[List[A]]]): PartialOrder[StreamingT[F, A]] =
     new PartialOrder[StreamingT[F, A]] {
       def partialCompare(x: StreamingT[F, A], y: StreamingT[F, A]): Double =
@@ -456,7 +456,7 @@ trait StreamingTInstances1 extends StreamingTInstances2 {
     }
 }
 
-trait StreamingTInstances2 {
+private[data] sealed trait StreamingTInstances2 {
   implicit def streamingTEq[F[_], A](implicit ev: Monad[F], eva: Eq[F[List[A]]]): Eq[StreamingT[F, A]] =
     new Eq[StreamingT[F, A]] {
       def eqv(x: StreamingT[F, A], y: StreamingT[F, A]): Boolean =

--- a/core/src/main/scala/cats/data/Validated.scala
+++ b/core/src/main/scala/cats/data/Validated.scala
@@ -163,7 +163,7 @@ object Validated extends ValidatedInstances with ValidatedFunctions{
 }
 
 
-sealed abstract class ValidatedInstances extends ValidatedInstances1 {
+private[data] sealed abstract class ValidatedInstances extends ValidatedInstances1 {
   implicit def validatedOrder[A: Order, B: Order]: Order[Validated[A,B]] = new Order[Validated[A,B]] {
     def compare(x: Validated[A,B], y: Validated[A,B]): Int = x compare y
     override def partialCompare(x: Validated[A,B], y: Validated[A,B]): Double = x partialCompare y
@@ -201,7 +201,7 @@ sealed abstract class ValidatedInstances extends ValidatedInstances1 {
     }
 }
 
-sealed abstract class ValidatedInstances1 extends ValidatedInstances2 {
+private[data] sealed abstract class ValidatedInstances1 extends ValidatedInstances2 {
   implicit def xorPartialOrder[A: PartialOrder, B: PartialOrder]: PartialOrder[Validated[A,B]] =
     new PartialOrder[Validated[A,B]] {
       def partialCompare(x: Validated[A,B], y: Validated[A,B]): Double = x partialCompare y
@@ -209,7 +209,7 @@ sealed abstract class ValidatedInstances1 extends ValidatedInstances2 {
     }
 }
 
-sealed abstract class ValidatedInstances2 {
+private[data] sealed abstract class ValidatedInstances2 {
   implicit def xorEq[A: Eq, B: Eq]: Eq[Validated[A,B]] =
     new Eq[Validated[A,B]] {
       def eqv(x: Validated[A,B], y: Validated[A,B]): Boolean = x === y

--- a/core/src/main/scala/cats/data/WriterT.scala
+++ b/core/src/main/scala/cats/data/WriterT.scala
@@ -36,7 +36,7 @@ final case class WriterT[F[_], L, V](run: F[(L, V)]) {
 }
 object WriterT extends WriterTInstances with WriterTFunctions
 
-sealed abstract class WriterTInstances {
+private[data] sealed abstract class WriterTInstances {
   implicit def writerTMonad[F[_], L](implicit monadF: Monad[F], monoidL: Monoid[L]) = {
     new Monad[WriterT[F, L, ?]] {
       override def pure[A](a: A): WriterT[F, L, A] =

--- a/core/src/main/scala/cats/data/Xor.scala
+++ b/core/src/main/scala/cats/data/Xor.scala
@@ -147,7 +147,7 @@ object Xor extends XorInstances with XorFunctions {
   final case class Right[+B](b: B) extends (Nothing Xor B)
 }
 
-sealed abstract class XorInstances extends XorInstances1 {
+private[data] sealed abstract class XorInstances extends XorInstances1 {
   implicit def xorOrder[A: Order, B: Order]: Order[A Xor B] =
     new Order[A Xor B] {
       def compare(x: A Xor B, y: A Xor B): Int = x compare y
@@ -193,14 +193,14 @@ sealed abstract class XorInstances extends XorInstances1 {
     }
 }
 
-sealed abstract class XorInstances1 extends XorInstances2 {
+private[data] sealed abstract class XorInstances1 extends XorInstances2 {
   implicit def xorPartialOrder[A: PartialOrder, B: PartialOrder]: PartialOrder[A Xor B] = new PartialOrder[A Xor B] {
     def partialCompare(x: A Xor B, y: A Xor B): Double = x partialCompare y
     override def eqv(x: A Xor B, y: A Xor B): Boolean = x === y
   }
 }
 
-sealed abstract class XorInstances2 {
+private[data] sealed abstract class XorInstances2 {
   implicit def xorEq[A: Eq, B: Eq]: Eq[A Xor B] =
     new Eq[A Xor B] {
       def eqv(x: A Xor B, y: A Xor B): Boolean = x === y

--- a/core/src/main/scala/cats/data/XorT.scala
+++ b/core/src/main/scala/cats/data/XorT.scala
@@ -140,7 +140,7 @@ trait XorTFunctions {
   }
 }
 
-abstract class XorTInstances extends XorTInstances1 {
+private[data] abstract class XorTInstances extends XorTInstances1 {
 
   /* TODO violates right absorbtion, right distributivity, and left distributivity -- re-enable when MonadCombine laws are split in to weak/strong
   implicit def xorTMonadCombine[F[_], L](implicit F: Monad[F], L: Monoid[L]): MonadCombine[XorT[F, L, ?]] = {

--- a/core/src/main/scala/cats/functor/Invariant.scala
+++ b/core/src/main/scala/cats/functor/Invariant.scala
@@ -64,7 +64,7 @@ object Invariant extends AlgebraInvariantInstances {
  * Invariant instances for types that are housed in Algebra and therefore
  * can't have instances for Cats type classes in their companion objects.
  */
-trait AlgebraInvariantInstances {
+private[functor] sealed trait AlgebraInvariantInstances {
 
   implicit val invariantSemigroup: Invariant[Semigroup] = new Invariant[Semigroup] {
     def imap[A, B](fa: Semigroup[A])(f: A => B)(g: B => A): Semigroup[B] = new Semigroup[B] {

--- a/core/src/main/scala/cats/std/either.scala
+++ b/core/src/main/scala/cats/std/either.scala
@@ -41,7 +41,7 @@ trait EitherInstances extends EitherInstances1 {
     }
 }
 
-sealed trait EitherInstances1 extends EitherInstances2 {
+private[std] sealed trait EitherInstances1 extends EitherInstances2 {
   implicit def eitherPartialOrder[A, B](implicit A: PartialOrder[A], B: PartialOrder[B]): PartialOrder[Either[A, B]] =
     new PartialOrder[Either[A, B]] {
       def partialCompare(x: Either[A, B], y: Either[A, B]): Double = x.fold(
@@ -51,7 +51,7 @@ sealed trait EitherInstances1 extends EitherInstances2 {
     }
 }
 
-sealed trait EitherInstances2 {
+private[std] sealed trait EitherInstances2 {
   implicit def eitherEq[A, B](implicit A: Eq[A], B: Eq[B]): Eq[Either[A, B]] = new Eq[Either[A, B]] {
     def eqv(x: Either[A, B], y: Either[A, B]): Boolean = x.fold(
       a => y.fold(A.eqv(a, _), _ => false),

--- a/core/src/main/scala/cats/std/future.scala
+++ b/core/src/main/scala/cats/std/future.scala
@@ -37,12 +37,12 @@ trait FutureInstances extends FutureInstances1 {
     new FutureGroup[A]
 }
 
-trait FutureInstances1 extends FutureInstances2 {
+private[std] sealed trait FutureInstances1 extends FutureInstances2 {
   implicit def futureMonoid[A: Monoid](implicit ec: ExecutionContext): Monoid[Future[A]] =
     new FutureMonoid[A]
 }
 
-trait FutureInstances2 {
+private[std] sealed trait FutureInstances2 {
   implicit def futureSemigroup[A: Semigroup](implicit ec: ExecutionContext): Semigroup[Future[A]] =
     new FutureSemigroup[A]
 }

--- a/core/src/main/scala/cats/std/list.scala
+++ b/core/src/main/scala/cats/std/list.scala
@@ -72,7 +72,7 @@ trait ListInstances extends ListInstances1 {
   implicit def listOrder[A: Order]: Order[List[A]] = new ListOrder[A]
 }
 
-trait ListInstances1 extends ListInstances2 {
+private[std] sealed trait ListInstances1 extends ListInstances2 {
   implicit def partialOrderList[A: PartialOrder]: PartialOrder[List[A]] =
     new PartialOrder[List[A]] {
       def partialCompare(x: List[A], y: List[A]): Double = {
@@ -94,7 +94,7 @@ trait ListInstances1 extends ListInstances2 {
     }
 }
 
-trait ListInstances2 {
+private[std] sealed trait ListInstances2 {
   implicit def eqList[A: Eq]: Eq[List[A]] =
     new Eq[List[A]] {
       def eqv(x: List[A], y: List[A]): Boolean = {

--- a/core/src/main/scala/cats/std/option.scala
+++ b/core/src/main/scala/cats/std/option.scala
@@ -81,7 +81,7 @@ trait OptionInstances extends OptionInstances1 {
     }
 }
 
-trait OptionInstances1 extends OptionInstances2 {
+private[std] sealed trait OptionInstances1 extends OptionInstances2 {
   implicit def partialOrderOption[A](implicit ev: PartialOrder[A]): PartialOrder[Option[A]] =
     new PartialOrder[Option[A]] {
       def partialCompare(x: Option[A], y: Option[A]): Double =
@@ -89,7 +89,7 @@ trait OptionInstances1 extends OptionInstances2 {
     }
 }
 
-trait OptionInstances2 {
+private[std] sealed trait OptionInstances2 {
   implicit def eqOption[A](implicit ev: Eq[A]): Eq[Option[A]] =
     new Eq[Option[A]] {
       def eqv(x: Option[A], y: Option[A]): Boolean =

--- a/js/src/main/scala/cats/js/std/future.scala
+++ b/js/src/main/scala/cats/js/std/future.scala
@@ -18,7 +18,7 @@ object Await {
     }
 }
 
-trait FutureInstances0 extends FutureInstances1 {
+private[std] sealed trait FutureInstances0 extends FutureInstances1 {
   def futureComonad(atMost: FiniteDuration)(implicit ec: E): Comonad[Future] =
     new FutureCoflatMap with Comonad[Future] {
       def extract[A](x: Future[A]): A =
@@ -32,7 +32,7 @@ trait FutureInstances0 extends FutureInstances1 {
     }
 }
 
-trait FutureInstances1 extends FutureInstances2 {
+private[std] sealed trait FutureInstances1 extends FutureInstances2 {
   def futurePartialOrder[A: PartialOrder](atMost: FiniteDuration)(implicit ec: E): PartialOrder[Future[A]] =
     new PartialOrder[Future[A]] {
       def partialCompare(x: Future[A], y: Future[A]): Double =
@@ -41,7 +41,7 @@ trait FutureInstances1 extends FutureInstances2 {
 
 }
 
-trait FutureInstances2 {
+private[std] sealed trait FutureInstances2 {
   def futureEq[A: Eq](atMost: FiniteDuration)(implicit ec: E): Eq[Future[A]] =
     new Eq[Future[A]] {
       def eqv(x: Future[A], y: Future[A]): Boolean =

--- a/jvm/src/main/scala/cats/jvm/std/future.scala
+++ b/jvm/src/main/scala/cats/jvm/std/future.scala
@@ -11,7 +11,7 @@ import cats.syntax.all._
 
 object future extends FutureInstances0
 
-trait FutureInstances0 extends FutureInstances1 {
+private[std] sealed trait FutureInstances0 extends FutureInstances1 {
   def futureComonad(atMost: FiniteDuration)(implicit ec: E): Comonad[Future] =
     new FutureCoflatMap with Comonad[Future] {
       def extract[A](x: Future[A]): A =
@@ -25,7 +25,7 @@ trait FutureInstances0 extends FutureInstances1 {
     }
 }
 
-trait FutureInstances1 extends FutureInstances2 {
+private[std] sealed trait FutureInstances1 extends FutureInstances2 {
   def futurePartialOrder[A: PartialOrder](atMost: FiniteDuration)(implicit ec: E): PartialOrder[Future[A]] =
     new PartialOrder[Future[A]] {
       def partialCompare(x: Future[A], y: Future[A]): Double =
@@ -34,7 +34,7 @@ trait FutureInstances1 extends FutureInstances2 {
 
 }
 
-trait FutureInstances2 {
+private[std] sealed trait FutureInstances2 {
   def futureEq[A: Eq](atMost: FiniteDuration)(implicit ec: E): Eq[Future[A]] =
     new Eq[Future[A]] {
       def eqv(x: Future[A], y: Future[A]): Boolean =

--- a/state/src/main/scala/cats/state/StateT.scala
+++ b/state/src/main/scala/cats/state/StateT.scala
@@ -98,7 +98,7 @@ object StateT extends StateTInstances {
     StateT(s => F.pure((s, a)))
 }
 
-sealed abstract class StateTInstances extends StateTInstances0 {
+private[state] sealed abstract class StateTInstances extends StateTInstances0 {
   implicit def stateTMonadState[F[_], S](implicit F: Monad[F]): MonadState[StateT[F, S, ?], S] =
     new MonadState[StateT[F, S, ?], S] {
       def pure[A](a: A): StateT[F, S, A] =
@@ -116,7 +116,7 @@ sealed abstract class StateTInstances extends StateTInstances0 {
     }
 }
 
-sealed abstract class StateTInstances0 {
+private[state] sealed abstract class StateTInstances0 {
   implicit def stateMonadState[S]: MonadState[State[S, ?], S] =
     StateT.stateTMonadState[Trampoline, S]
 }


### PR DESCRIPTION
This is related to #496, but it's a broader issue than just this change.

These instances traits/classes are used internally for code organization
and implicit prioritization, but they aren't really meant to be part of
the public API. Making them private/sealed may be helpful for binary
compatibility in the future. It also may be a helpful indicator to
newcomers which traits/classes are actually meant for consumption, so
they can ignore some of the noise.

So far, I have left the traits for orphans from `std` (such as
`StringInstances`), and I have left the omni-instance traits exposed.