### PR TITLE
Add contravariant instances for Const and Kleisli

### DIFF
--- a/core/src/main/scala/cats/data/Const.scala
+++ b/core/src/main/scala/cats/data/Const.scala
@@ -1,6 +1,8 @@
 package cats
 package data
 
+import cats.functor.Contravariant
+
 /**
  * [[Const]] is a phantom type, it does not contain a value of its second type parameter `B`
  * [[Const]] can be seen as a type level version of `Function.const[A, B]: A => B => A`
@@ -44,6 +46,11 @@ private[data] sealed abstract class ConstInstances extends ConstInstances0 {
 
   implicit def constShow[A: Show, B]: Show[Const[A, B]] = new Show[Const[A, B]] {
     def show(f: Const[A, B]): String = f.show
+  }
+
+  implicit def constContravariant[C]: Contravariant[Const[C, ?]] = new Contravariant[Const[C, ?]] {
+    override def contramap[A, B](fa: Const[C, A])(f: (B) => A): Const[C, B] =
+      fa.retag[B]
   }
 
   implicit def constTraverse[C]: Traverse[Const[C, ?]] = new Traverse[Const[C, ?]] {

--- a/core/src/main/scala/cats/data/Kleisli.scala
+++ b/core/src/main/scala/cats/data/Kleisli.scala
@@ -2,7 +2,7 @@ package cats
 package data
 
 import cats.arrow.{Arrow, Choice, Split}
-import cats.functor.Strong
+import cats.functor.{Contravariant, Strong}
 
 /**
  * Represents a function `A => F[B]`.
@@ -115,6 +115,12 @@ private[data] sealed abstract class KleisliInstances extends KleisliInstances0 {
 
       def local[B](f: A => A)(fa: Kleisli[F, A, B]): Kleisli[F, A, B] =
         Kleisli(f.andThen(fa.run))
+    }
+
+  implicit def kleisliContravariant[F[_], C]: Contravariant[Kleisli[F, ?, C]] =
+    new Contravariant[Kleisli[F, ?, C]] {
+      override def contramap[A, B](fa: Kleisli[F, A, C])(f: (B) => A): Kleisli[F, B, C] =
+        fa.lmap(f)
     }
 }
 

--- a/tests/src/test/scala/cats/tests/ConstTests.scala
+++ b/tests/src/test/scala/cats/tests/ConstTests.scala
@@ -4,7 +4,8 @@ package tests
 import algebra.laws.{GroupLaws, OrderLaws}
 
 import cats.data.{Const, NonEmptyList}
-import cats.laws.discipline.{ApplyTests, ApplicativeTests, SerializableTests, TraverseTests}
+import cats.functor.Contravariant
+import cats.laws.discipline._
 import cats.laws.discipline.arbitrary.{constArbitrary, oneAndArbitrary}
 
 class ConstTests extends CatsSuite {
@@ -31,4 +32,7 @@ class ConstTests extends CatsSuite {
   checkAll("Const[Map[Int, Int], String]", OrderLaws[Const[Map[Int, Int], String]].eqv)
   checkAll("PartialOrder[Const[Set[Int], String]]", OrderLaws[Const[Set[Int], String]].partialOrder)
   checkAll("Order[Const[Int, String]]", OrderLaws[Const[Int, String]].order)
+
+  checkAll("Const[String, Int]", ContravariantTests[Const[String, ?]].contravariant[Int, Int, Int])
+  checkAll("Contravariant[Const[String, ?]]", SerializableTests.serializable(Contravariant[Const[String, ?]]))
 }

--- a/tests/src/test/scala/cats/tests/KleisliTests.scala
+++ b/tests/src/test/scala/cats/tests/KleisliTests.scala
@@ -3,7 +3,7 @@ package tests
 
 import cats.arrow.{Arrow, Choice, Split}
 import cats.data.Kleisli
-import cats.functor.Strong
+import cats.functor.{Contravariant, Strong}
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.eq._
@@ -92,6 +92,9 @@ class KleisliTests extends CatsSuite {
     checkAll("Kleisli[Option, Int, Int]", SemigroupKTests[Lambda[A => Kleisli[Option, A, A]]].semigroupK[Int])
     checkAll("SemigroupK[Lambda[A => Kleisli[Option, A, A]]]", SerializableTests.serializable(kleisliSemigroupK))
   }
+
+  checkAll("Kleisli[Option, ?, Int]", ContravariantTests[Kleisli[Option, ?, Int]].contravariant[Int, Int, Int])
+  checkAll("Contravariant[Kleisli[Option, ?, Int]]", SerializableTests.serializable(Contravariant[Kleisli[Option, ?, Int]]))
 
   test("local composes functions") {
     forAll { (f: Int => Option[String], g: Int => Int, i: Int) =>


### PR DESCRIPTION
I realise that this is very similar to @vikraman's work in #590, but I think this addresses the issues raised by @ceedubs and it was much easier to get this working against master than raising a PR onto that branch, thanks to the removal of `ArbitraryK`.