### PR TITLE
Add WriterT instances for supertypes of Monad

### DIFF
--- a/core/src/main/scala/cats/data/WriterT.scala
+++ b/core/src/main/scala/cats/data/WriterT.scala
@@ -8,6 +8,12 @@ final case class WriterT[F[_], L, V](run: F[(L, V)]) {
   def value(implicit functorF: Functor[F]): F[V] =
     functorF.map(run)(_._2)
 
+  def ap[Z](f: WriterT[F, L, V => Z])(implicit F: Apply[F], L: Semigroup[L]): WriterT[F, L, Z] =
+    WriterT(
+      F.map2(f.run, run){
+        case ((l1, fvz), (l2, v)) => (L.combine(l1, l2), fvz(v))
+      })
+
   def map[Z](fn: V => Z)(implicit functorF: Functor[F]): WriterT[F, L, Z] =
     WriterT {
       functorF.map(run) { z => (z._1, fn(z._2)) }
@@ -36,19 +42,100 @@ final case class WriterT[F[_], L, V](run: F[(L, V)]) {
 }
 object WriterT extends WriterTInstances with WriterTFunctions
 
-private[data] sealed abstract class WriterTInstances {
-  implicit def writerTMonad[F[_], L](implicit monadF: Monad[F], monoidL: Monoid[L]): Monad[WriterT[F, L, ?]] = {
-    new Monad[WriterT[F, L, ?]] {
-      override def pure[A](a: A): WriterT[F, L, A] =
-        WriterT.value[F, L, A](a)
+private[data] sealed abstract class WriterTInstances extends WriterTInstances0 {
 
-      override def flatMap[A, B](fa: WriterT[F, L, A])(f: A => WriterT[F, L, B]): WriterT[F, L, B] =
-        fa.flatMap(a => f(a))
+  implicit def writerTIdMonad[L:Monoid]: Monad[WriterT[Id, L, ?]] =
+    writerTMonad[Id, L]
+
+  // The Eq[(L, V)] can be derived from an Eq[L] and Eq[V], but we are waiting
+  // on an algebra release that includes https://github.com/non/algebra/pull/82
+  implicit def writerTIdEq[L, V](implicit E: Eq[(L, V)]): Eq[WriterT[Id, L, V]] =
+    writerTEq[Id, L, V]
+}
+
+private[data] sealed abstract class WriterTInstances0 extends WriterTInstances1 {
+  implicit def writerTMonad[F[_], L](implicit F: Monad[F], L: Monoid[L]): Monad[WriterT[F, L, ?]] =
+    new WriterTMonad[F, L] {
+      implicit val F0: Monad[F] = F
+      implicit val L0: Monoid[L] = L
     }
-  }
+
+  implicit def writerTIdFunctor[L]: Functor[WriterT[Id, L, ?]] =
+    writerTFunctor[Id, L]
+
+  implicit def writerTIdFlatMap[L:Semigroup]: FlatMap[WriterT[Id, L, ?]] =
+    writerTFlatMap[Id, L]
 
   implicit def writerTEq[F[_], L, V](implicit F: Eq[F[(L, V)]]): Eq[WriterT[F, L, V]] =
     F.on(_.run)
+}
+
+private[data] sealed abstract class WriterTInstances1 extends WriterTInstances2 {
+  implicit def writerTApplicative[F[_], L](implicit F: Applicative[F], L: Monoid[L]): Applicative[WriterT[F, L, ?]] =
+    new WriterTApplicative[F, L] {
+      implicit val F0: Applicative[F] = F
+      implicit val L0: Monoid[L] = L
+    }
+}
+private[data] sealed abstract class WriterTInstances2 extends WriterTInstances3 {
+  implicit def writerTFlatMap[F[_], L](implicit F: FlatMap[F], L: Semigroup[L]): FlatMap[WriterT[F, L, ?]] =
+    new WriterTFlatMap[F, L] {
+      implicit val F0: FlatMap[F] = F
+      implicit val L0: Semigroup[L] = L
+    }
+}
+
+private[data] sealed abstract class WriterTInstances3 extends WriterTInstances4 {
+  implicit def writerTApply[F[_], L](implicit F: Apply[F], L: Semigroup[L]): Apply[WriterT[F, L, ?]] =
+    new WriterTApply[F, L] {
+      implicit val F0: Apply[F] = F
+      implicit val L0: Semigroup[L] = L
+    }
+}
+
+private[data] sealed abstract class WriterTInstances4 {
+  implicit def writerTFunctor[F[_], L](implicit F: Functor[F]): Functor[WriterT[F, L, ?]] = new WriterTFunctor[F, L] {
+    implicit val F0: Functor[F] = F
+  }
+}
+
+private[data] sealed trait WriterTFunctor[F[_], L] extends Functor[WriterT[F, L, ?]] {
+  implicit def F0: Functor[F]
+
+  def map[A, B](fa: WriterT[F, L, A])(f: A => B): WriterT[F, L, B] =
+    fa.map(f)
+}
+
+private[data] sealed trait WriterTApply[F[_], L] extends WriterTFunctor[F, L] with Apply[WriterT[F, L, ?]] {
+  override implicit def F0: Apply[F]
+  implicit def L0: Semigroup[L]
+
+  def ap[A, B](fa: WriterT[F, L, A])(f: WriterT[F, L, A => B]): WriterT[F, L, B] =
+    fa ap f
+}
+
+private[data] sealed trait WriterTFlatMap[F[_], L] extends WriterTApply[F, L] with FlatMap[WriterT[F, L, ?]] {
+  override implicit def F0: FlatMap[F]
+  implicit def L0: Semigroup[L]
+
+  def flatMap[A, B](fa: WriterT[F, L, A])(f: A => WriterT[F, L, B]): WriterT[F, L, B] =
+    fa flatMap f
+}
+
+private[data] sealed trait WriterTApplicative[F[_], L] extends WriterTApply[F, L] with Applicative[WriterT[F, L, ?]] {
+  override implicit def F0: Applicative[F]
+  override implicit def L0: Monoid[L]
+
+  def pure[A](a: A): WriterT[F, L, A] =
+    WriterT.value[F, L, A](a)
+}
+
+private[data] sealed trait WriterTMonad[F[_], L] extends WriterTApplicative[F, L] with Monad[WriterT[F, L, ?]] {
+  override implicit def F0: Monad[F]
+  override implicit def L0: Monoid[L]
+
+  def flatMap[A, B](fa: WriterT[F, L, A])(f: A => WriterT[F, L, B]): WriterT[F, L, B] =
+    fa.flatMap(f)
 }
 
 trait WriterTFunctions {

--- a/laws/src/main/scala/cats/laws/discipline/Arbitrary.scala
+++ b/laws/src/main/scala/cats/laws/discipline/Arbitrary.scala
@@ -9,7 +9,7 @@ import org.scalacheck.Arbitrary.{arbitrary => getArbitrary}
 /**
  * Arbitrary instances for cats.data
  */
-object arbitrary {
+object arbitrary extends ArbitraryInstances0 {
 
   implicit def constArbitrary[A, B](implicit A: Arbitrary[A]): Arbitrary[Const[A, B]] =
     Arbitrary(A.arbitrary.map(Const[A, B]))
@@ -76,10 +76,15 @@ object arbitrary {
       as <- Gen.listOf(A.arbitrary).map(_.take(8))
     } yield StreamingT.fromList(as))
 
-  implicit def writerTArbitrary[F[_], L, V](implicit F: Arbitrary[F[(L, V)]]): Arbitrary[WriterT[F, L, V]] =
-    Arbitrary(F.arbitrary.map(WriterT(_)))
+  implicit def writerArbitrary[L:Arbitrary, V:Arbitrary]: Arbitrary[Writer[L, V]] =
+    writerTArbitrary[Id, L, V]
 
   // until this is provided by scalacheck
   implicit def partialFunctionArbitrary[A, B](implicit F: Arbitrary[A => Option[B]]): Arbitrary[PartialFunction[A, B]] =
     Arbitrary(F.arbitrary.map(Function.unlift))
+}
+
+private[discipline] sealed trait ArbitraryInstances0 {
+  implicit def writerTArbitrary[F[_], L, V](implicit F: Arbitrary[F[(L, V)]]): Arbitrary[WriterT[F, L, V]] =
+    Arbitrary(F.arbitrary.map(WriterT(_)))
 }


### PR DESCRIPTION
This is a partial fix for #620. There are still more `WriterT` instances that could be added, but this is already a sizable PR, so I thought getting in the supertypes of `Monad` would be a good chunk of work to split off.

I've gone to fairly great lengths to ensure that implicit resolution works in various cases in the tests. Perhaps I've even gone a bit overboard, but I think that these tests are kind of necessary, because there are some inference issues with `Id` that are compounded by issues with type aliases. In fact I had to rework the prioritization hierarchy several times as these tests uncovered issues.