### PR TITLE
Check more Eval instance laws

### DIFF
--- a/core/src/main/scala/cats/Eval.scala
+++ b/core/src/main/scala/cats/Eval.scala
@@ -33,7 +33,7 @@ import cats.syntax.all._
  * Eval instance -- this can defeat the trampolining and lead to stack
  * overflows.
  */
-sealed abstract class Eval[A] { self =>
+sealed abstract class Eval[A] extends Serializable { self =>
 
   /**
    * Evaluate the computation and return an A value.
@@ -290,7 +290,7 @@ private[cats] trait EvalInstances extends EvalInstances0 {
     }
 
   implicit def evalGroup[A: Group]: Group[Eval[A]] =
-    new EvalGroup[A] { val algebra = Group[A] }
+    new EvalGroup[A] { val algebra: Group[A] = Group[A] }
 }
 
 private[cats] trait EvalInstances0 extends EvalInstances1 {

--- a/tests/src/test/scala/cats/tests/EvalTests.scala
+++ b/tests/src/test/scala/cats/tests/EvalTests.scala
@@ -4,6 +4,7 @@ package tests
 import scala.math.min
 import cats.laws.discipline.{BimonadTests, SerializableTests}
 import cats.laws.discipline.arbitrary._
+import algebra.laws.{GroupLaws, OrderLaws}
 
 class EvalTests extends CatsSuite {
 
@@ -77,5 +78,32 @@ class EvalTests extends CatsSuite {
 
   checkAll("Eval[Int]", BimonadTests[Eval].bimonad[Int, Int, Int])
   checkAll("Bimonad[Eval]", SerializableTests.serializable(Bimonad[Eval]))
+
+  checkAll("Eval[Int]", GroupLaws[Eval[Int]].group)
+
+  {
+    implicit val A = ListWrapper.monoid[Int]
+    checkAll("Eval[ListWrapper[Int]]", GroupLaws[Eval[ListWrapper[Int]]].monoid)
+  }
+
+  {
+    implicit val A = ListWrapper.semigroup[Int]
+    checkAll("Eval[ListWrapper[Int]]", GroupLaws[Eval[ListWrapper[Int]]].semigroup)
+  }
+
+  {
+    implicit val A = ListWrapper.order[Int]
+    checkAll("Eval[ListWrapper[Int]]", OrderLaws[Eval[ListWrapper[Int]]].order)
+  }
+
+  {
+    implicit val A = ListWrapper.partialOrder[Int]
+    checkAll("Eval[ListWrapper[Int]]", OrderLaws[Eval[ListWrapper[Int]]].partialOrder)
+  }
+
+  {
+    implicit val A = ListWrapper.eqv[Int]
+    checkAll("Eval[ListWrapper[Int]]", OrderLaws[Eval[ListWrapper[Int]]].eqv)
+  }
 
 }

--- a/tests/src/test/scala/cats/tests/ListWrapper.scala
+++ b/tests/src/test/scala/cats/tests/ListWrapper.scala
@@ -39,11 +39,11 @@ import org.scalacheck.Arbitrary.arbitrary
 final case class ListWrapper[A](list: List[A]) extends AnyVal
 
 object ListWrapper {
-  def eqv[A : Eq]: Eq[ListWrapper[A]] =
-    new Eq[ListWrapper[A]] {
-      def eqv(x: ListWrapper[A], y: ListWrapper[A]): Boolean =
-        Eq[List[A]].eqv(x.list, y.list)
-    }
+  def order[A:Order]: Order[ListWrapper[A]] = Order[List[A]].on[ListWrapper[A]](_.list)
+
+  def partialOrder[A:PartialOrder]: PartialOrder[ListWrapper[A]] = PartialOrder[List[A]].on[ListWrapper[A]](_.list)
+
+  def eqv[A : Eq]: Eq[ListWrapper[A]] = Eq[List[A]].on[ListWrapper[A]](_.list)
 
   def foldable: Foldable[ListWrapper] =
     new Foldable[ListWrapper] {
@@ -66,6 +66,8 @@ object ListWrapper {
         ListWrapper(SemigroupK[List].combine(x.list, y.list))
     }
 
+  def semigroup[A]: Semigroup[ListWrapper[A]] = semigroupK.algebra[A]
+
   def monadCombine: MonadCombine[ListWrapper] = {
     val M = MonadCombine[List]
 
@@ -81,6 +83,8 @@ object ListWrapper {
         ListWrapper(M.combine(x.list, y.list))
     }
   }
+
+  def monoid[A]: Monoid[ListWrapper[A]] = monadCombine.algebra[A]
 
   implicit def listWrapperArbitrary[A: Arbitrary]: Arbitrary[ListWrapper[A]] =
     Arbitrary(arbitrary[List[A]].map(ListWrapper.apply))


### PR DESCRIPTION
This makes `Eval` serializable and adds law-checking for its `Group`, `Monoid`,
`Semigroup`, `Order`, `PartialOrder`, and `Eq` instances.

Fixes #630.