### PR TITLE
Add Traverse[Id] and Id law-checking

### DIFF
--- a/core/src/main/scala/cats/package.scala
+++ b/core/src/main/scala/cats/package.scala
@@ -26,8 +26,8 @@ package object cats {
  * encodes pure unary function application.
  */
   type Id[A] = A
-  implicit val Id: Bimonad[Id] =
-    new Bimonad[Id] {
+  implicit val Id: Bimonad[Id] with Traverse[Id] =
+    new Bimonad[Id] with Traverse[Id] {
       def pure[A](a: A): A = a
       def extract[A](a: A): A = a
       def flatMap[A, B](a: A)(f: A => B): B = f(a)
@@ -38,6 +38,11 @@ package object cats {
       override def map2[A, B, Z](fa: A, fb: B)(f: (A, B) => Z): Z = f(fa, fb)
       override def lift[A, B](f: A => B): A => B = f
       override def imap[A, B](fa: A)(f: A => B)(fi: B => A): B = f(fa)
+      def foldLeft[A, B](a: A, b: B)(f: (B, A) => B) = f(b, a)
+      def foldRight[A, B](a: A, lb: Eval[B])(f: (A, Eval[B]) => Eval[B]): Eval[B] =
+        f(a, lb)
+      def traverse[G[_], A, B](a: A)(f: A => G[B])(implicit G: Applicative[G]): G[B] =
+        f(a)
   }
 
   type Eq[A] = algebra.Eq[A]

--- a/tests/src/test/scala/cats/tests/IdTests.scala
+++ b/tests/src/test/scala/cats/tests/IdTests.scala
@@ -1,0 +1,13 @@
+package cats
+package tests
+
+import org.scalacheck.Prop.forAll
+import cats.laws.discipline._
+
+class IdTests extends CatsSuite {
+  checkAll("Id[Int]", BimonadTests[Id].bimonad[Int, Int, Int])
+  checkAll("Bimonad[Id]", SerializableTests.serializable(Bimonad[Id]))
+
+  checkAll("Id[Int]", TraverseTests[Id].traverse[Int, Int, Int, Int, Option, Option])
+  checkAll("Traverse[Id]", SerializableTests.serializable(Traverse[Id]))
+}


### PR DESCRIPTION
We should also be able to add a `Reducible` instance for `Id`, but I think that should wait for #629.