### PR TITLE
Tests: XorT with Id as F should be consistent with Xor

### DIFF
--- a/core/src/main/scala/cats/data/Streaming.scala
+++ b/core/src/main/scala/cats/data/Streaming.scala
@@ -89,7 +89,7 @@ sealed abstract class Streaming[A] { lhs =>
   /**
    * A variant of fold, used for constructing streams.
    *
-   * The only difference is that foldStream will preserve deferred
+   * The only difference is that foldStreaming will preserve deferred
    * streams. This makes it more appropriate to use in situations
    * where the stream's laziness must be preserved.
    */

--- a/tests/src/test/scala/cats/tests/XorTTests.scala
+++ b/tests/src/test/scala/cats/tests/XorTTests.scala
@@ -1,6 +1,6 @@
-package cats.tests
+package cats
+package tests
 
-import cats.{Id, MonadError}
 import cats.data.{Xor, XorT}
 import cats.laws.discipline.{BifunctorTests, MonadErrorTests, MonoidKTests, SerializableTests}
 import cats.laws.discipline.arbitrary._
@@ -101,6 +101,72 @@ class XorTTests extends CatsSuite {
   test("subflatMap consistent with value.map+flatMap") {
     forAll { (xort: XorT[List, String, Int], f: Int => String Xor Double) =>
       xort.subflatMap(f) should === (XorT(xort.value.map(_.flatMap(f))))
+    }
+  }
+
+  test("fold with Id consistent with Xor fold") {
+    forAll { (xort: XorT[Id, String, Int], f: String => Long, g: Int => Long) =>
+      xort.fold(f, g) should === (xort.value.fold(f, g))
+    }
+  }
+
+  test("getOrElse with Id consistent with Xor getOrElse") {
+    forAll { (xort: XorT[Id, String, Int], i: Int) =>
+      xort.getOrElse(i) should === (xort.value.getOrElse(i))
+    }
+  }
+
+  test("forall with Id consistent with Xor forall") {
+    forAll { (xort: XorT[Id, String, Int], f: Int => Boolean) =>
+      xort.forall(f) should === (xort.value.forall(f))
+    }
+  }
+
+  test("exists with Id consistent with Xor exists") {
+    forAll { (xort: XorT[Id, String, Int], f: Int => Boolean) =>
+      xort.exists(f) should === (xort.value.exists(f))
+    }
+  }
+
+  test("leftMap with Id consistent with Xor leftMap") {
+    forAll { (xort: XorT[Id, String, Int], f: String => Long) =>
+      xort.leftMap(f).value should === (xort.value.leftMap(f))
+    }
+  }
+
+  test("compare with Id consistent with Xor compare") {
+    forAll { (x: XorT[Id, String, Int], y: XorT[Id, String, Int]) =>
+      x.compare(y) should === (x.value.compare(y.value))
+    }
+  }
+
+  test("=== with Id consistent with Xor ===") {
+    forAll { (x: XorT[Id, String, Int], y: XorT[Id, String, Int]) =>
+      x === y should === (x.value === y.value)
+    }
+  }
+
+  test("traverse with Id consistent with Xor traverse") {
+    forAll { (x: XorT[Id, String, Int], f: Int => Option[Long]) =>
+      x.traverse(f).map(_.value) should === (x.value.traverse(f))
+    }
+  }
+
+  test("foldLeft with Id consistent with Xor foldLeft") {
+    forAll { (x: XorT[Id, String, Int], l: Long, f: (Long, Int) => Long) =>
+      x.foldLeft(l)(f) should === (x.value.foldLeft(l)(f))
+    }
+  }
+
+  test("foldRight with Id consistent with Xor foldRight") {
+    forAll { (x: XorT[Id, String, Int], l: Eval[Long], f: (Int, Eval[Long]) => Eval[Long]) =>
+      x.foldRight(l)(f) should === (x.value.foldRight(l)(f))
+    }
+  }
+
+  test("merge with Id consistent with Xor merge") {
+    forAll { (x: XorT[Id, Int, Int]) =>
+      x.merge should === (x.value.merge)
     }
   }
 }


### PR DESCRIPTION
Add a bunch of tests that XorT[Id, A, B] methods are consistent with
Xor[A, B].