### PR TITLE
Change ProdInstance to ProdInstances for consistency

### DIFF
--- a/core/src/main/scala/cats/data/Prod.scala
+++ b/core/src/main/scala/cats/data/Prod.scala
@@ -21,7 +21,7 @@ object Prod extends ProdInstances {
     Some((x.first, x.second))
 }
 
-private[data] sealed abstract class ProdInstances extends ProdInstance0 {
+private[data] sealed abstract class ProdInstances extends ProdInstances0 {
   implicit def prodAlternative[F[_], G[_]](implicit FF: Alternative[F], GG: Alternative[G]): Alternative[Lambda[X => Prod[F, G, X]]] = new ProdAlternative[F, G] {
     def F: Alternative[F] = FF
     def G: Alternative[G] = GG
@@ -33,35 +33,35 @@ private[data] sealed abstract class ProdInstances extends ProdInstance0 {
   }
 }
 
-sealed abstract class ProdInstance0 extends ProdInstance1 {
+sealed abstract class ProdInstances0 extends ProdInstances1 {
   implicit def prodMonoidK[F[_], G[_]](implicit FF: MonoidK[F], GG: MonoidK[G]): MonoidK[Lambda[X => Prod[F, G, X]]] = new ProdMonoidK[F, G] {
     def F: MonoidK[F] = FF
     def G: MonoidK[G] = GG
   }
 }
 
-sealed abstract class ProdInstance1 extends ProdInstance2 {
+sealed abstract class ProdInstances1 extends ProdInstances2 {
   implicit def prodSemigroupK[F[_], G[_]](implicit FF: SemigroupK[F], GG: SemigroupK[G]): SemigroupK[Lambda[X => Prod[F, G, X]]] = new ProdSemigroupK[F, G] {
     def F: SemigroupK[F] = FF
     def G: SemigroupK[G] = GG
   }
 }
 
-sealed abstract class ProdInstance2 extends ProdInstance3 {
+sealed abstract class ProdInstances2 extends ProdInstances3 {
   implicit def prodApplicative[F[_], G[_]](implicit FF: Applicative[F], GG: Applicative[G]): Applicative[Lambda[X => Prod[F, G, X]]] = new ProdApplicative[F, G] {
     def F: Applicative[F] = FF
     def G: Applicative[G] = GG
   }
 }
 
-sealed abstract class ProdInstance3 extends ProdInstance4 {
+sealed abstract class ProdInstances3 extends ProdInstances4 {
   implicit def prodApply[F[_], G[_]](implicit FF: Apply[F], GG: Apply[G]): Apply[Lambda[X => Prod[F, G, X]]] = new ProdApply[F, G] {
     def F: Apply[F] = FF
     def G: Apply[G] = GG
   }
 }
 
-sealed abstract class ProdInstance4 {
+sealed abstract class ProdInstances4 {
   implicit def prodFunctor[F[_], G[_]](implicit FF: Functor[F], GG: Functor[G]): Functor[Lambda[X => Prod[F, G, X]]] = new ProdFunctor[F, G] {
     def F: Functor[F] = FF
     def G: Functor[G] = GG


### PR DESCRIPTION
This makes the `Prod` instances hierarchy names consistent with instances for
other data types. Mostly this is to make them easier to find with
grepping.