### PR TITLE
Streaming and StreamingT extend Product with Serializable

### DIFF
--- a/core/src/main/scala/cats/data/Streaming.scala
+++ b/core/src/main/scala/cats/data/Streaming.scala
@@ -58,7 +58,7 @@ import scala.collection.mutable
  *     constructed with `Foldable#foldRight`, and that `.map` and
  *     `.flatMap` operations over the tail will be safely trampolined.
  */
-sealed abstract class Streaming[A] { lhs =>
+sealed abstract class Streaming[A] extends Product with Serializable { lhs =>
 
   import Streaming.{Empty, Wait, Cons}
 

--- a/core/src/main/scala/cats/data/StreamingT.scala
+++ b/core/src/main/scala/cats/data/StreamingT.scala
@@ -14,7 +14,7 @@ import cats.syntax.all._
  * not support many methods on `Streaming[A]` which return immediate
  * values.
  */
-sealed abstract class StreamingT[F[_], A] { lhs =>
+sealed abstract class StreamingT[F[_], A] extends Product with Serializable { lhs =>
 
   import StreamingT.{Empty, Wait, Cons}
 


### PR DESCRIPTION
This helps type inference by fixing the least upper bound of subtypes of
Streaming(T).

Before:
```scala
scala> val x = if (true) Cons(1, Now(Streaming.empty[Int])) else Streaming.Empty[Int]()
x: Product with Serializable with cats.data.Streaming[Int] = Streaming(1, ...)
```

After:
```scala
scala> val x = if (true) Cons(1, Now(Streaming.empty[Int])) else Streaming.Empty[Int]()
x: cats.data.Streaming[Int] = Streaming(1, ...)
```