### PR TITLE
Fix outdated example in Scaladoc for catchOnly

### DIFF
--- a/core/src/main/scala/cats/data/Xor.scala
+++ b/core/src/main/scala/cats/data/Xor.scala
@@ -217,7 +217,7 @@ trait XorFunctions {
    * the resulting `Xor`. Uncaught exceptions are propagated.
    *
    * For example: {{{
-   * val result: NumberFormatException Xor Int = catching[NumberFormatException] { "foo".toInt }
+   * val result: NumberFormatException Xor Int = catchOnly[NumberFormatException] { "foo".toInt }
    * }}}
    */
   def catchOnly[T >: Null <: Throwable]: CatchOnlyPartiallyApplied[T] =


### PR DESCRIPTION
Just noticed that the example didn't get the rename.