### PR TITLE
Add tests to cover derived methods leftMap and rightMap on BiFunctor

### DIFF
--- a/core/src/main/scala/cats/syntax/bifunctor.scala
+++ b/core/src/main/scala/cats/syntax/bifunctor.scala
@@ -10,5 +10,10 @@ trait BifunctorSyntax {
 }
 
 class BifunctorOps[F[_, _], A, B](fab: F[A, B])(implicit F: Bifunctor[F]) {
+  
   def bimap[C, D](f: A => C, g: B => D): F[C,D] = F.bimap(fab)(f,g)
+
+  def leftMap[C](f: A => C): F[C, B] = F.leftMap(fab)(f)
+
+  def rightMap[D](f: B => D): F[A, D] = F.rightMap(fab)(f)
 }

--- a/laws/src/main/scala/cats/laws/BifunctorLaws.scala
+++ b/laws/src/main/scala/cats/laws/BifunctorLaws.scala
@@ -15,6 +15,13 @@ trait BifunctorLaws[F[_, _]] {
   def bifunctorComposition[A, B, C, X, Y, Z](fa: F[A, X], f: A => B, f2: B => C, g: X => Y, g2: Y => Z): IsEq[F[C, Z]] = {
     fa.bimap(f, g).bimap(f2, g2) <-> fa.bimap(f andThen f2, g andThen g2)
   }
+
+  def bifunctorLeftMapIdentity[A, B](fa: F[A, B]): IsEq[F[A, B]] =
+    F.leftMap(fa)(identity) <-> fa
+
+  def bifunctorRightMapIdentity[A, B](fa: F[A, B]): IsEq[F[A, B]] =
+    F.rightMap(fa)(identity) <-> fa
+
 }
 
 object BifunctorLaws {

--- a/laws/src/main/scala/cats/laws/BifunctorLaws.scala
+++ b/laws/src/main/scala/cats/laws/BifunctorLaws.scala
@@ -17,10 +17,18 @@ trait BifunctorLaws[F[_, _]] {
   }
 
   def bifunctorLeftMapIdentity[A, B](fa: F[A, B]): IsEq[F[A, B]] =
-    F.leftMap(fa)(identity) <-> fa
+    fa.leftMap(identity) <-> fa
 
   def bifunctorRightMapIdentity[A, B](fa: F[A, B]): IsEq[F[A, B]] =
-    F.rightMap(fa)(identity) <-> fa
+    fa.rightMap(identity) <-> fa
+
+  def bifunctorLeftMapComposition[A, B, C, D](fa: F[A, B], f: A => C, g: C => D): IsEq[F[D, B]] = {
+    fa.leftMap(f).leftMap(g) <-> fa.leftMap(f andThen g)
+  }
+
+  def bifunctorRightMapComposition[A, B, C, D](fa: F[A, B], f: B => C, g: C => D): IsEq[F[A, D]] = {
+    fa.rightMap(f).rightMap(g) <-> fa.rightMap(f andThen g)
+  }
 
 }
 

--- a/laws/src/main/scala/cats/laws/discipline/BifunctorTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/BifunctorTests.scala
@@ -23,7 +23,9 @@ trait BifunctorTests[F[_, _]] extends Laws {
       name = "Bifunctor",
       parent = None,
       "Bifunctor Identity" -> forAll(laws.bifunctorIdentity[A, B] _),
-      "Bifunctor associativity" -> forAll(laws.bifunctorComposition[A, A2, A3, B, B2, B3] _)
+      "Bifunctor associativity" -> forAll(laws.bifunctorComposition[A, A2, A3, B, B2, B3] _),
+      "Bifunctor leftMap Identity" -> forAll(laws.bifunctorLeftMapIdentity[A, B] _),
+      "Bifunctor rightMap Identity" -> forAll(laws.bifunctorRightMapIdentity[A, B] _)
     )
   }
 }

--- a/laws/src/main/scala/cats/laws/discipline/BifunctorTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/BifunctorTests.scala
@@ -17,7 +17,9 @@ trait BifunctorTests[F[_, _]] extends Laws {
       ArbB2: Arbitrary[B => B2],
       ArbB3: Arbitrary[B2 => B3],
       EqFAB: Eq[F[A, B]],
-      EqFCZ: Eq[F[A3, B3]]
+      EqFCZ: Eq[F[A3, B3]],
+      EqFA3B: Eq[F[A3, B]],
+      EqFAB3: Eq[F[A, B3]]
   ): RuleSet = {
     new DefaultRuleSet(
       name = "Bifunctor",
@@ -25,7 +27,9 @@ trait BifunctorTests[F[_, _]] extends Laws {
       "Bifunctor Identity" -> forAll(laws.bifunctorIdentity[A, B] _),
       "Bifunctor associativity" -> forAll(laws.bifunctorComposition[A, A2, A3, B, B2, B3] _),
       "Bifunctor leftMap Identity" -> forAll(laws.bifunctorLeftMapIdentity[A, B] _),
-      "Bifunctor rightMap Identity" -> forAll(laws.bifunctorRightMapIdentity[A, B] _)
+      "Bifunctor rightMap Identity" -> forAll(laws.bifunctorRightMapIdentity[A, B] _),
+      "Bifunctor leftMap associativity" -> forAll(laws.bifunctorLeftMapComposition[A, B, A2, A3] _),
+      "Bifunctor rightMap associativity" -> forAll(laws.bifunctorRightMapComposition[A, B, B2, B3] _)
     )
   }
 }


### PR DESCRIPTION
This PR would add tests that should cover identity for the derived leftMap and rightMap on BiFunctor.

I guess this PR is exploratory:
* Is this a suitable use of the laws infrastructure? Seems to be a good use, but not sure if you would actually consider them laws.

Also:
* There is no syntax for leftMap and rightMap at this stage, just bimap; would it make sense to add these as syntax also. I’ve not done that in this PR, but if it is generally in line with what we want to do I can add.