### PR TITLE
Tests: Xor.to and Ior.to consistency

### DIFF
--- a/tests/src/test/scala/cats/tests/IorTests.scala
+++ b/tests/src/test/scala/cats/tests/IorTests.scala
@@ -130,4 +130,16 @@ class IorTests extends CatsSuite {
       iorMaybe should === (Some(ior))
     }
   }
+
+  test("to consistent with toList") {
+    forAll { (x: Int Ior String) =>
+      x.to[List, String] should === (x.toList)
+    }
+  }
+
+  test("to consistent with toOption") {
+    forAll { (x: Int Ior String) =>
+      x.to[Option, String] should === (x.toOption)
+    }
+  }
 }

--- a/tests/src/test/scala/cats/tests/XorTests.scala
+++ b/tests/src/test/scala/cats/tests/XorTests.scala
@@ -183,4 +183,16 @@ class XorTests extends CatsSuite {
     }
   }
 
+  test("to consistent with toList") {
+    forAll { (x: Int Xor String) =>
+      x.to[List, String] should === (x.toList)
+    }
+  }
+
+  test("to consistent with toOption") {
+    forAll { (x: Int Xor String) =>
+      x.to[Option, String] should === (x.toOption)
+    }
+  }
+
 }


### PR DESCRIPTION
Test that `Xor.to` and `Ior.to` are consistent with the less general
`toOption` and `toList` methods