### PR TITLE
DO NOT MERGE: repeat evaluation with Streaming.memoize

### DIFF
--- a/tests/src/test/scala/cats/tests/StreamingTests.scala
+++ b/tests/src/test/scala/cats/tests/StreamingTests.scala
@@ -43,6 +43,18 @@ class AdHocStreamingTests extends CatsSuite {
     }
   }
 
+  test("results aren't reevaluated after memoize") {
+    forAll { (orig: Streaming[Int]) =>
+      val size = orig.toList.size
+      var i = 0
+      val memoized = orig.map(_ => i += 1).memoize
+      memoized.toList
+      i should === (size)
+      memoized.toList
+      i should === (size)
+    }
+  }
+
   // convert (A => List[B]) to (A => Streaming[B])
   def convertF[A, B](f: A => List[B]): A => Streaming[B] =
     (a: A) => Streaming.fromList(f(a))


### PR DESCRIPTION
This is a potential bug report and is not meant to be merged in its
current form.

This test fails. It attempts to check that if a `Streaming` instance is
created via `.memoize`, then its elements won't be evaluated multiple
times (such as when `.toList` is called).

One could argue that this is a bogus test case, since side effects
should be tracked in a type other than `Unit`. However, I believe that
this means that we might be evaluating arguments overly-eagerly, which
is a problem in itself.

I made a naive attempt at fixing this by making `Streaming.map` a little
lazier in the `Cons` case, but that didn't seem to do the trick.

@non do you have any thoughts?