### PR TITLE
Fix Streaming#memoization.

### DIFF
--- a/core/src/main/scala/cats/data/Streaming.scala
+++ b/core/src/main/scala/cats/data/Streaming.scala
@@ -642,14 +642,21 @@ sealed abstract class Streaming[A] extends Product with Serializable { lhs =>
    * Ensure that repeated traversals of the stream will not cause
    * repeated tail computations.
    *
-   * By default stream does not memoize to avoid memory leaks when the
-   * head of the stream is retained.
+   * By default this structure does not memoize to avoid memory leaks
+   * when the head of the stream is retained. However, the user
+   * ultimately has control of the memoization approach based on what
+   * kinds of Eval instances they use.
+   *
+   * There are two calls to memoized here -- one is a recursive call
+   * to this method (on the tail) and the other is a call to memoize
+   * the Eval instance holding the tail. For more information on how
+   * .memoize works see Eval#memoize.
    */
   def memoize: Streaming[A] =
     this match {
       case Empty() => Empty()
-      case Wait(lt) => Wait(lt.memoize)
-      case Cons(a, lt) => Cons(a, lt.memoize)
+      case Wait(lt) => Wait(lt.map(_.memoize).memoize)
+      case Cons(a, lt) => Cons(a, lt.map(_.memoize).memoize)
     }
 
   /**

--- a/core/src/main/scala/cats/data/Streaming.scala
+++ b/core/src/main/scala/cats/data/Streaming.scala
@@ -647,10 +647,10 @@ sealed abstract class Streaming[A] extends Product with Serializable { lhs =>
    * ultimately has control of the memoization approach based on what
    * kinds of Eval instances they use.
    *
-   * There are two calls to memoized here -- one is a recursive call
+   * There are two calls to .memoize here -- one is a recursive call
    * to this method (on the tail) and the other is a call to memoize
    * the Eval instance holding the tail. For more information on how
-   * .memoize works see Eval#memoize.
+   * this works see [[cats.Eval.memoize]].
    */
   def memoize: Streaming[A] =
     this match {

--- a/tests/src/test/scala/cats/tests/StreamingTests.scala
+++ b/tests/src/test/scala/cats/tests/StreamingTests.scala
@@ -23,6 +23,24 @@ class StreamingTests extends CatsSuite {
 
 class AdHocStreamingTests extends CatsSuite {
 
+  test("results aren't reevaluated after memoize") {
+    forAll { (orig: Streaming[Int]) =>
+      val ns = orig.toList
+      val size = ns.size
+
+      var i = 0
+      val memoized = orig.map { n => i += 1; n }.memoize
+
+      val xs = memoized.toList
+      i should === (size)
+      xs should === (ns)
+
+      val ys = memoized.toList
+      i should === (size)
+      ys should === (ns)
+    }
+  }
+
   // convert List[A] to Streaming[A]
   def convert[A](as: List[A]): Streaming[A] =
     Streaming.fromList(as)

--- a/tests/src/test/scala/cats/tests/StreamingTests.scala
+++ b/tests/src/test/scala/cats/tests/StreamingTests.scala
@@ -55,10 +55,6 @@ class AdHocStreamingTests extends CatsSuite {
     }
   }
 
-  // convert List[A] to Streaming[A]
-  def convert[A](as: List[A]): Streaming[A] =
-    Streaming.fromList(as)
-
   test("fromList/toList") {
     forAll { (xs: List[Int]) =>
       Streaming.fromList(xs).toList should === (xs)


### PR DESCRIPTION
This commit fixes a bug noticed by @ceedubs. The basic issue
is that we have to be sure to memoize the Eval instance holding
the tail while *also* memoizing the tail itself when it is
calculated. Previously we were only memoizing the head node.