### PR TITLE
Add law-checking for Either Eq instance

### DIFF
--- a/tests/src/test/scala/cats/tests/EitherTests.scala
+++ b/tests/src/test/scala/cats/tests/EitherTests.scala
@@ -11,19 +11,25 @@ class EitherTests extends CatsSuite {
   checkAll("Either[Int, Int] with Option", TraverseTests[Either[Int, ?]].traverse[Int, Int, Int, Int, Option, Option])
   checkAll("Traverse[Either[Int, ?]", SerializableTests.serializable(Traverse[Either[Int, ?]]))
 
-  val eq = eitherEq[Int, String]
   val partialOrder = eitherPartialOrder[Int, String]
   val order = implicitly[Order[Either[Int, String]]]
   val monad = implicitly[Monad[Either[Int, ?]]]
   val show = implicitly[Show[Either[Int, String]]]
 
+  {
+    implicit val S = ListWrapper.eqv[String]
+    implicit val I = ListWrapper.eqv[Int]
+    checkAll("Either[ListWrapper[String], ListWrapper[Int]]", OrderLaws[Either[ListWrapper[String], ListWrapper[Int]]].eqv)
+    checkAll("Eq[Either[ListWrapper[String], ListWrapper[Int]]]", SerializableTests.serializable(Eq[Either[ListWrapper[String], ListWrapper[Int]]]))
+  }
+
   val orderLaws = OrderLaws[Either[Int, String]]
-  checkAll("Either[Int, String]", orderLaws.eqv)
   checkAll("Either[Int, String]", orderLaws.partialOrder(partialOrder))
   checkAll("Either[Int, String]", orderLaws.order(order))
 
 
   test("implicit instances resolve specifically") {
+    val eq = eitherEq[Int, String]
     assert(!eq.isInstanceOf[PartialOrder[_]])
     assert(!eq.isInstanceOf[Order[_]])
     assert(!partialOrder.isInstanceOf[Order[_]])


### PR DESCRIPTION
I think we were trying to do this before, but the approach we were
taking was testing the Order instance instead of the Eq instance.