### PR TITLE
Fix bug with Streaming#thunk.

### DIFF
--- a/core/src/main/scala/cats/data/Streaming.scala
+++ b/core/src/main/scala/cats/data/Streaming.scala
@@ -808,8 +808,8 @@ object Streaming extends StreamingInstances {
    * Continually return the result of a thunk.
    *
    * This method only differs from `continually` in that the thunk may
-   * not be pure. The stream is memoized to ensure that repeated
-   * traversals produce the same results.
+   * not be pure. Thus, repeated traversals may produce different
+   * results.
    */
   def thunk[A](f: () => A): Streaming[A] =
     knot(s => Cons(f(), s), memo = false)

--- a/core/src/main/scala/cats/data/Streaming.scala
+++ b/core/src/main/scala/cats/data/Streaming.scala
@@ -812,7 +812,7 @@ object Streaming extends StreamingInstances {
    * traversals produce the same results.
    */
   def thunk[A](f: () => A): Streaming[A] =
-    knot(s => Cons(f(), s), memo = true)
+    knot(s => Cons(f(), s), memo = false)
 
   /**
    * Produce an infinite stream of values given an initial value and a

--- a/tests/src/test/scala/cats/tests/StreamingTests.scala
+++ b/tests/src/test/scala/cats/tests/StreamingTests.scala
@@ -157,6 +157,16 @@ class AdHocStreamingTests extends CatsSuite {
     }
   }
 
+  test("thunk is evaluated for each item") {
+    // don't want the stream to be too big
+    implicit val arbInt = Arbitrary(Gen.choose(-10, 20))
+    forAll { (start: Int, end: Int) =>
+      var i = start - 1
+      val stream = Streaming.thunk{ () => i += 1; i}.takeWhile(_ <= end)
+      stream.toList should === ((start to end).toList)
+    }
+  }
+
   test("interval") {
     // we don't want this test to take a really long time
     implicit val arbInt: Arbitrary[Int] = Arbitrary(Gen.choose(-10, 20))


### PR DESCRIPTION
The .thunk method is not supposed to memoize the results,
allowing the caller to provide an impure function which
returns different values on different calls.

However, .thunk's definition used .knot with memoization,
which completely defeated the point. This commit removes
the memoization allowing this method to function correctly.

Fixes #677.