### PR TITLE
Fix copy-paste naming errors (xor -> validated)

### DIFF
--- a/core/src/main/scala/cats/data/Validated.scala
+++ b/core/src/main/scala/cats/data/Validated.scala
@@ -215,7 +215,7 @@ private[data] sealed abstract class ValidatedInstances extends ValidatedInstance
 }
 
 private[data] sealed abstract class ValidatedInstances1 extends ValidatedInstances2 {
-  implicit def xorPartialOrder[A: PartialOrder, B: PartialOrder]: PartialOrder[Validated[A,B]] =
+  implicit def validatedPartialOrder[A: PartialOrder, B: PartialOrder]: PartialOrder[Validated[A,B]] =
     new PartialOrder[Validated[A,B]] {
       def partialCompare(x: Validated[A,B], y: Validated[A,B]): Double = x partialCompare y
       override def eqv(x: Validated[A,B], y: Validated[A,B]): Boolean = x === y
@@ -223,7 +223,7 @@ private[data] sealed abstract class ValidatedInstances1 extends ValidatedInstanc
 }
 
 private[data] sealed abstract class ValidatedInstances2 {
-  implicit def xorEq[A: Eq, B: Eq]: Eq[Validated[A,B]] =
+  implicit def validatedEq[A: Eq, B: Eq]: Eq[Validated[A,B]] =
     new Eq[Validated[A,B]] {
       def eqv(x: Validated[A,B], y: Validated[A,B]): Boolean = x === y
     }


### PR DESCRIPTION
Am I correct in assuming that these were:
  1.  supposed to say "validated"
  2.  probably copy-paste errors
  3.  in any case, not semantically meaningful, as they are usually imported as a group of implicits rather than individually?