### PR TITLE
Move NaturalTransformation.or from companion to trait

### DIFF
--- a/core/src/main/scala/cats/arrow/NaturalTransformation.scala
+++ b/core/src/main/scala/cats/arrow/NaturalTransformation.scala
@@ -13,19 +13,19 @@ trait NaturalTransformation[F[_], G[_]] extends Serializable { self =>
 
   def andThen[H[_]](f: NaturalTransformation[G, H]): NaturalTransformation[F, H] =
     f.compose(self)
+
+  def or[H[_]](h: H ~> G): Coproduct[F, H, ?] ~> G =
+    new (Coproduct[F, H, ?] ~> G) {
+      def apply[A](fa: Coproduct[F, H, A]): G[A] = fa.run match {
+        case Xor.Left(ff) => self(ff)
+        case Xor.Right(gg) => h(gg)
+      }
+    }
 }
 
 object NaturalTransformation {
   def id[F[_]]: NaturalTransformation[F, F] =
     new NaturalTransformation[F, F] {
       def apply[A](fa: F[A]): F[A] = fa
-    }
-
-  def or[F[_], G[_], H[_]](f: F ~> H, g: G ~> H): Coproduct[F, G, ?] ~> H =
-    new (Coproduct[F, G, ?] ~> H) {
-      def apply[A](fa: Coproduct[F, G, A]): H[A] = fa.run match {
-        case Xor.Left(ff) => f(ff)
-        case Xor.Right(gg) => g(gg)
-      }
     }
 }

--- a/docs/src/main/tut/freemonad.md
+++ b/docs/src/main/tut/freemonad.md
@@ -448,7 +448,7 @@ object InMemoryDatasourceInterpreter extends (DataOp ~> Id) {
   }
 }
 
-val interpreter: CatsApp ~> Id = NaturalTransformation.or(InMemoryDatasourceInterpreter, ConsoleCatsInterpreter)
+val interpreter: CatsApp ~> Id = InMemoryDatasourceInterpreter or ConsoleCatsInterpreter
 ```
 
 Now if we run our program and type in "snuggles" when prompted, we see something like this:

--- a/docs/src/main/tut/freemonad.md
+++ b/docs/src/main/tut/freemonad.md
@@ -357,7 +357,6 @@ lets us compose different algebras in the context of `Free`.
 Let's see a trivial example of unrelated ADT's getting composed as a `Coproduct` that can form a more complex program.
 
 ```tut:silent
-import cats.arrow.NaturalTransformation
 import cats.data.{Xor, Coproduct}
 import cats.free.{Inject, Free}
 import cats.{Id, ~>}

--- a/free/src/test/scala/cats/free/InjectTests.scala
+++ b/free/src/test/scala/cats/free/InjectTests.scala
@@ -1,7 +1,6 @@
 package cats
 package free
 
-import cats.arrow.NaturalTransformation
 import cats.data.{Xor, Coproduct}
 import cats.laws.discipline.arbitrary
 import cats.tests.CatsSuite
@@ -53,7 +52,7 @@ class InjectTests extends CatsSuite {
     }
   }
 
-  val coProductInterpreter: T ~> Id = NaturalTransformation.or(Test1Interpreter, Test2Interpreter)
+  val coProductInterpreter: T ~> Id = Test1Interpreter or Test2Interpreter
 
   val x: Free[T, Int] = Free.inject[Test1Algebra, T](Test1(1, identity))
 

--- a/tests/src/test/scala/cats/tests/NaturalTransformationTests.scala
+++ b/tests/src/test/scala/cats/tests/NaturalTransformationTests.scala
@@ -59,10 +59,10 @@ class NaturalTransformationTests extends CatsSuite {
   }
 
   test("or") {
-    val combinedInterpreter = NaturalTransformation.or(Test1NT, Test2NT)
+    val combinedInterpreter = Test1NT or Test2NT
     forAll { (a : Int, b : Int) =>
-      (combinedInterpreter(Coproduct.left(Test1(a))) == Id.pure(a)) should ===(true)
-      (combinedInterpreter(Coproduct.right(Test2(b))) == Id.pure(b)) should ===(true)
+      combinedInterpreter(Coproduct.left(Test1(a))) should === (Id.pure(a))
+      combinedInterpreter(Coproduct.right(Test2(b))) should === (Id.pure(b))
     }
   }
 }


### PR DESCRIPTION
I think this provides slightly nicer syntax for combining natural
transformations, and it makes it more consistent with `andThen` and
`compose`. If people like it, they can merge, but if not it's no
problem.