### PR TITLE
Reduce OptionT from MonadCombine to Monad

### DIFF
--- a/core/src/main/scala/cats/data/OptionT.scala
+++ b/core/src/main/scala/cats/data/OptionT.scala
@@ -137,8 +137,9 @@ private[data] sealed trait OptionTInstances1 {
 }
 
 private[data] sealed trait OptionTInstances extends OptionTInstances1 {
-  implicit def optionTMonadCombine[F[_]](implicit F: Monad[F]): MonadCombine[OptionT[F, ?]] =
-    new MonadCombine[OptionT[F, ?]] {
+
+  implicit def optionTMonad[F[_]](implicit F: Monad[F]): Monad[OptionT[F, ?]] =
+    new Monad[OptionT[F, ?]] {
       def pure[A](a: A): OptionT[F, A] = OptionT.pure(a)
 
       def flatMap[A, B](fa: OptionT[F, A])(f: A => OptionT[F, B]): OptionT[F, B] =
@@ -146,10 +147,8 @@ private[data] sealed trait OptionTInstances extends OptionTInstances1 {
 
       override def map[A, B](fa: OptionT[F, A])(f: A => B): OptionT[F, B] =
         fa.map(f)
-
-      override def empty[A]: OptionT[F,A] = OptionT(F.pure(None))
-      override def combine[A](x: OptionT[F,A], y: OptionT[F,A]): OptionT[F,A] = x orElse y
     }
+
   implicit def optionTEq[F[_], A](implicit FA: Eq[F[Option[A]]]): Eq[OptionT[F, A]] =
     FA.on(_.value)
 

--- a/tests/src/test/scala/cats/tests/OptionTTests.scala
+++ b/tests/src/test/scala/cats/tests/OptionTTests.scala
@@ -2,7 +2,7 @@ package cats.tests
 
 import cats.{Applicative, Id, Monad, Show}
 import cats.data.{OptionT, Validated, Xor}
-import cats.laws.discipline.{ApplicativeTests, FunctorTests, MonadCombineTests, SerializableTests}
+import cats.laws.discipline.{ApplicativeTests, FunctorTests, MonadTests, SerializableTests}
 import cats.laws.discipline.arbitrary._
 import org.scalacheck.{Arbitrary, Gen}
 
@@ -146,8 +146,8 @@ class OptionTTests extends CatsSuite {
     }
   }
 
-  checkAll("OptionT[List, Int]", MonadCombineTests[OptionT[List, ?]].monad[Int, Int, Int])
-  checkAll("MonadOptionT[List, ?]]", SerializableTests.serializable(Monad[OptionT[List, ?]]))
+  checkAll("Monad[OptionT[List, Int]]", MonadTests[OptionT[List, ?]].monad[Int, Int, Int])
+  checkAll("Monad[OptionT[List, ?]]", SerializableTests.serializable(Monad[OptionT[List, ?]]))
 
   {
     implicit val F = ListWrapper.functor


### PR DESCRIPTION
Reduces `OptionT` `MonadCombine` instance to `Monad`. 

The `MonadCombine` instance for `OptionT` was not tested and does not pass laws.

This addresses #693. 

#694 exists for tracking potential changes to laws which may allow this instance, or an alternative type class instance, to be reinstated. 