### PR TITLE
Add some documentation to the Travis script.

### DIFF
--- a/scripts/travis-publish.sh
+++ b/scripts/travis-publish.sh
@@ -1,5 +1,17 @@
 #!/bin/bash
 
+# Build Overview:
+# The overall build is split into a number of parts
+# 1. The build for coverage is performed. This:
+#   a. First enables the coverage processing, and then
+#   b. Builds and tests for the JVM using the validateJVM target, and then
+#   c. Produces the coverage report, and then
+#   d. Clean is run (as part of coverageReport), to clear down the built artifacts
+# 2. The scala js build is executed, compiling the application and testing it for scala js.
+# 3. The validateJVM target is executed again, due to the fact that producing coverage with the
+#    code coverage tool causes the byte code to be instrumented/modified to record the coverage
+#    metrics when the tests are executing. This causes the full JVM build to be run a second time.
+
 # Example setting to use at command line for testing:
 # export TRAVIS_SCALA_VERSION=2.10.5;export TRAVIS_PULL_REQUEST="false";export TRAVIS_BRANCH="master"
 


### PR DESCRIPTION
This PR is to add some documentation to the Travis build script based on the discussion in #699. 

I’ve just put some information in the script and I haven’t gone into a huge amount of detail. The main thing I wanted to capture was the rationale for building the JVM twice rather than once - which makes perfect sense once you understand the coverage tool; but confused me at first.

Happy to restructure or move elsewhere if that is preferred.