### PR TITLE
Adds test for Show[Const]

### DIFF
--- a/tests/src/test/scala/cats/tests/ConstTests.scala
+++ b/tests/src/test/scala/cats/tests/ConstTests.scala
@@ -35,4 +35,19 @@ class ConstTests extends CatsSuite {
 
   checkAll("Const[String, Int]", ContravariantTests[Const[String, ?]].contravariant[Int, Int, Int])
   checkAll("Contravariant[Const[String, ?]]", SerializableTests.serializable(Contravariant[Const[String, ?]]))
+
+  test("show") {
+
+    Const(1).show should === ("Const(1)")
+
+    forAll { const: Const[Int, String] =>
+      const.show.startsWith("Const(") should === (true)
+      const.show.contains(const.getConst.show)
+      const.show should === (implicitly[Show[Const[Int, String]]].show(const))
+      const.show should === (const.retag[Boolean].show)
+    }
+  }
+
+
+
 }


### PR DESCRIPTION
Adds a test for `Show[Const]`, includes:
* Simple test of a specific value
* Test that all output starts with “Const(“
* Test that the `Show` for the result of `const.getConst` is contained in the result
* Test that implicitly obtained `Show` instance produces a result consistent with direct method invocation.
* Tests that retagging the `Const` does not affect the `Show` result

The last one raises an interesting question. The phantom type of the `Const` might be interesting enough information in some cases. The question is whether it is interesting enough to show.

Basically, `Const[Int, String]` and `Const[Int, Boolean]` produce the same show result. I implemented a test for the behaviour primarily to demonstrate that it is the case, and to raise a discussion on whether it warrants inclusion.