### PR TITLE
Add documentation for `OneAnd`

### DIFF
--- a/docs/src/main/tut/oneand.md
+++ b/docs/src/main/tut/oneand.md
@@ -7,3 +7,24 @@ scaladoc: "#cats.data.OneAnd"
 ---
 # OneAnd
 
+The `OneAnd[F[_],A]` data type represents a single element of type `A`
+that is guaranteed to be present (`head`) and in addition to this a
+second part that is wrapped inside an higher kinded type constructor
+`F[_]`.  By choosing the `F` parameter, you can model for example
+non-empty lists by choosing `List` for `F`, giving:
+
+```tut:silent
+import cats.data.OneAnd
+
+type NonEmptyList[A] = OneAnd[List, A]
+```
+
+which is the actual implementation of non-empty lists in cats.  By
+having the higher kinded type parameter `F[_]`, `OneAnd` is also able
+to represent other "non-empty" data structures, e.g.
+
+```tut:silent
+import cats.data.OneAnd
+
+type NonEmptyVector[A] = OneAnd[Vector, A]
+```


### PR DESCRIPTION
Hi all, I wrote a quick introduction to the `OneAnd` data type.  It is not especially fancy but it should at least give a brief overview and is better than an empty page ;)

I'd be happy to apply any additions / modifications, so let me know.

Best,
Markus

-- 24pullrequests
[![](http://24pullrequests.com/assets/logo-8a77737f86fec8def19a1c9a605c9841dbd44e59f243ed3bf64bbdf3214d6fa1.png)](http://24pullrequests.com/)