### PR TITLE
Adds Semigroup for Validated

### DIFF
--- a/core/src/main/scala/cats/data/Validated.scala
+++ b/core/src/main/scala/cats/data/Validated.scala
@@ -236,6 +236,12 @@ private[data] sealed abstract class ValidatedInstances extends ValidatedInstance
 }
 
 private[data] sealed abstract class ValidatedInstances1 extends ValidatedInstances2 {
+
+  implicit def validatedSemigroup[A, B](implicit A: Semigroup[A], B: Semigroup[B]): Semigroup[Validated[A, B]] =
+    new Semigroup[Validated[A, B]] {
+      def combine(x: Validated[A, B], y: Validated[A, B]): Validated[A, B] = x combine y
+    }
+
   implicit def validatedPartialOrder[A: PartialOrder, B: PartialOrder]: PartialOrder[Validated[A,B]] =
     new PartialOrder[Validated[A,B]] {
       def partialCompare(x: Validated[A,B], y: Validated[A,B]): Double = x partialCompare y

--- a/tests/src/test/scala/cats/tests/ValidatedTests.scala
+++ b/tests/src/test/scala/cats/tests/ValidatedTests.scala
@@ -24,6 +24,8 @@ class ValidatedTests extends CatsSuite {
 
   checkAll("Monoid[Validated[String, Int]]", GroupLaws[Validated[String, Int]].monoid)
 
+  checkAll("Semigroup[Validated[String, NonEmptyList[Int]]]", GroupLaws[Validated[String, NonEmptyList[Int]]].semigroup)
+
   {
     implicit val S = ListWrapper.partialOrder[String]
     implicit val I = ListWrapper.partialOrder[Int]

--- a/tests/src/test/scala/cats/tests/ValidatedTests.scala
+++ b/tests/src/test/scala/cats/tests/ValidatedTests.scala
@@ -22,9 +22,9 @@ class ValidatedTests extends CatsSuite {
   checkAll("Validated[String, Int]", OrderLaws[Validated[String, Int]].order)
   checkAll("Order[Validated[String, Int]]", SerializableTests.serializable(Order[Validated[String, Int]]))
 
-  checkAll("Monoid[Validated[String, Int]]", GroupLaws[Validated[String, Int]].monoid)
+  checkAll("Validated[String, Int]", GroupLaws[Validated[String, Int]].monoid)
 
-  checkAll("Semigroup[Validated[String, NonEmptyList[Int]]]", GroupLaws[Validated[String, NonEmptyList[Int]]].semigroup)
+  checkAll("Validated[String, NonEmptyList[Int]]", GroupLaws[Validated[String, NonEmptyList[Int]]].semigroup)
 
   {
     implicit val S = ListWrapper.partialOrder[String]


### PR DESCRIPTION
Added a `Semigroup` for `Validated` based on comment:
https://github.com/non/cats/pull/715#issuecomment-162326224

On a side note, I think there is at least one other `Monoid` instance (`Xor`) that has the same characteristics, i.e. no separate `Semigroup` instance . Seems based on the referenced comment it would be good to add these too?
