### PR TITLE
Adds Semigroup for Xor

### DIFF
--- a/core/src/main/scala/cats/data/Xor.scala
+++ b/core/src/main/scala/cats/data/Xor.scala
@@ -194,6 +194,12 @@ private[data] sealed abstract class XorInstances extends XorInstances1 {
 }
 
 private[data] sealed abstract class XorInstances1 extends XorInstances2 {
+
+  implicit def xorSemigroup[A, B](implicit A: Semigroup[A], B: Semigroup[B]): Semigroup[A Xor B] =
+    new Semigroup[A Xor B] {
+      def combine(x: A Xor B, y: A Xor B): A Xor B = x combine y
+    }
+
   implicit def xorPartialOrder[A: PartialOrder, B: PartialOrder]: PartialOrder[A Xor B] = new PartialOrder[A Xor B] {
     def partialCompare(x: A Xor B, y: A Xor B): Double = x partialCompare y
     override def eqv(x: A Xor B, y: A Xor B): Boolean = x === y

--- a/tests/src/test/scala/cats/tests/XorTests.scala
+++ b/tests/src/test/scala/cats/tests/XorTests.scala
@@ -12,8 +12,9 @@ import org.scalacheck.Arbitrary._
 import scala.util.Try
 
 class XorTests extends CatsSuite {
-  checkAll("Monoid[Xor[String, Int]]", GroupLaws[Xor[String, Int]].monoid)
-  checkAll("Semigroup[Xor[String, NonEmptyList[Int]]]", GroupLaws[Xor[String, NonEmptyList[Int]]].semigroup)
+  checkAll("Xor[String, Int]", GroupLaws[Xor[String, Int]].monoid)
+
+  checkAll("Xor[String, NonEmptyList[Int]]", GroupLaws[Xor[String, NonEmptyList[Int]]].semigroup)
 
   implicit val eq0 = XorT.xorTEq[Xor[String, ?], String, Int]
 

--- a/tests/src/test/scala/cats/tests/XorTests.scala
+++ b/tests/src/test/scala/cats/tests/XorTests.scala
@@ -1,9 +1,9 @@
 package cats
 package tests
 
-import cats.data.{Xor, XorT}
+import cats.data.{NonEmptyList, Xor, XorT}
 import cats.data.Xor._
-import cats.laws.discipline.arbitrary.xorArbitrary
+import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.{BifunctorTests, TraverseTests, MonadErrorTests, SerializableTests}
 import algebra.laws.{GroupLaws, OrderLaws}
 import org.scalacheck.{Arbitrary, Gen}
@@ -12,7 +12,8 @@ import org.scalacheck.Arbitrary._
 import scala.util.Try
 
 class XorTests extends CatsSuite {
-  checkAll("Xor[String, Int]", GroupLaws[Xor[String, Int]].monoid)
+  checkAll("Monoid[Xor[String, Int]]", GroupLaws[Xor[String, Int]].monoid)
+  checkAll("Semigroup[Xor[String, NonEmptyList[Int]]]", GroupLaws[Xor[String, NonEmptyList[Int]]].semigroup)
 
   implicit val eq0 = XorT.xorTEq[Xor[String, ?], String, Int]
 


### PR DESCRIPTION
As per #716, adding a `Semigroup` for the `Xor` data type which currently
has a `Monoid` instance but no `Semigroup` instance.