### PR TITLE
Adds Semigroup for Const

### DIFF
--- a/core/src/main/scala/cats/data/Const.scala
+++ b/core/src/main/scala/cats/data/Const.scala
@@ -72,6 +72,11 @@ private[data] sealed abstract class ConstInstances extends ConstInstances0 {
 }
 
 private[data] sealed abstract class ConstInstances0 extends ConstInstances1 {
+
+  implicit def constSemigroup[A: Semigroup, B]: Semigroup[Const[A, B]] = new Semigroup[Const[A, B]] {
+    def combine(x: Const[A, B], y: Const[A, B]): Const[A, B] = x combine y
+  }
+
   implicit def constPartialOrder[A: PartialOrder, B]: PartialOrder[Const[A, B]] = new PartialOrder[Const[A, B]]{
     def partialCompare(x: Const[A, B], y: Const[A, B]): Double =
       x partialCompare y

--- a/tests/src/test/scala/cats/tests/ConstTests.scala
+++ b/tests/src/test/scala/cats/tests/ConstTests.scala
@@ -25,6 +25,8 @@ class ConstTests extends CatsSuite {
   // Algebra checks for Serializability of instances as part of the laws
   checkAll("Monoid[Const[Int, String]]", GroupLaws[Const[Int, String]].monoid)
 
+  checkAll("Const[NonEmptyList[Int], String]", GroupLaws[Const[NonEmptyList[Int], String]].semigroup)
+
   // Note while Eq is a superclass of PartialOrder and PartialOrder a superclass
   // of Order, you can get different instances with different (more general) constraints.
   // For instance, you can get an Order for Const if the first type parameter has an Order,


### PR DESCRIPTION
Adding a `Semigroup` for `Const` to allow `Semigroup` behaviour for data
types with no valid `Monoid` instance.