### PR TITLE
Make StreamingT toString more like Streaming toString

### DIFF
--- a/core/src/main/scala/cats/data/StreamingT.scala
+++ b/core/src/main/scala/cats/data/StreamingT.scala
@@ -273,11 +273,12 @@ sealed abstract class StreamingT[F[_], A] extends Product with Serializable { lh
    * This method will not force evaluation of any lazy part of a
    * stream. As a result, you will see at most one element (the first
    * one).
-   *
-   * Use .toString(n) to see the first n elements of the stream.
    */
-  override def toString: String =
-    "StreamingT(...)"
+  override def toString: String = this match {
+    case Cons(a, _) => s"StreamingT($a, ...)"
+    case Wait(_) => "StreamingT(...)"
+    case Empty() => "StreamingT()"
+  }
 }
 
 object StreamingT extends StreamingTInstances {

--- a/tests/src/test/scala/cats/tests/StreamingTTests.scala
+++ b/tests/src/test/scala/cats/tests/StreamingTTests.scala
@@ -176,6 +176,14 @@ class StreamingTTests extends CatsSuite {
       StreamingT[Id, Int](x1, x2, tail: _*) should === (fromList)
     }
   }
+
+  test("toString is wrapped in StreamingT()"){
+    forAll { (xs: StreamingT[Option, Int]) =>
+      val s = xs.toString
+      s.take(11) should === ("StreamingT(")
+      s.last should === (')')
+    }
+  }
 }
 
 class SpecificStreamingTTests extends CatsSuite {


### PR DESCRIPTION
Before this, StreamingT was always returning "StreamingT(...)" for its
toString. It's now similar to Streaming in that it will return
"StreamingT()" in the case of Empty and will show the head element in
the case of Cons.

I also added a pretty weak test for its toString (which actually doesn't
capture my changes at all). It may be good to add further tests in the
future, but I've got to get to work, and I think this is at least an
improvement to the current status.