### PR TITLE
Add MonadFilter consistency to MonadFilter tests

### DIFF
--- a/laws/src/main/scala/cats/laws/discipline/MonadFilterTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/MonadFilterTests.scala
@@ -23,7 +23,8 @@ trait MonadFilterTests[F[_]] extends MonadTests[F] {
       name = "monadFilter",
       parent = Some(monad[A, B, C]),
       "monadFilter left empty" -> forAll(laws.monadFilterLeftEmpty[A, B] _),
-      "monadFilter right empty" -> forAll(laws.monadFilterRightEmpty[A, B] _))
+      "monadFilter right empty" -> forAll(laws.monadFilterRightEmpty[A, B] _),
+      "monadFilter consistency" -> forAll(laws.monadFilterConsistency[A, B] _))
   }
 }
 


### PR DESCRIPTION
A `monadFilterConsistency` law was added in
8f7a110d536c087c8b70032103fb5a51fab5f34f but wasn't hooked up in the
tests. This might be better accomplished with something like #370, but
in the interim I think we should at least hook it up.