### PR TITLE
Make table in Kleisli readable

### DIFF
--- a/docs/src/main/tut/kleisli.md
+++ b/docs/src/main/tut/kleisli.md
@@ -102,6 +102,7 @@ final case class Kleisli[F[_], A, B](run: A => F[B]) {
 Below are some more methods on `Kleisli` that can be used so long as the constraint on `F[_]`
 is satisfied.
 
+```
 Method    | Constraint on `F[_]`
 --------- | -------------------
 andThen   | FlatMap
@@ -110,6 +111,7 @@ flatMap   | FlatMap
 lower     | Monad
 map       | Functor
 traverse  | Applicative
+```
 
 ### Type class instances
 The type class instances for `Kleisli`, like that for functions, often fix the input type (and the `F[_]`) and leave


### PR DESCRIPTION
The table in the docs for [Kleisli](http://non.github.io/cats//tut/kleisli.html) is not readable, because it is missing markup.  I added ``` such that the table should now display properly

-- 24pullrequests
[![](http://24pullrequests.com/assets/logo-8a77737f86fec8def19a1c9a605c9841dbd44e59f243ed3bf64bbdf3214d6fa1.png)](http://24pullrequests.com/)
