### PR TITLE
typeclass -> type class

### DIFF
--- a/docs/src/main/tut/freemonad.md
+++ b/docs/src/main/tut/freemonad.md
@@ -350,8 +350,8 @@ val result: Map[String, Int] = compilePure(program, Map.empty)
 
 ## Composing Free monads ADTs.
 
-Real world applications often time combine different algebras. 
-The `Inject` typeclass described by Swierstra in [Data types à la carte](http://www.staff.science.uu.nl/~swier004/Publications/DataTypesALaCarte.pdf)
+Real world applications often time combine different algebras.
+The `Inject` type class described by Swierstra in [Data types à la carte](http://www.staff.science.uu.nl/~swier004/Publications/DataTypesALaCarte.pdf)
 lets us compose different algebras in the context of `Free`.
 
 Let's see a trivial example of unrelated ADT's getting composed as a `Coproduct` that can form a more complex program.

--- a/docs/src/main/tut/invariant.md
+++ b/docs/src/main/tut/invariant.md
@@ -7,7 +7,7 @@ scaladoc: "#cats.functor.Invariant"
 ---
 # Invariant
 
-The `Invariant` typeclass is for functors that define an `imap`
+The `Invariant` type class is for functors that define an `imap`
 function with the following type:
 
 ```scala
@@ -66,8 +66,8 @@ but we can't turn it back into a `Date` using only `contramap`!
 
 From the previous discussion we conclude that we need both the `map`
 from (covariant) `Functor` and `contramap` from `Contravariant`.
-There already is a typeclass for this and it is called `Invariant`.
-Instances of the `Invariant` typeclass provide the `imap` function:
+There already is a type class for this and it is called `Invariant`.
+Instances of the `Invariant` type class provide the `imap` function:
 
 ```scala
 def imap[A, B](fa: F[A])(f: A => B)(g: B => A): F[B]

--- a/docs/src/main/tut/monad.md
+++ b/docs/src/main/tut/monad.md
@@ -25,7 +25,7 @@ List(List(1),List(2,3)).flatten
 
 If `Applicative` is already present and `flatten` is well-behaved,
 extending the `Applicative` to a `Monad` is trivial. To provide evidence
-that a type belongs in the `Monad` typeclass, cats' implementation
+that a type belongs in the `Monad` type class, cats' implementation
 requires us to provide an implementation of `pure` (which can be reused
 from `Applicative`) and `flatMap`.
 

--- a/docs/src/main/tut/semigroup.md
+++ b/docs/src/main/tut/semigroup.md
@@ -47,9 +47,9 @@ Semigroup[Int => Int].combine({(x: Int) => x + 1},{(x: Int) => x * 10}).apply(6)
 
 Many of these types have methods defined directly on them,
 which allow for such combining, e.g. `++` on List, but the
-value of having a `Semigroup` typeclass available is that these
-compose, so for instance, we can say 
- 
+value of having a `Semigroup` type class available is that these
+compose, so for instance, we can say
+
 ```tut
 Map("foo" -> Map("bar" -> 5)).combine(Map("foo" -> Map("bar" -> 6), "baz" -> Map()))
 Map("foo" -> List(1, 2)).combine(Map("foo" -> List(3,4), "bar" -> List(42)))
@@ -87,7 +87,7 @@ two |+| n
 
 You'll notice that instead of declaring `one` as `Some(1)`, I chose
 `Option(1)`, and I added an explicit type declaration for `n`. This is
-because there aren't typeclass instances for Some or None, but for
+because there aren't type class instances for Some or None, but for
 Option. If we try to use Some and None, we'll get errors:
 
 ```tut:nofail
@@ -96,7 +96,7 @@ None |+| Some(1)
 ```
 
 N.B.
-Cats does not define a `Semigroup` typeclass itself, it uses the [`Semigroup`
+Cats does not define a `Semigroup` type class itself, it uses the [`Semigroup`
 trait](https://github.com/non/algebra/blob/master/core/src/main/scala/algebra/Semigroup.scala)
 which is defined in the [algebra project](https://github.com/non/algebra) on 
 which it depends. The [`cats` package object](https://github.com/non/cats/blob/master/core/src/main/scala/cats/package.scala)


### PR DESCRIPTION
In the documentation, most occurrences use "type class", but there are some occurrences of "typeclass" as well, this commit replaces all occurrences of "typeclass" with "type class" for a uniform naming.

-- 24pullrequests
[![](http://24pullrequests.com/assets/logo-8a77737f86fec8def19a1c9a605c9841dbd44e59f243ed3bf64bbdf3214d6fa1.png)](http://24pullrequests.com/)
