### PR TITLE
Remove unused Cokleisli.cokleisli method

### DIFF
--- a/core/src/main/scala/cats/data/Cokleisli.scala
+++ b/core/src/main/scala/cats/data/Cokleisli.scala
@@ -38,15 +38,9 @@ final case class Cokleisli[F[_], A, B](run: F[A] => B) { self =>
     Cokleisli(fca => F.extract(F.map(fca)(_._1)) -> run(F.map(fca)(_._2)))
 }
 
-object Cokleisli extends CokleisliInstances with CokleisliFunctions {
+object Cokleisli extends CokleisliInstances {
   def pure[F[_], A, B](x: B): Cokleisli[F, A, B] =
     Cokleisli(_ => x)
-}
-
-sealed trait CokleisliFunctions {
-  /** creates a [[Cokleisli]] from a function */
-  def cokleisli[F[_], A, B](f: F[A] => B): Cokleisli[F, A, B] =
-    Cokleisli(f)
 }
 
 private[data] sealed abstract class CokleisliInstances extends CokleisliInstances0 {

--- a/core/src/main/scala/cats/data/Kleisli.scala
+++ b/core/src/main/scala/cats/data/Kleisli.scala
@@ -64,9 +64,6 @@ final case class Kleisli[F[_], A, B](run: A => F[B]) { self =>
 object Kleisli extends KleisliInstances with KleisliFunctions
 
 private[data] sealed trait KleisliFunctions {
-  /** creates a [[Kleisli]] from a function */
-  def function[F[_], A, B](f: A => F[B]): Kleisli[F, A, B] =
-    Kleisli(f)
 
   def pure[F[_], A, B](x: B)(implicit F: Applicative[F]): Kleisli[F, A, B] =
     Kleisli(_ => F.pure(x))
@@ -153,7 +150,7 @@ private[data] sealed abstract class KleisliInstances1 extends KleisliInstances2 
       fb.map(f)
 
     def product[B, C](fb: Kleisli[F, A, B], fc: Kleisli[F, A, C]): Kleisli[F, A, (B, C)] =
-      Kleisli.function(a => Applicative[F].product(fb.run(a), fc.run(a)))
+      Kleisli(a => Applicative[F].product(fb.run(a), fc.run(a)))
   }
 }
 
@@ -163,7 +160,7 @@ private[data] sealed abstract class KleisliInstances2 extends KleisliInstances3 
       fa(f)
 
     def product[B, C](fb: Kleisli[F, A, B], fc: Kleisli[F, A, C]): Kleisli[F, A, (B, C)] =
-      Kleisli.function(a => Apply[F].product(fb.run(a), fc.run(a)))
+      Kleisli(a => Apply[F].product(fb.run(a), fc.run(a)))
 
     def map[B, C](fa: Kleisli[F, A, B])(f: B => C): Kleisli[F, A, C] =
       fa.map(f)

--- a/core/src/main/scala/cats/data/package.scala
+++ b/core/src/main/scala/cats/data/package.scala
@@ -39,7 +39,7 @@ package object data {
 
   type Reader[A, B] = ReaderT[Id, A, B]
   object Reader {
-    def apply[A, B](f: A => B): Reader[A, B] = ReaderT.function[Id, A, B](f)
+    def apply[A, B](f: A => B): Reader[A, B] = ReaderT[Id, A, B](f)
   }
 
   type Writer[L, V] = WriterT[Id, L, V]

--- a/tests/src/test/scala/cats/tests/KleisliTests.scala
+++ b/tests/src/test/scala/cats/tests/KleisliTests.scala
@@ -103,7 +103,7 @@ class KleisliTests extends CatsSuite {
 
   test("local composes functions") {
     forAll { (f: Int => Option[String], g: Int => Int, i: Int) =>
-      f(g(i)) should === (Kleisli.local[Option, String, Int](g)(Kleisli.function(f)).run(i))
+      f(g(i)) should === (Kleisli.local[Option, String, Int](g)(Kleisli(f)).run(i))
     }
   }
 
@@ -114,26 +114,26 @@ class KleisliTests extends CatsSuite {
   }
 
   test("lift") {
-    val f = Kleisli.function { (x: Int) => (Some(x + 1): Option[Int]) }
+    val f = Kleisli { (x: Int) => (Some(x + 1): Option[Int]) }
     val l = f.lift[List]
     (List(1, 2, 3) >>= l.run) should === (List(Some(2), Some(3), Some(4)))
   }
 
   test("transform") {
-    val opt = Kleisli.function { (x: Int) => Option(x.toDouble) }
+    val opt = Kleisli { (x: Int) => Option(x.toDouble) }
     val optToList = new (Option ~> List) { def apply[A](fa: Option[A]): List[A] = fa.toList }
     val list = opt.transform(optToList)
 
     val is = 0.to(10).toList
-    is.map(list.run) should === (is.map(Kleisli.function { (x: Int) => List(x.toDouble) }.run))
+    is.map(list.run) should === (is.map(Kleisli { (x: Int) => List(x.toDouble) }.run))
   }
 
   test("local") {
     case class Config(i: Int, s: String)
 
-    val kint = Kleisli.function { (x: Int) => Option(x.toDouble) }
+    val kint = Kleisli { (x: Int) => Option(x.toDouble) }
     val kconfig1 = kint.local[Config](_.i)
-    val kconfig2 = Kleisli.function { (c: Config) => Option(c.i.toDouble) }
+    val kconfig2 = Kleisli { (c: Config) => Option(c.i.toDouble) }
 
     val config = Config(0, "cats")
     kconfig1.run(config) should === (kconfig2.run(config))


### PR DESCRIPTION
This method currently isn't used. Since `Cokleisli` is already a case
class with an equivalent auto-generated `apply` method, I don't think I
see the usefulness of it. Feel free to let me know if you would prefer
to keep this around.