### PR TITLE
Fix docs duped url slashes

### DIFF
--- a/docs/src/main/tut/xor.md
+++ b/docs/src/main/tut/xor.md
@@ -39,7 +39,7 @@ How then do we communicate an error? By making it explicit in the data type we r
 
 ### `Xor` vs `Validated`
 
-In general, `Validated` is used to accumulate errors, while `Xor` is used to short-circuit a computation upon the first error. For more information, see the `Validated` vs `Xor` section of the [`Validated` documentation]({{ baseurl }}/tut/validated.html).
+In general, `Validated` is used to accumulate errors, while `Xor` is used to short-circuit a computation upon the first error. For more information, see the `Validated` vs `Xor` section of the [`Validated` documentation]({{ site.baseurl }}/tut/validated.html).
 
 ### Why not `Either`
 `Xor` is very similar to `scala.util.Either` - in fact, they are *isomorphic* (that is,

--- a/docs/src/site/_config.dev.yml
+++ b/docs/src/site/_config.dev.yml
@@ -1,9 +1,0 @@
-name: Cats Documentation
-markdown: redcarpet
-highlighter: pygments
-baseurl: /
-apidocs: /api/
-
-collections:
-  tut:
-    output: true

--- a/docs/src/site/_config.yml
+++ b/docs/src/site/_config.yml
@@ -1,7 +1,7 @@
 name: Cats Documentation
 markdown: redcarpet
 highlighter: pygments
-baseurl: /cats/
+baseurl: /cats
 apidocs: /cats/api/
 
 collections:

--- a/docs/src/site/_layouts/default.html
+++ b/docs/src/site/_layouts/default.html
@@ -10,9 +10,9 @@
     </script>
     <title>{{ site.name }} - {{ page.title }}</title>
 
-    <link rel="stylesheet" href="{{ site.baseurl }}css/styles.css">
-    <link rel="stylesheet" href="{{ site.baseurl }}css/custom.css">
-    <link rel="stylesheet" href="{{ site.baseurl }}css/syntax.css">
+    <link rel="stylesheet" href="{{ site.baseurl }}/css/styles.css">
+    <link rel="stylesheet" href="{{ site.baseurl }}/css/custom.css">
+    <link rel="stylesheet" href="{{ site.baseurl }}/css/syntax.css">
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
     <!--[if lt IE 9]>
 	<script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
@@ -79,6 +79,6 @@
       </div>
     </div>
 
-    <script src="{{ site.baseurl }}js/scale.fix.js" type="text/javascript"></script>
+    <script src="{{ site.baseurl }}/js/scale.fix.js" type="text/javascript"></script>
   </body>
 </html>


### PR DESCRIPTION
I'm not super experienced with Jekyll but I took a shot at fixing some of the urls in the documentation by following the advice here in http://stackoverflow.com/a/21441767, there were duped slashes in the URLs that were really annoying me for no good reason. I took a cursory once-over if anything was 404'ing and couldn't find anything.

note: went ahead and deleted the `.config.dev.yml` since that wasn't working and testing with the regular `.config.yml` was good and dandy.