### PR TITLE
Improve stack consumption of `Eval.Call`

### DIFF
--- a/core/src/main/scala/cats/Eval.scala
+++ b/core/src/main/scala/cats/Eval.scala
@@ -222,8 +222,22 @@ object Eval extends EvalInstances {
    * they will be automatically created when needed.
    */
   sealed abstract class Call[A](val thunk: () => Eval[A]) extends Eval[A] {
-    def memoize: Eval[A] = new Later(() => thunk().value)
-    def value: A = thunk().value
+    def memoize: Eval[A] = new Later(() => value)
+    def value: A = {
+      def loop(fa: Eval[A]): Eval[A] = fa match {
+        case call: Eval.Call[A] =>
+          loop(call.thunk())
+        case compute: Eval.Compute[A] =>
+          new Eval.Compute[A] {
+            type Start = compute.Start
+            val start: () => Eval[Start] = () => compute.start()
+            val run: Start => Eval[A] = s => loop(compute.run(s))
+          }
+        case other => other
+      }
+
+      loop(this).value
+    }
   }
 
   /**

--- a/tests/src/test/scala/cats/tests/FoldableTests.scala
+++ b/tests/src/test/scala/cats/tests/FoldableTests.scala
@@ -97,6 +97,10 @@ class FoldableTestsAdditional extends CatsSuite {
     }
     assert(result.value)
 
+    // test trampolining
+    val large = Stream((1 to 10000): _*)
+    assert(contains(large, 10000).value)
+
     // toStreaming should be lazy
     assert(dangerous.toStreaming.take(3).toList == List(0, 1, 2))
   }


### PR DESCRIPTION
I think that the awesome speed boost for `Eval` introduced by `Eval.Call` has broken the stack-safety of `Eval.defer` and that this is the reason that the `FoldableTestsAdditional` suite is failing now and then.
I have tried to reduce the stack consumption of `Eval.Call` by forcing thunks in such a way that the compiler can eliminate most of the stack.