### PR TITLE
add Reducible instance for OneAnd, deprecate Foldable instance

### DIFF
--- a/core/src/main/scala/cats/data/OneAnd.scala
+++ b/core/src/main/scala/cats/data/OneAnd.scala
@@ -106,9 +106,6 @@ private[data] sealed trait OneAndInstances extends OneAndLowPriority1 {
   implicit def oneAndSemigroup[F[_]: MonadCombine, A]: Semigroup[OneAnd[F, A]] =
     oneAndSemigroupK.algebra
 
-  @deprecated("use oneAndReducible", "0.4.0")
-  def oneAndFoldable[F[_]: Foldable]: Foldable[OneAnd[F, ?]] = oneAndReducible[F]
-
   implicit def oneAndReducible[F[_]](implicit F: Foldable[F]): Reducible[OneAnd[F, ?]] =
     new NonEmptyReducible[OneAnd[F,?], F] {
       override def split[A](fa: OneAnd[F,A]): (A, F[A]) = (fa.head, fa.tail)


### PR DESCRIPTION
I didn't add a test for `oneAndReducible` because I couldn't find tests for `Reducible`.  If they're here already, could you point me to them?

Because the new type suggested a name change, I left a `Foldable` instance in as `@deprecated`, non-`implicit`.  Let me know if I should do something else.