### PR TITLE
Adds Show[Stream]

### DIFF
--- a/core/src/main/scala/cats/std/stream.scala
+++ b/core/src/main/scala/cats/std/stream.scala
@@ -2,6 +2,7 @@ package cats
 package std
 
 import scala.collection.immutable.Stream.Empty
+import cats.syntax.show._
 
 trait StreamInstances {
   implicit val streamInstance: Traverse[Stream] with MonadCombine[Stream] with CoflatMap[Stream] =
@@ -56,6 +57,11 @@ trait StreamInstances {
         fa.forall(p)
 
       override def isEmpty[A](fa: Stream[A]): Boolean = fa.isEmpty
+    }
+
+  implicit def streamShow[A: Show]: Show[Stream[A]] =
+    new Show[Stream[A]] {
+      def show(fa: Stream[A]): String = if(fa.isEmpty) "Stream()" else s"Stream(${fa.head.show}, ?)"
     }
 
   // TODO: eventually use algebra's instances (which will deal with

--- a/tests/src/test/scala/cats/tests/StreamTests.scala
+++ b/tests/src/test/scala/cats/tests/StreamTests.scala
@@ -16,4 +16,26 @@ class StreamTests extends CatsSuite {
 
   checkAll("Stream[Int] with Option", TraverseTests[Stream].traverse[Int, Int, Int, List[Int], Option, Option])
   checkAll("Traverse[Stream]", SerializableTests.serializable(Traverse[Stream]))
+
+  test("show") {
+    Stream(1, 2, 3).show should === ("Stream(1, ?)")
+    Stream.empty[Int].show should === ("Stream()")
+  }
+
+  test("Show[Stream] is referentially transparent, unlike Stream.toString") {
+    forAll { stream: Stream[Int] =>
+      if (!stream.isEmpty) {
+        val unevaluatedStream = stream map identity
+        val initialShow = unevaluatedStream.show
+
+        // Evaluating the tail can cause Stream.toString to return different values,
+        // depending on the internal state of the Stream. Show[Stream] should return
+        // consistent values independent of internal state.
+        unevaluatedStream.tail
+        initialShow should === (unevaluatedStream.show)
+      } else {
+        stream.show should === (stream.toString)
+      }
+    }
+  }
 }


### PR DESCRIPTION
Adds a `Show` instance for `Stream`.

Of note, unlike `Stream.toString`, this proposed implementation is referentially transparent.

A test exists for this property. 

I thought about adding some checks in that test to demonstrate that `toString` exhibits behaviour that violates referential transparency, but I thought that would be too brittle to included in this test, as if a future Scala version rectifies this behaviour in`Stream`, then the test might break, which might not be nice. It is straightforward to add something that shows this however. 
