### PR TITLE
factor out a static inner method from #769 for better GC

### DIFF
--- a/core/src/main/scala/cats/Eval.scala
+++ b/core/src/main/scala/cats/Eval.scala
@@ -223,20 +223,21 @@ object Eval extends EvalInstances {
    */
   sealed abstract class Call[A](val thunk: () => Eval[A]) extends Eval[A] {
     def memoize: Eval[A] = new Later(() => value)
-    def value: A = {
-      def loop(fa: Eval[A]): Eval[A] = fa match {
-        case call: Eval.Call[A] =>
-          loop(call.thunk())
-        case compute: Eval.Compute[A] =>
-          new Eval.Compute[A] {
-            type Start = compute.Start
-            val start: () => Eval[Start] = () => compute.start()
-            val run: Start => Eval[A] = s => loop(compute.run(s))
-          }
-        case other => other
-      }
+    def value: A = Call.loop(this).value
+  }
 
-      loop(this).value
+  object Call {
+    /** Collapse the call stack for eager evaluations */
+    private def loop[A](fa: Eval[A]): Eval[A] = fa match {
+      case call: Eval.Call[A] =>
+        loop(call.thunk())
+      case compute: Eval.Compute[A] =>
+        new Eval.Compute[A] {
+          type Start = compute.Start
+          val start: () => Eval[Start] = () => compute.start()
+          val run: Start => Eval[A] = s => loop(compute.run(s))
+        }
+      case other => other
     }
   }
 


### PR DESCRIPTION
I think the existing implementation will retain a reference to the outer-most `Call` by referencing its ` cats$Eval$Call$$loop$1` member.  This patch makes `loop` private/static instead.