### PR TITLE
Add ScalaDoc examples for Coproduct syntax

### DIFF
--- a/core/src/main/scala/cats/syntax/coproduct.scala
+++ b/core/src/main/scala/cats/syntax/coproduct.scala
@@ -7,7 +7,37 @@ trait CoproductSyntax {
   implicit def coproductSyntax[F[_], A](a: F[A]): CoproductOps[F, A] = new CoproductOps(a)
 }
 
-final class CoproductOps[F[_], A](val a: F[A]) extends AnyVal {
-  def leftc[G[_]]: Coproduct[F, G, A] = Coproduct.leftc(a)
-  def rightc[G[_]]: Coproduct[G, F, A] = Coproduct.rightc(a)
+final class CoproductOps[F[_], A](val fa: F[A]) extends AnyVal {
+
+  /**
+   * Lift an `F[A]` into a `Coproduct[F, G, A]` for any type constructor `G[_]`.
+   *
+   * @see [[rightc]] to swap the order of `F` and `G` in the result type.
+   *
+   * Example:
+   * {{{
+   * scala> import cats.data.Coproduct
+   * scala> import cats.Eval
+   * scala> import cats.syntax.coproduct._ 
+   * scala> List(1, 2, 3).leftc[Eval]
+   * res0: Coproduct[List, Eval, Int] = Coproduct(Left(List(1, 2, 3)))
+   * }}}
+   */
+  def leftc[G[_]]: Coproduct[F, G, A] = Coproduct.leftc(fa)
+
+  /**
+   * Lift an `F[A]` into a `Coproduct[G, F, A]` for any type constructor `G[_]`.
+   *
+   * @see [[leftc]] to swap the order of `F` and `G` in the result type.
+   *
+   * Example:
+   * {{{
+   * scala> import cats.data.Coproduct
+   * scala> import cats.Eval
+   * scala> import cats.syntax.coproduct._ 
+   * scala> List(1, 2, 3).rightc[Eval]
+   * res0: Coproduct[Eval, List, Int] = Coproduct(Right(List(1, 2, 3)))
+   * }}}
+   */
+  def rightc[G[_]]: Coproduct[G, F, A] = Coproduct.rightc(fa)
 }

--- a/core/src/main/scala/cats/syntax/package.scala
+++ b/core/src/main/scala/cats/syntax/package.scala
@@ -6,6 +6,7 @@ package object syntax {
   object monoidal extends MonoidalSyntax
   object bifunctor extends BifunctorSyntax
   object coflatMap extends CoflatMapSyntax
+  object coproduct extends CoproductSyntax
   object comonad extends ComonadSyntax
   object compose extends ComposeSyntax
   object contravariant extends ContravariantSyntax


### PR DESCRIPTION
Also add the missing `coproduct` syntax `object`.