### PR TITLE
Make Scaladoc (but not Unidoc) warnings non-fatal

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -37,7 +37,8 @@ lazy val commonSettings = Seq(
     compilerPlugin("org.scalamacros" %% "paradise" % "2.1.0-M5" cross CrossVersion.full),
     compilerPlugin("org.spire-math" %% "kind-projector" % "0.6.3")
   ),
-  parallelExecution in Test := false
+  parallelExecution in Test := false,
+  scalacOptions in (Compile, doc) := (scalacOptions in (Compile, doc)).value.filter(_ != "-Xfatal-warnings")
 ) ++ warnUnusedImport
 
 lazy val commonJsSettings = Seq(
@@ -68,6 +69,7 @@ lazy val docSettings = Seq(
   ghpagesNoJekyll := false,
   siteMappings += file("CONTRIBUTING.md") -> "contributing.md",
   scalacOptions in (ScalaUnidoc, unidoc) ++= Seq(
+    "-Xfatal-warnings",
     "-doc-source-url", scmInfo.value.get.browseUrl + "/tree/master€{FILE_PATH}.scala",
     "-sourcepath", baseDirectory.in(LocalRootProject).value.getAbsolutePath,
     "-diagrams"


### PR DESCRIPTION
This change addresses the errors mentioned [here](https://gitter.im/non/cats?at=568e7fc7d739f50a360243c2).

The issue is that Unidoc supports cross-module links, but Scaladoc does not. Since we're using Unidoc, it's reasonable to want to be able to have links between modules, but the publish task will still use Scaladoc to create the docs for the javadoc.jar artifacts. Any cross-module links will result in warnings, which will currently fail the build.

This change makes all warnings non-fatal for Scaladoc, but then turns fatal warnings back on for Unidoc. This allows publishing to succeed even with cross-module link warnings from Scaladoc, but the build will still fail if Unidoc runs into warnings.

An alternative solution would be to use `publishArtifact in (Compile, packageDoc) := false` to skip the javadoc.jar artifacts altogether, but that could cause other problems for repositories that expect these.

Note that there currently aren't any cross-module links in the API docs, but it's a reasonable thing to want to support even outside of the context of #786 (where the errors are first turning up).