### PR TITLE
Add ApplicativeError

### DIFF
--- a/core/src/main/scala/cats/ApplicativeError.scala
+++ b/core/src/main/scala/cats/ApplicativeError.scala
@@ -1,0 +1,81 @@
+package cats
+
+import cats.data.{Xor, XorT}
+
+/**
+ * An applicative that also allows you to raise and or handle an error value.
+ *
+ * This type class allows one to abstract over error-handling applicatives.
+ */
+trait ApplicativeError[F[_], E] extends Applicative[F] {
+  /**
+   * Lift an error into the `F` context.
+   */
+  def raiseError[A](e: E): F[A]
+
+  /**
+   * Handle any error, potentially recovering from it, by mapping it to an
+   * `F[A]` value.
+   *
+   * @see [[handleError]] to handle any error by simply mapping it to an `A`
+   * value instead of an `F[A]`.
+   *
+   * @see [[recoverWith]] to recover from only certain errors.
+   */
+  def handleErrorWith[A](fa: F[A])(f: E => F[A]): F[A]
+
+  /**
+   * Handle any error, by mapping it to an `A` value.
+   *
+   * @see [[handleErrorWith]] to map to an `F[A]` value instead of simply an
+   * `A` value.
+   *
+   * @see [[recover]] to only recover from certain errors.
+   */
+  def handleError[A](fa: F[A])(f: E => A): F[A] = handleErrorWith(fa)(f andThen pure)
+
+  /**
+   * Handle errors by turning them into [[cats.data.Xor.Left]] values.
+   *
+   * If there is no error, then an [[cats.data.Xor.Right]] value will be returned instead.
+   *
+   * All non-fatal errors should be handled by this method.
+   */
+  def attempt[A](fa: F[A]): F[E Xor A] = handleErrorWith(
+    map(fa)(Xor.right[E, A])
+  )(e => pure(Xor.left(e)))
+
+  /**
+   * Similar to [[attempt]], but wraps the result in a [[cats.data.XorT]] for
+   * convenience.
+   */
+  def attemptT[A](fa: F[A]): XorT[F, E, A] = XorT(attempt(fa))
+
+  /**
+   * Recover from certain errors by mapping them to an `A` value.
+   *
+   * @see [[handleError]] to handle any/all errors.
+   *
+   * @see [[recoverWith]] to recover from certain errors by mapping them to
+   * `F[A]` values.
+   */
+  def recover[A](fa: F[A])(pf: PartialFunction[E, A]): F[A] =
+    handleErrorWith(fa)(e =>
+      (pf andThen pure) applyOrElse(e, raiseError))
+
+  /**
+   * Recover from certain errors by mapping them to an `F[A]` value.
+   *
+   * @see [[handleErrorWith]] to handle any/all errors.
+   *
+   * @see [[recover]] to recover from certain errors by mapping them to `A`
+   * values.
+   */
+  def recoverWith[A](fa: F[A])(pf: PartialFunction[E, F[A]]): F[A] =
+    handleErrorWith(fa)(e =>
+      pf applyOrElse(e, raiseError))
+}
+
+object ApplicativeError {
+  def apply[F[_], E](implicit F: ApplicativeError[F, E]): ApplicativeError[F, E] = F
+}

--- a/core/src/main/scala/cats/MonadError.scala
+++ b/core/src/main/scala/cats/MonadError.scala
@@ -7,74 +7,7 @@ import cats.data.{Xor, XorT}
  *
  * This type class allows one to abstract over error-handling monads.
  */
-trait MonadError[F[_], E] extends Monad[F] {
-  /**
-   * Lift an error into the `F` context.
-   */
-  def raiseError[A](e: E): F[A]
-
-  /**
-   * Handle any error, potentially recovering from it, by mapping it to an
-   * `F[A]` value.
-   *
-   * @see [[handleError]] to handle any error by simply mapping it to an `A`
-   * value instead of an `F[A]`.
-   *
-   * @see [[recoverWith]] to recover from only certain errors.
-   */
-  def handleErrorWith[A](fa: F[A])(f: E => F[A]): F[A]
-
-  /**
-   * Handle any error, by mapping it to an `A` value.
-   *
-   * @see [[handleErrorWith]] to map to an `F[A]` value instead of simply an
-   * `A` value.
-   *
-   * @see [[recover]] to only recover from certain errors.
-   */
-  def handleError[A](fa: F[A])(f: E => A): F[A] = handleErrorWith(fa)(f andThen pure)
-
-  /**
-   * Handle errors by turning them into [[cats.data.Xor.Left]] values.
-   *
-   * If there is no error, then an [[cats.data.Xor.Right]] value will be returned instead.
-   *
-   * All non-fatal errors should be handled by this method.
-   */
-  def attempt[A](fa: F[A]): F[E Xor A] = handleErrorWith(
-    map(fa)(Xor.right[E, A])
-  )(e => pure(Xor.left(e)))
-
-  /**
-   * Similar to [[attempt]], but wraps the result in a [[cats.data.XorT]] for
-   * convenience.
-   */
-  def attemptT[A](fa: F[A]): XorT[F, E, A] = XorT(attempt(fa))
-
-  /**
-   * Recover from certain errors by mapping them to an `A` value.
-   *
-   * @see [[handleError]] to handle any/all errors.
-   *
-   * @see [[recoverWith]] to recover from certain errors by mapping them to
-   * `F[A]` values.
-   */
-  def recover[A](fa: F[A])(pf: PartialFunction[E, A]): F[A] =
-    handleErrorWith(fa)(e =>
-      (pf andThen pure) applyOrElse(e, raiseError))
-
-  /**
-   * Recover from certain errors by mapping them to an `F[A]` value.
-   *
-   * @see [[handleErrorWith]] to handle any/all errors.
-   *
-   * @see [[recover]] to recover from certain errors by mapping them to `A`
-   * values.
-   */
-  def recoverWith[A](fa: F[A])(pf: PartialFunction[E, F[A]]): F[A] =
-    handleErrorWith(fa)(e =>
-      pf applyOrElse(e, raiseError))
-}
+trait MonadError[F[_], E] extends ApplicativeError[F, E] with Monad[F]
 
 object MonadError {
   def apply[F[_], E](implicit F: MonadError[F, E]): MonadError[F, E] = F

--- a/laws/src/main/scala/cats/laws/ApplicativeErrorLaws.scala
+++ b/laws/src/main/scala/cats/laws/ApplicativeErrorLaws.scala
@@ -1,0 +1,44 @@
+package cats
+package laws
+
+import cats.data.{Xor, XorT}
+
+// Taken from http://functorial.com/psc-pages/docs/Control/Monad/Error/Class/index.html
+trait ApplicativeErrorLaws[F[_], E] extends ApplicativeLaws[F] {
+  implicit override def F: ApplicativeError[F, E]
+
+  def applicativeErrorHandleWith[A](e: E, f: E => F[A]): IsEq[F[A]] =
+    F.handleErrorWith(F.raiseError[A](e))(f) <-> f(e)
+
+  def applicativeErrorHandle[A](e: E, f: E => A): IsEq[F[A]] =
+    F.handleError(F.raiseError[A](e))(f) <-> F.pure(f(e))
+
+  def handleErrorWithPure[A](a: A, f: E => F[A]): IsEq[F[A]] =
+    F.handleErrorWith(F.pure(a))(f) <-> F.pure(a)
+
+  def handleErrorPure[A](a: A, f: E => A): IsEq[F[A]] =
+    F.handleError(F.pure(a))(f) <-> F.pure(a)
+
+  def raiseErrorAttempt(e: E): IsEq[F[E Xor Unit]] =
+    F.attempt(F.raiseError[Unit](e)) <-> F.pure(Xor.left(e))
+
+  def pureAttempt[A](a: A): IsEq[F[E Xor A]] =
+    F.attempt(F.pure(a)) <-> F.pure(Xor.right(a))
+
+  def handleErrorWithConsistentWithRecoverWith[A](fa: F[A], f: E => F[A]): IsEq[F[A]] =
+    F.handleErrorWith(fa)(f) <-> F.recoverWith(fa)(PartialFunction(f))
+
+  def handleErrorConsistentWithRecover[A](fa: F[A], f: E => A): IsEq[F[A]] =
+    F.handleError(fa)(f) <-> F.recover(fa)(PartialFunction(f))
+
+  def recoverConsistentWithRecoverWith[A](fa: F[A], pf: PartialFunction[E, A]): IsEq[F[A]] =
+    F.recover(fa)(pf) <-> F.recoverWith(fa)(pf andThen F.pure)
+
+  def attemptConsistentWithAttemptT[A](fa: F[A]): IsEq[XorT[F, E, A]] =
+    XorT(F.attempt(fa)) <-> F.attemptT(fa)
+}
+
+object ApplicativeErrorLaws {
+  def apply[F[_], E](implicit ev: ApplicativeError[F, E]): ApplicativeErrorLaws[F, E] =
+    new ApplicativeErrorLaws[F, E] { def F: ApplicativeError[F, E] = ev }
+}

--- a/laws/src/main/scala/cats/laws/MonadErrorLaws.scala
+++ b/laws/src/main/scala/cats/laws/MonadErrorLaws.scala
@@ -1,44 +1,12 @@
 package cats
 package laws
 
-import cats.data.{Xor, XorT}
-
 // Taken from http://functorial.com/psc-pages/docs/Control/Monad/Error/Class/index.html
-trait MonadErrorLaws[F[_], E] extends MonadLaws[F] {
+trait MonadErrorLaws[F[_], E] extends ApplicativeErrorLaws[F, E] with MonadLaws[F] {
   implicit override def F: MonadError[F, E]
 
   def monadErrorLeftZero[A, B](e: E, f: A => F[B]): IsEq[F[B]] =
     F.flatMap(F.raiseError[A](e))(f) <-> F.raiseError[B](e)
-
-  def monadErrorHandleWith[A](e: E, f: E => F[A]): IsEq[F[A]] =
-    F.handleErrorWith(F.raiseError[A](e))(f) <-> f(e)
-
-  def monadErrorHandle[A](e: E, f: E => A): IsEq[F[A]] =
-    F.handleError(F.raiseError[A](e))(f) <-> F.pure(f(e))
-
-  def handleErrorWithPure[A](a: A, f: E => F[A]): IsEq[F[A]] =
-    F.handleErrorWith(F.pure(a))(f) <-> F.pure(a)
-
-  def handleErrorPure[A](a: A, f: E => A): IsEq[F[A]] =
-    F.handleError(F.pure(a))(f) <-> F.pure(a)
-
-  def raiseErrorAttempt(e: E): IsEq[F[E Xor Unit]] =
-    F.attempt(F.raiseError[Unit](e)) <-> F.pure(Xor.left(e))
-
-  def pureAttempt[A](a: A): IsEq[F[E Xor A]] =
-    F.attempt(F.pure(a)) <-> F.pure(Xor.right(a))
-
-  def handleErrorWithConsistentWithRecoverWith[A](fa: F[A], f: E => F[A]): IsEq[F[A]] =
-    F.handleErrorWith(fa)(f) <-> F.recoverWith(fa)(PartialFunction(f))
-
-  def handleErrorConsistentWithRecover[A](fa: F[A], f: E => A): IsEq[F[A]] =
-    F.handleError(fa)(f) <-> F.recover(fa)(PartialFunction(f))
-
-  def recoverConsistentWithRecoverWith[A](fa: F[A], pf: PartialFunction[E, A]): IsEq[F[A]] =
-    F.recover(fa)(pf) <-> F.recoverWith(fa)(pf andThen F.pure)
-
-  def attemptConsistentWithAttemptT[A](fa: F[A]): IsEq[XorT[F, E, A]] =
-    XorT(F.attempt(fa)) <-> F.attemptT(fa)
 }
 
 object MonadErrorLaws {

--- a/laws/src/main/scala/cats/laws/discipline/ApplicativeErrorTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/ApplicativeErrorTests.scala
@@ -1,0 +1,57 @@
+package cats
+package laws
+package discipline
+
+import cats.data.{ Xor, XorT }
+import cats.laws.discipline.MonoidalTests.Isomorphisms
+import cats.laws.discipline.arbitrary._
+import cats.laws.discipline.eq.unitEq
+import org.scalacheck.{Arbitrary, Prop}
+import org.scalacheck.Prop.forAll
+
+trait ApplicativeErrorTests[F[_], E] extends ApplicativeTests[F] {
+  def laws: ApplicativeErrorLaws[F, E]
+
+  def applicativeError[A: Arbitrary: Eq, B: Arbitrary: Eq, C: Arbitrary: Eq](implicit
+    ArbFA: Arbitrary[F[A]],
+    ArbFB: Arbitrary[F[B]],
+    ArbFC: Arbitrary[F[C]],
+    ArbFAtoB: Arbitrary[F[A => B]],
+    ArbFBtoC: Arbitrary[F[B => C]],
+    ArbE: Arbitrary[E],
+    EqFA: Eq[F[A]],
+    EqFB: Eq[F[B]],
+    EqFC: Eq[F[C]],
+    EqE: Eq[E],
+    EqFXorEU: Eq[F[E Xor Unit]],
+    EqFXorEA: Eq[F[E Xor A]],
+    EqXorTFEA: Eq[XorT[F, E, A]],
+    EqFABC: Eq[F[(A, B, C)]],
+    iso: Isomorphisms[F]
+  ): RuleSet = {
+    new RuleSet {
+      def name: String = "applicativeError"
+      def bases: Seq[(String, RuleSet)] = Nil
+      def parents: Seq[RuleSet] = Seq(applicative[A, B, C])
+      def props: Seq[(String, Prop)] = Seq(
+        "applicativeError handleWith" -> forAll(laws.applicativeErrorHandleWith[A] _),
+        "applicativeError handle" -> forAll(laws.applicativeErrorHandle[A] _),
+        "applicativeError handleErrorWith pure" -> forAll(laws.handleErrorWithPure[A] _),
+        "applicativeError handleError pure" -> forAll(laws.handleErrorPure[A] _),
+        "applicativeError raiseError attempt" -> forAll(laws.raiseErrorAttempt _),
+        "applicativeError pure attempt" -> forAll(laws.pureAttempt[A] _),
+        "applicativeError handleErrorWith consistent with recoverWith" -> forAll(laws.handleErrorWithConsistentWithRecoverWith[A] _),
+        "applicativeError handleError consistent with recover" -> forAll(laws.handleErrorConsistentWithRecover[A] _),
+        "applicativeError recover consistent with recoverWith" -> forAll(laws.recoverConsistentWithRecoverWith[A] _),
+        "applicativeError attempt consistent with attemptT" -> forAll(laws.attemptConsistentWithAttemptT[A] _)
+      )
+    }
+  }
+}
+
+object ApplicativeErrorTests {
+  def apply[F[_], E](implicit FE: ApplicativeError[F, E]): ApplicativeErrorTests[F, E] =
+    new ApplicativeErrorTests[F, E] {
+      def laws: ApplicativeErrorLaws[F, E] = ApplicativeErrorLaws[F, E]
+    }
+}

--- a/laws/src/main/scala/cats/laws/discipline/MonadErrorTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/MonadErrorTests.scala
@@ -4,12 +4,11 @@ package discipline
 
 import cats.data.{ Xor, XorT }
 import cats.laws.discipline.MonoidalTests.Isomorphisms
-import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.eq.unitEq
 import org.scalacheck.{Arbitrary, Prop}
 import org.scalacheck.Prop.forAll
 
-trait MonadErrorTests[F[_], E] extends MonadTests[F] {
+trait MonadErrorTests[F[_], E] extends ApplicativeErrorTests[F, E] with MonadTests[F] {
   def laws: MonadErrorLaws[F, E]
 
   def monadError[A: Arbitrary: Eq, B: Arbitrary: Eq, C: Arbitrary: Eq](implicit
@@ -32,19 +31,9 @@ trait MonadErrorTests[F[_], E] extends MonadTests[F] {
     new RuleSet {
       def name: String = "monadError"
       def bases: Seq[(String, RuleSet)] = Nil
-      def parents: Seq[RuleSet] = Seq(monad[A, B, C])
+      def parents: Seq[RuleSet] = Seq(applicativeError[A, B, C], monad[A, B, C])
       def props: Seq[(String, Prop)] = Seq(
-        "monadError left zero" -> forAll(laws.monadErrorLeftZero[A, B] _),
-        "monadError handleWith" -> forAll(laws.monadErrorHandleWith[A] _),
-        "monadError handle" -> forAll(laws.monadErrorHandle[A] _),
-        "monadError handleErrorWith pure" -> forAll(laws.handleErrorWithPure[A] _),
-        "monadError handleError pure" -> forAll(laws.handleErrorPure[A] _),
-        "monadError raiseError attempt" -> forAll(laws.raiseErrorAttempt _),
-        "monadError pure attempt" -> forAll(laws.pureAttempt[A] _),
-        "monadError handleErrorWith consistent with recoverWith" -> forAll(laws.handleErrorWithConsistentWithRecoverWith[A] _),
-        "monadError handleError consistent with recover" -> forAll(laws.handleErrorConsistentWithRecover[A] _),
-        "monadError recover consistent with recoverWith" -> forAll(laws.recoverConsistentWithRecoverWith[A] _),
-        "monadError attempt consistent with attemptT" -> forAll(laws.attemptConsistentWithAttemptT[A] _)
+        "monadError left zero" -> forAll(laws.monadErrorLeftZero[A, B] _)
       )
     }
   }

--- a/tests/src/test/scala/cats/tests/ValidatedTests.scala
+++ b/tests/src/test/scala/cats/tests/ValidatedTests.scala
@@ -1,9 +1,9 @@
 package cats
 package tests
 
-import cats.data.{NonEmptyList, Validated, ValidatedNel, Xor}
+import cats.data.{NonEmptyList, Validated, ValidatedNel, Xor, XorT}
 import cats.data.Validated.{Valid, Invalid}
-import cats.laws.discipline.{BifunctorTests, TraverseTests, ApplicativeTests, SerializableTests, MonoidalTests}
+import cats.laws.discipline.{BifunctorTests, TraverseTests, ApplicativeErrorTests, SerializableTests, MonoidalTests}
 import org.scalacheck.{Gen, Arbitrary}
 import org.scalacheck.Arbitrary._
 import cats.laws.discipline.arbitrary._
@@ -17,12 +17,15 @@ class ValidatedTests extends CatsSuite {
   checkAll("Validated[String, Int]", MonoidalTests[Validated[String,?]].monoidal[Int, Int, Int])
   checkAll("Monoidal[Validated[String,?]]", SerializableTests.serializable(Monoidal[Validated[String,?]]))
 
-  checkAll("Validated[String, Int]", ApplicativeTests[Validated[String,?]].applicative[Int, Int, Int])
   checkAll("Validated[?, ?]", BifunctorTests[Validated].bifunctor[Int, Int, Int, Int, Int, Int])
-  checkAll("Applicative[Validated[String,?]]", SerializableTests.serializable(Applicative[Validated[String,?]]))
+
+  implicit val eq0 = XorT.xorTEq[Validated[String, ?], String, Int]
+
+  checkAll("Validated[String, Int]", ApplicativeErrorTests[Validated[String, ?], String].applicativeError[Int, Int, Int])
+  checkAll("ApplicativeError[Xor, String]", SerializableTests.serializable(ApplicativeError[Validated[String, ?], String]))
 
   checkAll("Validated[String, Int] with Option", TraverseTests[Validated[String,?]].traverse[Int, Int, Int, Int, Option, Option])
-  checkAll("Traverse[Validated[String,?]]", SerializableTests.serializable(Traverse[Validated[String,?]]))
+  checkAll("Traverse[Validated[String, ?]]", SerializableTests.serializable(Traverse[Validated[String,?]]))
 
   checkAll("Validated[String, Int]", OrderLaws[Validated[String, Int]].order)
   checkAll("Order[Validated[String, Int]]", SerializableTests.serializable(Order[Validated[String, Int]]))


### PR DESCRIPTION
This is a follow-up to [a question](https://gitter.im/non/cats?at=56983e475de13b3f15e3263c) I asked on Gitter a few days ago.

The basic idea is that it seems useful to be able to abstract over `Validated[E, ?]` as a context in which errors can be raised and handled, but `Validated` isn't monadic, so we can't provide a `MonadError` instance. None of the `MonadError` operations require monadic binding, though, and at least in the case of `Validated[E, ?]` there are reasonable implementations. The only `MonadError` law we lose is the left zero law.

This PR adds an `ApplicativeError` type class above `MonadError`, together with laws for `ApplicativeError` and an instance and tests for `Validated`. Current `MonadError` usage should be unaffected.