### PR TITLE
Request to Add CoflatMap Instance for Vector

### DIFF
--- a/core/src/main/scala/cats/std/vector.scala
+++ b/core/src/main/scala/cats/std/vector.scala
@@ -6,7 +6,7 @@ import cats.syntax.show._
 
 import scala.annotation.tailrec
 import scala.collection.+:
-import scala.collection.mutable.ArrayBuffer
+import scala.collection.mutable.ListBuffer
 
 trait VectorInstances {
   implicit val vectorInstance: Traverse[Vector] with MonadCombine[Vector] with CoflatMap[Vector] =
@@ -28,12 +28,12 @@ trait VectorInstances {
         fa.flatMap(a => fb.map(b => f(a, b)))
 
       def coflatMap[A, B](fa: Vector[A])(f: Vector[A] => B): Vector[B] = {
-        @tailrec def loop(buf: ArrayBuffer[B], as: Vector[A]): Vector[B] =
+        @tailrec def loop(buf: ListBuffer[B], as: Vector[A]): Vector[B] =
           as match {
             case _ +: rest => loop(buf += f(as), rest)
             case _ => buf.to[Vector]
           }
-        loop(ArrayBuffer.empty[B], fa)
+        loop(ListBuffer.empty[B], fa)
       }
 
       def foldLeft[A, B](fa: Vector[A], b: B)(f: (B, A) => B): B =

--- a/core/src/main/scala/cats/std/vector.scala
+++ b/core/src/main/scala/cats/std/vector.scala
@@ -6,7 +6,7 @@ import cats.syntax.show._
 
 import scala.annotation.tailrec
 import scala.collection.+:
-import scala.collection.mutable.{ArrayBuffer, ListBuffer}
+import scala.collection.mutable.ArrayBuffer
 
 trait VectorInstances {
   implicit val vectorInstance: Traverse[Vector] with MonadCombine[Vector] with CoflatMap[Vector] =

--- a/core/src/main/scala/cats/std/vector.scala
+++ b/core/src/main/scala/cats/std/vector.scala
@@ -6,7 +6,7 @@ import cats.syntax.show._
 
 import scala.annotation.tailrec
 import scala.collection.+:
-import scala.collection.mutable.ListBuffer
+import scala.collection.immutable.VectorBuilder
 
 trait VectorInstances {
   implicit val vectorInstance: Traverse[Vector] with MonadCombine[Vector] with CoflatMap[Vector] =
@@ -28,12 +28,12 @@ trait VectorInstances {
         fa.flatMap(a => fb.map(b => f(a, b)))
 
       def coflatMap[A, B](fa: Vector[A])(f: Vector[A] => B): Vector[B] = {
-        @tailrec def loop(buf: ListBuffer[B], as: Vector[A]): Vector[B] =
+        @tailrec def loop(builder: VectorBuilder[B], as: Vector[A]): Vector[B] =
           as match {
-            case _ +: rest => loop(buf += f(as), rest)
-            case _ => buf.to[Vector]
+            case _ +: rest => loop(builder += f(as), rest)
+            case _ => builder.result()
           }
-        loop(ListBuffer.empty[B], fa)
+        loop(new VectorBuilder[B], fa)
       }
 
       def foldLeft[A, B](fa: Vector[A], b: B)(f: (B, A) => B): B =

--- a/tests/src/test/scala/cats/tests/VectorTests.scala
+++ b/tests/src/test/scala/cats/tests/VectorTests.scala
@@ -1,12 +1,16 @@
 package cats
 package tests
 
-import cats.laws.discipline.{MonadCombineTests, SerializableTests, TraverseTests, MonoidalTests}
+import cats.laws.discipline.{MonadCombineTests, CoflatMapTests, SerializableTests, TraverseTests, MonoidalTests}
 import cats.laws.discipline.eq.tuple3Eq
 
 class VectorTests extends CatsSuite {
+
   checkAll("Vector[Int]", MonoidalTests[Vector].monoidal[Int, Int, Int])
   checkAll("Monoidal[Vector]", SerializableTests.serializable(Monoidal[Vector]))
+
+  checkAll("Vector[Int]", CoflatMapTests[Vector].coflatMap[Int, Int, Int])
+  checkAll("CoflatMap[Vector]", SerializableTests.serializable(CoflatMap[Vector]))
 
   checkAll("Vector[Int]", MonadCombineTests[Vector].monadCombine[Int, Int, Int])
   checkAll("MonadCombine[Vector]", SerializableTests.serializable(MonadCombine[Vector]))


### PR DESCRIPTION
This PR brings the `CoflatMap` typeclass instance for `Vector`.

Here an example session:

```
scala> :paste
// Entering paste mode (ctrl-D to finish)

import cats._, cats.std.all._, cats.syntax.coflatMap._

def foo(vector: Vector[Int]) = vector map (_ + 1)

def bar(vector: Vector[Int]) = vector map (_ - 1)

scala> Vector(1).coflatMap(foo(_))
res0: Vector[scala.collection.immutable.Vector[Int]] = Vector(Vector(2))

scala> Vector(1).coflatMap(bar(_))
res1: Vector[scala.collection.immutable.Vector[Int]] = Vector(Vector(0))
```

@non @ceedubs @adelbertc @milessabin Thanks for your consideration.