### PR TITLE
Upgrade to simulacrum 0.6.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -30,7 +30,7 @@ lazy val commonSettings = Seq(
     Resolver.sonatypeRepo("snapshots")
   ),
   libraryDependencies ++= Seq(
-    "com.github.mpilquist" %%% "simulacrum" % "0.5.0",
+    "com.github.mpilquist" %%% "simulacrum" % "0.6.1",
     "org.spire-math" %%% "algebra" % "0.3.1",
     "org.spire-math" %%% "algebra-std" % "0.3.1",
     "org.typelevel" %%% "machinist" % "0.4.1",

--- a/core/src/main/scala/cats/Foldable.scala
+++ b/core/src/main/scala/cats/Foldable.scala
@@ -24,7 +24,7 @@ import simulacrum.typeclass
  *
  * See: [[http://www.cs.nott.ac.uk/~pszgmh/fold.pdf A tutorial on the universality and expressiveness of fold]]
  */
-@typeclass trait Foldable[F[_]] extends Serializable { self =>
+@typeclass trait Foldable[F[_]] { self =>
 
   /**
    * Left associative fold on 'F' using the function 'f'.

--- a/core/src/main/scala/cats/SemigroupK.scala
+++ b/core/src/main/scala/cats/SemigroupK.scala
@@ -20,7 +20,7 @@ import simulacrum.{op, typeclass}
  *    The combination operation just depends on the structure of F,
  *    but not the structure of A.
  */
-@typeclass trait SemigroupK[F[_]] extends Serializable { self =>
+@typeclass trait SemigroupK[F[_]] { self =>
 
   /**
    * Combine two F[A] values.

--- a/core/src/main/scala/cats/Show.scala
+++ b/core/src/main/scala/cats/Show.scala
@@ -10,7 +10,7 @@ import cats.functor.Contravariant
  * made a toString method, a Show instance will only exist if someone
  * explicitly provided one.
  */
-@typeclass trait Show[T] extends Serializable {
+@typeclass trait Show[T] {
   def show(f: T): String
 }
 

--- a/core/src/main/scala/cats/functor/Invariant.scala
+++ b/core/src/main/scala/cats/functor/Invariant.scala
@@ -6,7 +6,7 @@ import simulacrum.typeclass
 /**
  * Must obey the laws defined in cats.laws.InvariantLaws.
  */
-@typeclass trait Invariant[F[_]] extends Any with Serializable { self =>
+@typeclass trait Invariant[F[_]] { self =>
   def imap[A, B](fa: F[A])(f: A => B)(g: B => A): F[B]
 
   /**


### PR DESCRIPTION
Simulacrum 0.6.1 was just released. Type classes automatically extend `Any` and `Serializable` now, so explicit declarations of these super types are not necessary any longer.